### PR TITLE
Add log format flag and default to logfmt formatting for logs

### DIFF
--- a/cmd/promscale/main.go
+++ b/cmd/promscale/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
@@ -14,7 +13,6 @@ import (
 )
 
 func main() {
-	logLevel := flag.String("log-level", "debug", "The log level to use [ \"error\", \"warn\", \"info\", \"debug\" ].")
 	cfg := &runner.Config{}
 	cfg, err := runner.ParseFlags(cfg)
 	if err != nil {
@@ -22,7 +20,7 @@ func main() {
 		fmt.Println("Fatal error: cannot parse flags ", err)
 		os.Exit(1)
 	}
-	err = log.Init(*logLevel)
+	err = log.Init(cfg.LogCfg)
 	if err != nil {
 		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
 		fmt.Println("Fatal error: cannot start logger", err)

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -12,7 +12,9 @@ import (
 )
 
 func TestCORSWrapper(t *testing.T) {
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 	acceptSpecific, _ := regexp.Compile("^(?:" + "http://some-site.com" + ")$")
 	acceptAny, _ := regexp.Compile("^(?:" + ".*" + ")$")
 

--- a/pkg/api/health_test.go
+++ b/pkg/api/health_test.go
@@ -27,7 +27,9 @@ func (m *mockHealthChecker) HealthCheck() error {
 }
 
 func TestHealth(t *testing.T) {
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 
 	testCases := []struct {
 		name                   string

--- a/pkg/api/labels_test.go
+++ b/pkg/api/labels_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestLabels(t *testing.T) {
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 	testCases := []struct {
 		name        string
 		querier     *mockQuerier

--- a/pkg/api/query_range_test.go
+++ b/pkg/api/query_range_test.go
@@ -18,7 +18,9 @@ import (
 )
 
 func TestRangedQuery(t *testing.T) {
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 	testCases := []struct {
 		name        string
 		timeout     string

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -121,7 +121,9 @@ func TestParseDuration(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 	testCases := []struct {
 		name        string
 		timeout     string

--- a/pkg/api/series_test.go
+++ b/pkg/api/series_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 func TestSeries(t *testing.T) {
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 
 	testCases := []struct {
 		name        string

--- a/pkg/api/write_test.go
+++ b/pkg/api/write_test.go
@@ -24,7 +24,9 @@ import (
 )
 
 func TestWrite(t *testing.T) {
-	testutil.Ok(t, log.Init("debug"))
+	testutil.Ok(t, log.Init(log.Config{
+		Level: "debug",
+	}))
 	testCases := []struct {
 		name             string
 		responseCode     int

--- a/pkg/pgmodel/end_to_end_tests/main_test.go
+++ b/pkg/pgmodel/end_to_end_tests/main_test.go
@@ -41,7 +41,9 @@ func TestMain(m *testing.M) {
 	func() {
 		flag.Parse()
 		ctx := context.Background()
-		_ = log.Init("debug")
+		_ = log.Init(log.Config{
+			Level: "debug",
+		})
 		if !testing.Short() {
 			var err error
 

--- a/pkg/pgmodel/upgrade_tests/upgrade_test.go
+++ b/pkg/pgmodel/upgrade_tests/upgrade_test.go
@@ -51,7 +51,9 @@ func TestMain(m *testing.M) {
 		prevDBImage = "timescaledev/timescale_prometheus_extra:0.1.1-pg12"
 	}
 	flag.Parse()
-	_ = log.Init("debug")
+	_ = log.Init(log.Config{
+		Level: "debug",
+	})
 	code = m.Run()
 	os.Exit(code)
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -33,6 +33,7 @@ type Config struct {
 	ListenAddr        string
 	TelemetryPath     string
 	PgmodelCfg        pgclient.Config
+	LogCfg            log.Config
 	HaGroupLockID     int64
 	RestElection      bool
 	PrometheusTimeout time.Duration
@@ -57,6 +58,7 @@ var (
 
 func ParseFlags(cfg *Config) (*Config, error) {
 	pgclient.ParseFlags(&cfg.PgmodelCfg)
+	log.ParseFlags(&cfg.LogCfg)
 
 	flag.StringVar(&cfg.ListenAddr, "web-listen-address", ":9201", "Address to listen on for web endpoints.")
 	flag.StringVar(&cfg.TelemetryPath, "web-telemetry-path", "/metrics", "Address to listen on for web endpoints.")

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -14,7 +14,9 @@ import (
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	err := log.Init("debug")
+	err := log.Init(log.Config{
+		Level: "debug",
+	})
 
 	if err != nil {
 		fmt.Println("Error initializing logger", err)

--- a/pkg/util/election_test.go
+++ b/pkg/util/election_test.go
@@ -205,7 +205,9 @@ func TestPrometheusLivenessCheck(t *testing.T) {
 }
 func TestMain(m *testing.M) {
 	flag.Parse()
-	err := log.Init("debug")
+	err := log.Init(log.Config{
+		Level: "debug",
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -17,7 +17,9 @@ const (
 )
 
 func init() {
-	err := log.Init("debug")
+	err := log.Init(log.Config{
+		Level: "debug",
+	})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This commit adds a new log format flag which can be used for setting the format
of the logs to either logfmt (default) or json. It also cleans up logger flags
and initalization logic a bit.

Closes #261 