### PR TITLE
Added quick getting started guide with docker-compose

### DIFF
--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,0 +1,41 @@
+# Docker-compose
+
+Here you can find an initial setup for getting started
+
+This docker-compose has 3 services:
+
+* Prometheus
+* TimescaleDB with the promscale extension
+* Promscale
+
+---
+
+First start up the stack:
+```console
+$ docker-compose up -d
+```
+
+Promscale might fail at first because it needs TimescaleBD container to be up, and the database inside should be ready to receive traffic. After a few restarts(that are already configured to happen in the docker-compose), promscale should be up and running.
+
+```console
+$ docker-compose -f docker-compose.yml ps
+           Name                          Command               State           Ports         
+---------------------------------------------------------------------------------------------
+dockercompose_prometheus_1    /bin/prometheus --config.f ...   Up      9090/tcp              
+dockercompose_promscale_1     /promscale                       Up                            
+dockercompose_timescaleDB_1   docker-entrypoint.sh postgres    Up      0.0.0.0:5432->5432/tcp
+```
+
+Promscale needs a database to be created previously at TimescaleDB, so we're creating a database called `timescale` in our [init.sql](./init.sql).
+
+Prometheus is configured to scrape itself, and promscale is already configured as the remote_write and remote_read backend. After everything is up and running, you can already see Prometheus metrics, inside timescale, with your preferable Postgres Client tool (e.g. `psql`).
+
+In this example we are searching for the metric `up`:
+```console
+$ PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d timescale -c "SELECT * FROM prom_metric.up;"
+            time            | value | series_id |   labels    | instance_id | job_id 
+----------------------------+-------+-----------+-------------+-------------+--------
+ 2020-11-10 18:51:33.832+00 |     1 |        85 | {114,22,43} |          22 |     43
+ 2020-11-10 18:51:48.832+00 |     1 |        85 | {114,22,43} |          22 |     43
+ 2020-11-10 18:52:03.832+00 |     1 |        85 | {114,22,43} |          22 |     43
+```

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.4'
+services:
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes: 
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command: 
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=8h
+
+  promscale: 
+    image: timescale/promscale:latest
+    environment: 
+      TS_PROM_DB_HOST: "timescaleDB"
+      TS_PROM_DB_PASSWORD: "postgres"
+      TS_PROM_DB_USER: "postgres"
+      TS_PROM_DB_SSL_MODE: "disable"
+    depends_on: 
+      - timescaleDB 
+    restart: on-failure # TimescaleDB container is up but db process isn't, causes promscale to fail
+
+  timescaleDB:
+    image: timescaledev/promscale-extension:latest-pg12
+    environment: 
+      POSTGRES_PASSWORD: "postgres"
+    ports: 
+      - "5432:5432"
+    volumes: 
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql

--- a/examples/docker-compose/init.sql
+++ b/examples/docker-compose/init.sql
@@ -1,0 +1,1 @@
+create database timescale;

--- a/examples/docker-compose/prometheus.yml
+++ b/examples/docker-compose/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s 
+
+remote_write: 
+  - url: http://promscale:9201/write
+
+remote_read: 
+  - url: http://promscale:9201/read
+
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
I'm playing around with different tools related to observability in the last couple of weeks, and Promscale and [Tempo](https://github.com/grafana/tempo) were two of them. 

Tempo had a [really simple tutorial for getting started with docker-compose](https://github.com/grafana/tempo/tree/master/example/docker-compose), with less than 5 minutes I had a Tempo instance up and running, and was easy to see the value of the tool.

On the other hand, it was quite hard to get Promscale up and running quickly, due to my lack of knowledge about Postgres and Promscale architecture.

I've spent a couple of hours to finally get it to work with my monitoring setup, and I thought it could be a useful addition if Promscale could offer a simple guide for people that are experimenting and want to see the tool in action in less than 5 minutes.

This PR is a simplified version of my docker-compose, which deploys Prometheus, TimescaleDB, and Promscale. Ready to use after running a single `docker-compose up -d` command.