### PR TITLE
Adds support for checking pg server version number on startup

### DIFF
--- a/pkg/pgmodel/migrate.go
+++ b/pkg/pgmodel/migrate.go
@@ -145,7 +145,7 @@ func CheckDependencies(db *pgx.Conn, versionInfo VersionInfo) (err error) {
 		return err
 	}
 
-	return checkExtensionsVersion(db)
+	return checkVersions(db)
 }
 
 // CheckSchemaVersion checks the DB schema version without checking the extension

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -36,6 +36,9 @@ var (
 	Version    = "0.1.1-dev.2"
 	CommitHash = ""
 
+	PgVersionNumRange       = "=12.x" // Corresponds to range within pg 12.0 to pg 12.99
+	pgAcceptedVersionsRange = semver.MustParseRange(PgVersionNumRange)
+
 	TimescaleVersionRangeString = struct {
 		Safe, Warn string
 	}{
@@ -52,6 +55,11 @@ var (
 	ExtVersionRangeString = "=0.1.x"
 	ExtVersionRange       = semver.MustParseRange(ExtVersionRangeString)
 )
+
+// VerifyPgVersion verifies the Postgresql version compatibility.
+func VerifyPgVersion(version semver.Version) bool {
+	return pgAcceptedVersionsRange(version)
+}
 
 // VerifyTimescaleVersion verifies version compatibility with Timescaledb.
 func VerifyTimescaleVersion(version semver.Version) uint {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Current valid range: `=12.x`.