### PR TITLE
Fix error reporting to prevent panic

### DIFF
--- a/pkg/pgmodel/sql_test.go
+++ b/pkg/pgmodel/sql_test.go
@@ -5,6 +5,7 @@ package pgmodel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -601,7 +602,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 					expErr = errMissingTableName
 				}
 
-				if err != expErr {
+				if !errors.Is(err, expErr) {
 					t.Errorf("unexpected error:\ngot\n%s\nwanted\n%s", err, expErr)
 				}
 


### PR DESCRIPTION
Previously, runInserterRoutine reported errors to two places:
1) the errChan originally starting the inserter
2) The errChan associated with the request it's handling

The reporting in (1) caused a send-on-closed-channel error
since the request that originally started the insert routine
is actually done after the first error and closes its errChan.

Another words, errors should always be reported on the errChan
assoicated with the request being handled, since we know that
request is still not done. As a plus, that's semantically more
correct too.

Thus, we get rid of (1) and keep (2). We also get rid of passing
errChan not associated with a request down -- this simplifies code
and prevents this type of error in the future.