### PR TITLE
[WIP] Batch inserts to multiple tables

### DIFF
--- a/pkg/pgmodel/metrics.go
+++ b/pkg/pgmodel/metrics.go
@@ -33,6 +33,14 @@ var (
 			Name:      "decompress_min_unix_time",
 			Help:      "Earliest decdompression time",
 		}, []string{"table"})
+	numInsertsPerBatch = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: util.PromNamespace,
+			Name:      "inserts_per_batch",
+			Help:      "number of INSERTs in a single transaction",
+			Buckets:   []float64{1, 2, 3, 4, 5, 10, 20, 30, 40, 50, 75, 100},
+		},
+	)
 )
 
 func init() {
@@ -40,4 +48,5 @@ func init() {
 	prometheus.MustRegister(duplicateWrites)
 	prometheus.MustRegister(decompressCalls)
 	prometheus.MustRegister(decompressEarliest)
+	prometheus.MustRegister(numInsertsPerBatch)
 }

--- a/pkg/pgmodel/sql_ingest.go
+++ b/pkg/pgmodel/sql_ingest.go
@@ -495,8 +495,8 @@ func inserterGetBatch(batch []copyRequest, in chan copyRequest) ([]copyRequest, 
 hot_gather:
 	for len(batch) < cap(batch) {
 		select {
-		case req := <-in:
-			batch = append(batch, req)
+		case r2 := <-in:
+			batch = append(batch, r2)
 		default:
 			break hot_gather
 		}
@@ -576,7 +576,8 @@ func tryRecovery(conn pgxConn, err error, req copyRequest) error {
 func doInsert(conn pgxConn, reqs ...copyRequest) (err error) {
 	batch := conn.NewBatch()
 	numRowsPerInsert := make([]int, 0, len(reqs))
-	for _, req := range reqs {
+	for r := range reqs {
+		req := &reqs[r]
 		numRows := 0
 		for i := range req.data.batch.sampleInfos {
 			numRows += len(req.data.batch.sampleInfos[i].samples)

--- a/pkg/pgmodel/sql_ingest.go
+++ b/pkg/pgmodel/sql_ingest.go
@@ -478,6 +478,8 @@ func runInserter(conn pgxConn, in chan copyRequest) {
 			return insertBatch[i].table < insertBatch[j].table
 		})
 
+		numInsertsPerBatch.Observe(float64(len(insertBatch)))
+
 		doInsertOrFallback(conn, insertBatch...)
 		for i := range insertBatch {
 			insertBatch[i] = copyRequest{}


### PR DESCRIPTION
This commit optimistically batches multiple INSERTs together into a single transaction if the inserter finds there are multiple requests available. This should reduce the number of transactions performed under high load, and may improve performance.