### PR TITLE
Fix TimescaleDB version accepted

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -42,7 +42,7 @@ var (
 	TimescaleVersionRangeString = struct {
 		Safe, Warn string
 	}{
-		Safe: ">=1.7.3 <2.0.0",
+		Safe: ">=1.7.3 <1.7.99",
 		Warn: ">=1.7.0 <1.7.3",
 	}
 	timescaleVersionSafeRange = semver.MustParseRange(TimescaleVersionRangeString.Safe)


### PR DESCRIPTION
Previously, the versions accepted the 2.0.0-rc which created problems
when being auto-upgraded. Fix this for now. But a fuller fix for
issue #329 will be in a separate PR.