### PR TITLE
fix `trimLeadingZeros()`

### DIFF
--- a/pkg/pgmodel/extension.go
+++ b/pkg/pgmodel/extension.go
@@ -289,5 +289,8 @@ func getNewExtensionVersion(extName string,
 
 // trimLeadingZeros removes the leading zeros passed in the version number.
 func trimLeadingZeros(s string) string {
-	return strings.TrimLeft(s, "0")
+	if s = strings.TrimLeft(s, "0"); s == "" {
+		return "0"
+	}
+	return s
 }


### PR DESCRIPTION
if there's nothing but zeroes in the version component it happens to strip
one too many for it should tolerate one leading zero if it also happens
to be a trailing one.