### PR TITLE
Enable to pass arguments to the promscale container

### DIFF
--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -24,6 +24,12 @@ spec:
         - image: {{ .Values.image }}
           imagePullPolicy: IfNotPresent
           name: promscale-connector
+          {{- if .Values.args }}
+          args:
+            {{- range .Values.args }}
+              - {{ . }}
+            {{- end }}
+          {{- end}}
           {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,6 +1,13 @@
 image: timescale/promscale
 # number of connector pods to spawn
 replicaCount: 1
+
+# Arguments that will be passed onto deployment pods
+# To activate HA, bump the replicaCount and set those arguments:
+# - -leader-election-pg-advisory-lock-id=1
+# - -leader-election-pg-advisory-lock-prometheus-timeout=6s
+args: []
+
 # connection options to connect to a target db
 connection:
   # user used to connect to TimescaleDB


### PR DESCRIPTION
This will give users more flexibility and enable them to pass HA configuration to promscale for example.

resolves timescale/promscale#307