### PR TITLE
Fix erroneous PromQL query in end-to-end tests

### DIFF
--- a/pkg/pgmodel/end_to_end_tests/promql_query_endpoint_test.go
+++ b/pkg/pgmodel/end_to_end_tests/promql_query_endpoint_test.go
@@ -2384,7 +2384,7 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 		},
 		{
 			name:  "complex query 1",
-			query: `sum by(instance) (metric_1) + on(foo) group_left(instance) metric_2`,
+			query: `sum by(instance) (metric_1) + on(instance) group_left(foo) metric_2`,
 		},
 		{
 			name:  "complex query 2",


### PR DESCRIPTION
This query had a logical error which was causing the tests to output lots
of logs, making the output noisy and hard to read.