### PR TITLE
Specify the version to test upgrades from explicitly

### DIFF
--- a/pkg/pgmodel/upgrade_tests/upgrade_test.go
+++ b/pkg/pgmodel/upgrade_tests/upgrade_test.go
@@ -88,8 +88,7 @@ func TestUpgradeFromPrevNoData(t *testing.T) {
 func getUpgradedDbInfo(t *testing.T, noData bool) (upgradedDbInfo dbInfo) {
 	// we test that upgrading from the previous version gives the correct output
 	// by induction, this property should hold true for any chain of versions
-	prevVersion := semver.MustParse(version.Version)
-	toPreviousVersion(&prevVersion)
+	prevVersion := semver.MustParse(version.EarliestUpgradeTestVersion)
 
 	// TODO we could probably improve performance of this test by 2x if we
 	//      gathered the db info in parallel. Unfortunately our db runner doesn't
@@ -416,50 +415,6 @@ func migrateToVersion(t testing.TB, connectURL string, version string, commitHas
 	if err != nil {
 		t.Fatal(err)
 	}
-}
-
-var firstVersion = semver.MustParse("0.1.0")
-
-func toPreviousVersion(version *semver.Version) {
-	if version.Equals(firstVersion) {
-		*version = semver.MustParse("0.1.0-beta.5")
-		return
-	}
-	// our versions must match the schema X.Y.Z[.<pre-release>.A][.dev.C]
-	// where capital letters are numbers, and <pre-release> is some arbitrary
-	// pre-release tag.
-	// We skip .dev versions as they won't have a docker image, and go to the
-	// last "released" one
-	if len(version.Pre) >= 2 && version.Pre[len(version.Pre)-2].VersionStr == "dev" {
-		version.Pre = version.Pre[:len(version.Pre)-2]
-	}
-
-	if len(version.Pre) > 0 {
-		if len(version.Pre) != 2 ||
-			!version.Pre[len(version.Pre)-1].IsNum ||
-			version.Pre[len(version.Pre)-2].IsNum {
-			panic(fmt.Sprintf("version \"%v\" does not match our version spec", version))
-		}
-		lastPreDigit := &version.Pre[len(version.Pre)-1]
-		if lastPreDigit.VersionNum > 0 {
-			lastPreDigit.VersionNum -= 1
-			return
-		}
-	}
-
-	version.Pre = nil
-
-	if version.Patch > 0 {
-		version.Patch = 0
-		return
-	}
-
-	if version.Minor > 0 {
-		version.Minor -= 1
-		return
-	}
-
-	version.Major -= 1
 }
 
 func tsWriteReq(ts []prompb.TimeSeries) prompb.WriteRequest {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -33,8 +33,9 @@ var (
 	// since an app version must uniquely determine the state of the schema.
 	// It is customary to bump the version by incrementing the numeral after
 	// the `dev` tag. The SQL migration script name must correspond to the /new/ version.
-	Version    = "0.1.3-dev.1"
-	CommitHash = ""
+	Version                    = "0.1.3-dev.1"
+	CommitHash                 = ""
+	EarliestUpgradeTestVersion = "0.1.0"
 
 	PgVersionNumRange       = "=12.x" // Corresponds to range within pg 12.0 to pg 12.99
 	pgAcceptedVersionsRange = semver.MustParseRange(PgVersionNumRange)


### PR DESCRIPTION
Instead of trying to determine the previous version for
the update tests, set it explicitly. Also set it as
far back as reasonable. Moving it back always adds
more code to what is tested, since more upgrade scripts
are run.