### PR TITLE
Add read-only mode to the connector

### DIFF
--- a/cmd/promscale/main.go
+++ b/cmd/promscale/main.go
@@ -14,16 +14,16 @@ import (
 
 func main() {
 	cfg := &runner.Config{}
-	cfg, err := runner.ParseFlags(cfg)
+	cfg, err := runner.ParseFlags(cfg, os.Args[1:])
 	if err != nil {
 		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
-		fmt.Println("Fatal error: cannot parse flags ", err)
+		fmt.Println("Fatal error: cannot parse flags: ", err)
 		os.Exit(1)
 	}
 	err = log.Init(cfg.LogCfg)
 	if err != nil {
 		fmt.Println("Version: ", version.Version, "Commit Hash: ", version.CommitHash)
-		fmt.Println("Fatal error: cannot start logger", err)
+		fmt.Println("Fatal error: cannot start logger: ", err)
 		os.Exit(1)
 	}
 	err = runner.Run(cfg)

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -28,6 +28,7 @@ var (
 
 type Config struct {
 	AllowedOrigin *regexp.Regexp
+	ReadOnly      bool
 }
 
 func corsWrapper(conf *Config, f http.HandlerFunc) http.HandlerFunc {


### PR DESCRIPTION
Read-only mode is added to run against a read replica. In this mode, migration
and leader election is disabled. Write route will be missing and return 404
error code.