### PR TITLE
Fix log location reporting

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -58,7 +58,9 @@ func Init(cfg Config) error {
 	}
 
 	l = level.NewFilter(l, logLevelOption)
-	logger = log.With(l, "ts", timestampFormat, "caller", log.DefaultCaller)
+	// NOTE: we add a level of indirection with our logging functions,
+	//       so we need additional caller depth
+	logger = log.With(l, "ts", timestampFormat, "caller", log.Caller(4))
 	return nil
 }
 


### PR DESCRIPTION
We add a level of indirection before calling `Log()`, so we need an to report the location a level higher in the callstack than the default.