### PR TITLE
Add support for HTTP Basic Authentication and TLS for web endpoints

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,18 @@ You can also find information on flags with `promscale_<version> -help`
 | web-enable-admin-api | boolean | false | Allow operations via API that are for advanced users. Currently, these operations are limited to deletion of series. |
 | web-listen-address | string | `:9201` | Address to listen on for web endpoints. |
 | web-telemetry-path | string | `/metrics` | Web endpoint for exposing Promscale's Prometheus metrics. |
+| tls-cert-file | string | "" (disabled) | TLS certificate file path for web server. To disable TLS, leave this field as blank. |
+| tls-key-file | string | "" (disabled) | TLS key file path for web server. To disable TLS, leave this field as blank. |
+
+## Auth flags
+
+| Flag | Type | Default | Description |
+|------|:-----:|:-------:|:-----------:|
+| auth-username | string | "" | Authentication username used for web endpoint authentication. Disabled by default. |
+| auth-password | string | "" | Authentication password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password-file and bearer-token methods. |
+| auth-password-file | string | "" | Path for auth password file containing the actual password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password and bearer-token methods. |
+| bearer-token | string | "" (disabled) | Bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token-file and basic auth methods. |
+| bearer-token-file | string | "" (disabled) | Path of the file containing the bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token and basic auth methods. |
 
 ## Database flags
 

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -2,15 +2,17 @@ package api
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math"
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/storage"
@@ -24,12 +26,96 @@ var (
 
 	minTimeFormatted = minTime.Format(time.RFC3339Nano)
 	maxTimeFormatted = maxTime.Format(time.RFC3339Nano)
+
+	usernameAndTokenFlagsSetError = fmt.Errorf("at most one of basic-auth-username, bearer-token & bearer-token-file must be set")
+	noUsernameFlagSetError        = fmt.Errorf("invalid auth setup, cannot enable authorization with password only (username required)")
+	noPasswordFlagsSetError       = fmt.Errorf("one of basic-auth-password & basic-auth-password-file must be configured")
+	multiplePasswordFlagsSetError = fmt.Errorf("at most one of basic-auth-password & basic-auth-password-file must be configured")
+	multipleTokenFlagsSetError    = fmt.Errorf("at most one of bearer-token & bearer-token-file must be set")
 )
+
+type Auth struct {
+	BasicAuthUsername     string
+	BasicAuthPassword     string
+	BasicAuthPasswordFile string
+
+	BearerToken     string
+	BearerTokenFile string
+}
+
+func (a *Auth) Validate() error {
+	switch {
+	case a.BasicAuthUsername != "":
+		if a.BearerToken != "" || a.BearerTokenFile != "" {
+			return usernameAndTokenFlagsSetError
+		}
+		if a.BasicAuthPassword == "" && a.BasicAuthPasswordFile == "" {
+			return noPasswordFlagsSetError
+		}
+		if a.BasicAuthPassword != "" && a.BasicAuthPasswordFile != "" {
+			return multiplePasswordFlagsSetError
+		}
+		pwd, err := readFromFile(a.BasicAuthPasswordFile, a.BasicAuthPassword)
+		if err != nil {
+			return fmt.Errorf("error reading password file: %w", err)
+		}
+		a.BasicAuthPassword = pwd
+	case a.BasicAuthPassword != "" || a.BasicAuthPasswordFile != "":
+		// At this point, if we have password set with no username, throw
+		// error to warn the user this is an invalid auth setup.
+		return noUsernameFlagSetError
+	case a.BearerToken != "" || a.BearerTokenFile != "":
+		if a.BearerToken != "" && a.BearerTokenFile != "" {
+			return multipleTokenFlagsSetError
+		}
+		token, err := readFromFile(a.BearerTokenFile, a.BearerToken)
+		if err != nil {
+			return fmt.Errorf("error reading bearer token file: %w", err)
+		}
+		a.BearerToken = token
+	}
+
+	return nil
+}
 
 type Config struct {
 	AllowedOrigin   *regexp.Regexp
 	ReadOnly        bool
 	AdminAPIEnabled bool
+	TelemetryPath   string
+
+	Auth *Auth
+}
+
+func ParseFlags(cfg *Config) *Config {
+	cfg.Auth = &Auth{}
+
+	flag.BoolVar(&cfg.ReadOnly, "read-only", false, "Read-only mode for the connector. Operations related to writing or updating the database are disallowed. It is used when pointing the connector to a TimescaleDB read replica.")
+	flag.BoolVar(&cfg.AdminAPIEnabled, "web-enable-admin-api", false, "Allow operations via API that are for advanced users. Currently, these operations are limited to deletion of series.")
+	flag.StringVar(&cfg.TelemetryPath, "web-telemetry-path", "/metrics", "Web endpoint for exposing Promscale's Prometheus metrics.")
+
+	flag.StringVar(&cfg.Auth.BasicAuthUsername, "auth-username", "", "Authentication username used for web endpoint authentication. Disabled by default.")
+	flag.StringVar(&cfg.Auth.BasicAuthPassword, "auth-password", "", "Authentication password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password-file and bearer-token flags.")
+	flag.StringVar(&cfg.Auth.BasicAuthPasswordFile, "auth-password-file", "", "Path for auth password file containing the actual password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password and bearer-token methods.")
+	flag.StringVar(&cfg.Auth.BearerToken, "bearer-token", "", "Bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token-file and basic auth methods.")
+	flag.StringVar(&cfg.Auth.BearerTokenFile, "bearer-token-file", "", "Path of the file containing the bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token and basic auth methods.")
+	return cfg
+}
+
+func Validate(cfg *Config) error {
+	return cfg.Auth.Validate()
+}
+
+func readFromFile(path string, defaultValue string) (string, error) {
+	if path == "" {
+		return defaultValue, nil
+	}
+	bs, err := ioutil.ReadFile(path) // #nosec G304
+	if err != nil {
+		return "", fmt.Errorf("unable to read file %s: %w", path, err)
+	}
+
+	return strings.TrimSpace(string(bs)), nil
 }
 
 func corsWrapper(conf *Config, f http.HandlerFunc) http.HandlerFunc {
@@ -175,19 +261,19 @@ func parseTime(s string) (time.Time, error) {
 	case maxTimeFormatted:
 		return maxTime, nil
 	}
-	return time.Time{}, errors.Errorf("cannot parse %q to a valid timestamp", s)
+	return time.Time{}, fmt.Errorf("cannot parse %q to a valid timestamp", s)
 }
 
 func parseDuration(s string) (time.Duration, error) {
 	if d, err := strconv.ParseFloat(s, 64); err == nil {
 		ts := d * float64(time.Second)
 		if ts > float64(math.MaxInt64) || ts < float64(math.MinInt64) {
-			return 0, errors.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
+			return 0, fmt.Errorf("cannot parse %q to a valid duration. It overflows int64", s)
 		}
 		return time.Duration(ts), nil
 	}
 	if d, err := model.ParseDuration(s); err == nil {
 		return time.Duration(d), nil
 	}
-	return 0, errors.Errorf("cannot parse %q to a valid duration", s)
+	return 0, fmt.Errorf("cannot parse %q to a valid duration", s)
 }

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -2,10 +2,14 @@ package api
 
 import (
 	"context"
+	"errors"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/timescale/promscale/pkg/log"
@@ -108,4 +112,141 @@ func doCORSWrapperRequest(t *testing.T, queryHandler http.Handler, url, origin s
 	w := httptest.NewRecorder()
 	queryHandler.ServeHTTP(w, req)
 	return w
+}
+
+func TestValidateConfig(t *testing.T) {
+	fileContents, err := ioutil.ReadFile("common_test.go")
+	if err != nil {
+		t.Fatal("error reading file contents common_test.go")
+	}
+	fileContentsString := strings.TrimSpace(string(fileContents))
+	testCases := []struct {
+		name      string
+		cfg       *Auth
+		returnErr error
+		passSet   string
+		tokenSet  string
+	}{
+		{
+			name: "empty config",
+			cfg:  &Auth{},
+		},
+		{
+			name: "basic auth and bearer token set",
+			cfg: &Auth{
+				BasicAuthUsername: "foo",
+				BearerToken:       "foo",
+			},
+			returnErr: usernameAndTokenFlagsSetError,
+		},
+		{
+			name: "basic auth missing password",
+			cfg: &Auth{
+				BasicAuthUsername: "foo",
+			},
+			returnErr: noPasswordFlagsSetError,
+		},
+		{
+			name: "basic auth password and password file set",
+			cfg: &Auth{
+				BasicAuthUsername:     "foo",
+				BasicAuthPassword:     "foo",
+				BasicAuthPasswordFile: "foo",
+			},
+			returnErr: multiplePasswordFlagsSetError,
+		},
+		{
+			name: "basic auth invalid password file",
+			cfg: &Auth{
+				BasicAuthUsername:     "foo",
+				BasicAuthPasswordFile: "invalid filename",
+			},
+			returnErr: os.ErrNotExist,
+		},
+		{
+			name: "basic auth password set",
+			cfg: &Auth{
+				BasicAuthUsername: "foo",
+				BasicAuthPassword: "pass",
+			},
+			passSet: "pass",
+		},
+		{
+			name: "basic auth no username set",
+			cfg: &Auth{
+				BasicAuthPassword: "pass",
+			},
+			returnErr: noUsernameFlagSetError,
+		},
+		{
+			name: "basic auth password file set",
+			cfg: &Auth{
+				BasicAuthUsername:     "foo",
+				BasicAuthPasswordFile: "common_test.go",
+			},
+			passSet: fileContentsString,
+		},
+		{
+			name: "bearer token and token file set",
+			cfg: &Auth{
+				BearerToken:     "foo",
+				BearerTokenFile: "foo",
+			},
+			returnErr: multipleTokenFlagsSetError,
+		},
+		{
+			name: "bearer token set",
+			cfg: &Auth{
+				BearerToken: "foo",
+			},
+			tokenSet: "foo",
+		},
+		{
+			name: "bearer token file set",
+			cfg: &Auth{
+				BearerTokenFile: "common_test.go",
+			},
+			tokenSet: fileContentsString,
+		},
+		{
+			name: "bearer token file invalid file set",
+			cfg: &Auth{
+				BearerTokenFile: "invalid file",
+			},
+			returnErr: os.ErrNotExist,
+		},
+		{
+			name: "all config options set",
+			cfg: &Auth{
+				BasicAuthUsername:     "set",
+				BasicAuthPassword:     "set",
+				BasicAuthPasswordFile: "set",
+				BearerToken:           "set",
+				BearerTokenFile:       "set",
+			},
+			returnErr: usernameAndTokenFlagsSetError,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			err := Validate(&Config{
+				Auth: c.cfg,
+			})
+			if c.returnErr != nil {
+				if !errors.Is(err, c.returnErr) {
+					t.Errorf("unexpected error received: %s", err)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error received: %s", err)
+			}
+
+			if c.passSet != "" && c.cfg.BasicAuthPassword != c.passSet {
+				t.Errorf("unexpected password set: got %s wanted %s", c.cfg.BasicAuthPassword, c.passSet)
+			}
+			if c.tokenSet != "" && c.cfg.BearerToken != c.tokenSet {
+				t.Errorf("unexpected bearer token set: got %s wanted %s", c.cfg.BearerToken, c.tokenSet)
+			}
+		})
+	}
 }

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -75,7 +75,7 @@ func TestParseFlags(t *testing.T) {
 			name: "Read-only mode",
 			args: []string{"-read-only"},
 			result: func(c Config) Config {
-				c.ReadOnly = true
+				c.APICfg.ReadOnly = true
 				c.Migrate = false
 				c.StopAfterMigrate = false
 				c.UseVersionLease = false

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -233,7 +233,15 @@ func dateHeadersMatch(expected, actual []string) bool {
 func buildRouter(pool *pgxpool.Pool) (http.Handler, *pgclient.Client, error) {
 	apiConfig := &api.Config{
 		AllowedOrigin: regexp.MustCompile(".*"),
+		TelemetryPath: "/metrics",
 	}
+
+	return buildRouterWithAPIConfig(pool, apiConfig)
+}
+
+// buildRouterWithAPIConfig builds a testing router from a connection pool and
+// an API config.
+func buildRouterWithAPIConfig(pool *pgxpool.Pool, cfg *api.Config) (http.Handler, *pgclient.Client, error) {
 	metrics := api.InitMetrics()
 	conf := &pgclient.Config{
 		AsyncAcks:               false,
@@ -250,5 +258,5 @@ func buildRouter(pool *pgxpool.Pool) (http.Handler, *pgclient.Client, error) {
 		return nil, pgClient, errors.New("Cannot run test, cannot instantiate pgClient")
 	}
 
-	return api.GenerateRouter(apiConfig, metrics, pgClient, nil), pgClient, nil
+	return api.GenerateRouter(cfg, metrics, pgClient, nil), pgClient, nil
 }

--- a/pkg/tests/end_to_end_tests/router_test.go
+++ b/pkg/tests/end_to_end_tests/router_test.go
@@ -1,0 +1,119 @@
+package end_to_end_tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/timescale/promscale/pkg/api"
+)
+
+var (
+	routes = map[string]string{
+		"/write":                         "POST",
+		"/read":                          "GET,POST",
+		"/delete_series":                 "PUT,POST",
+		"/api/v1/query":                  "GET,POST",
+		"/api/v1/query_range":            "GET,POST",
+		"/api/v1/series":                 "GET,POST",
+		"/api/v1/labels":                 "GET,POST",
+		"/api/v1/label/foo/values":       "GET",
+		"/healthz":                       "GET",
+		"/debug/pprof":                   "GET",
+		"/debug/pprof/cmdline":           "GET",
+		"/debug/pprof/profile?seconds=1": "GET",
+		"/debug/pprof/symbol":            "GET",
+		"/debug/pprof/trace":             "GET",
+		"/metrics":                       "GET",
+	}
+)
+
+func TestRouterAuth(t *testing.T) {
+	if testing.Short() || !*useDocker {
+		t.Skip("skipping integration test")
+	}
+	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
+		var tester *testing.T
+		var ok bool
+		if tester, ok = t.(*testing.T); !ok {
+			t.Fatalf("Cannot run test, not an instance of testing.T")
+			return
+		}
+
+		apiConfig := &api.Config{
+			AllowedOrigin: regexp.MustCompile(".*"),
+			TelemetryPath: "/metrics",
+		}
+
+		router, pgClient, err := buildRouterWithAPIConfig(db, apiConfig)
+		if err != nil {
+			t.Fatalf("Cannot run test, unable to build router: %s", err)
+			return
+		}
+		defer pgClient.Close()
+
+		ts := httptest.NewServer(router)
+		defer ts.Close()
+
+		client := &http.Client{Timeout: 10 * time.Second}
+
+		for path, methodCSV := range routes {
+			methods := strings.Split(methodCSV, ",")
+			for _, method := range methods {
+				req, err := http.NewRequest(method, ts.URL+path, nil)
+				if err != nil {
+					tester.Errorf("unexpected error while creating request: %s", err)
+				}
+				resp, err := client.Do(req)
+				if err != nil {
+					tester.Errorf("unexpected error while sending request: %s", err)
+				}
+
+				if resp.StatusCode == http.StatusUnauthorized {
+					tester.Errorf("unexpected Unauthorized HTTP status code: path %s, method %s", path, method)
+				}
+			}
+		}
+
+		apiConfig = &api.Config{
+			AllowedOrigin: regexp.MustCompile(".*"),
+			TelemetryPath: "/metrics",
+			Auth: &api.Auth{
+				BasicAuthUsername: "foo",
+				BasicAuthPassword: "foo",
+			},
+		}
+
+		router, pgClient, err = buildRouterWithAPIConfig(db, apiConfig)
+		if err != nil {
+			t.Fatalf("Cannot run test, unable to build router: %s", err)
+			return
+		}
+		defer pgClient.Close()
+
+		ts = httptest.NewServer(router)
+		defer ts.Close()
+
+		for path, methodCSV := range routes {
+			methods := strings.Split(methodCSV, ",")
+			for _, method := range methods {
+				req, err := http.NewRequest(method, ts.URL+path, nil)
+				if err != nil {
+					tester.Errorf("unexpected error while creating request: %s", err)
+				}
+				resp, err := client.Do(req)
+				if err != nil {
+					tester.Errorf("unexpected error while sending request: %s", err)
+				}
+
+				if resp.StatusCode != http.StatusUnauthorized {
+					tester.Errorf("unexpected HTTP status code, wanted Unauthorized: path %s, method %s code %d", path, method, resp.StatusCode)
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
This commit adds configuration flags for setting up HTTP Basic Authentication,
Bearer Token Authentication (JWT), and TLS certificate support for web server.