### PR TITLE
Provide real-time speed updates for fetching data in prom-migrator

### DIFF
--- a/cmd/prom-migrator/README.md
+++ b/cmd/prom-migrator/README.md
@@ -61,7 +61,7 @@ as write endpoints are somewhat constrained.
 #### Example
 
 ```
-./prom-migrator -mint=1606408552 -maxt=1606415752 -read-url=<read_endpoint_url_for_remote_read_storage> -write-url=<write_endpoint_url_for_remote_write_storage> -writer-read-url=<read_endpoint_url_for_remote_write_storage>
+./prom-migrator -mint=1606408552 -maxt=1606415752 -read-url=<read_endpoint_url_for_remote_read_storage> -write-url=<write_endpoint_url_for_remote_write_storage> -progress-metric-url=<read_endpoint_url_for_remote_write_storage>
 ```
 
 ## CLI flags

--- a/pkg/migration-tool/writer/writer.go
+++ b/pkg/migration-tool/writer/writer.go
@@ -74,6 +74,7 @@ func (rw *RemoteWrite) Run(errChan chan<- error) {
 				if !ok {
 					return
 				}
+				blockRef.SetDescription("preparing to push", 1)
 				ts = timeseriesRefToTimeseries(blockRef.MergeProgressSeries(rw.progressTimeSeries))
 				buf = []byte{}
 				if err = rw.sendSamplesWithBackoff(context.Background(), ts, &buf); err != nil {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This commit decouples the progress bars from writer and reader and
implements real-time speed updates on the fetching of block(s) side.

### Screenshot (Note the spinner to the left of the last line)

![Screenshot from 2020-12-11 22-53-01](https://user-images.githubusercontent.com/33792202/101935523-3cf31a00-3c05-11eb-8a79-0d1d547d8c8f.png)
