### PR TITLE
Fix max_connections setting in tests

### DIFF
--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -147,6 +147,7 @@ func StartPGContainerWithImage(ctx context.Context, image string, testDataDir st
 		req.Cmd = []string{
 			"-c", "shared_preload_libraries=timescaledb",
 			"-c", "local_preload_libraries=pgextwlist",
+			"-c", "max_connections=100",
 			//timescale_prometheus_extra included for upgrade tests with old extension name
 			"-c", "extwlist.extensions=promscale,timescaledb,timescale_prometheus_extra",
 		}


### PR DESCRIPTION
ts_tune sets max_connections conservatively in newer TimescaleDB docker images.
This now breaks some of our tests on some environments due to running out of connections.
To avoid this, set max_connections explicitly back to the default.