### PR TITLE
Add success/failure cronjob limits

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -74,6 +74,8 @@ helm install --name my-release -f myvalues.yaml .
 | `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
 | `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |
 | `dropChunk.schedule`              | The schedule with which the drop-chunk Job runs | `0,30 * * * *`                 |
+| `dropChunk.successLimit`          | The number of successful dropChunk pods to retain in-cluster | `5`               |
+| `dropChunk.failureLimit`          | The number of failed dropChunk pods to retain in-cluster | `5`                   |
 | `resources`                       | Requests and limits for each of the pods    | `{}`                               |
 | `nodeSelector`                    | Node labels to use for scheduling           | `{}`                               |
 

--- a/helm-chart/templates/cronjob-dropchunk.yaml
+++ b/helm-chart/templates/cronjob-dropchunk.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.dropChunk.schedule }}
+  successfulJobsHistoryLimit: {{.Values.dropChunk.successLimit}}
+  failedJobsHistoryLimit: {{.Values.dropChunk.failureLimit}}
   jobTemplate:
     spec:
       template:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -58,6 +58,8 @@ service:
 # the retention period
 dropChunk:
   schedule: "0,30 * * * *"
+  successLimit: 5
+  failureLimit: 5
 
 # set your own limits
 resources: {}


### PR DESCRIPTION
Adds helm values that limit the number of successful and failed cronjob pods in-cluster. If these are unbounded, it can create noise when using kubectl or other cluster inspection tools.