### PR TITLE
Add support for go-sec based vulnerability scanning

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,20 @@
+name: Run Gosec
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: -exclude-dir=pkg/promql -exclude-dir=pkg/prompb ./...

--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -245,6 +245,7 @@ func StartPGContainerWithImage(ctx context.Context, image string, testDataDir st
 }
 
 // StartPromContainer starts a Prometheus container for use in testing
+// #nosec
 func StartPromContainer(storagePath string, ctx context.Context) (testcontainers.Container, error) {
 	// Set the storage directories permissions so Prometheus can write to them.
 	err := os.Chmod(storagePath, 0777)


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Note:
1. Most issues that this tool found are from `promql` which is excluded since we do not want to edit those changes. They seem mostly towards unhandled error returns which are from log.Warn, meaning, safe to ignore.