### PR TITLE
Update helm drop chunks job

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -110,6 +110,9 @@ helm install --name my-release -f myvalues.yaml .
 | `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
 | `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |
 | `maintenance.schedule`            | The schedule with which the Job, that deletes data outside the retention period, runs | `0,30 * * * *` |
+| `maintenance.startingDeadlineSeconds` | If set, CronJob controller counts how many missed jobs occurred from the set value until now | `200` |
+| `maintenance.successfulJobsHistoryLimit` | The number of successful maintenance pods to retain in-cluster | `3`      |
+| `maintenance.failedJobsHistoryLimit` | The number of failed maintenance pods to retain in-cluster | `1`              |
 | `resources`                       | Requests and limits for each of the pods    | `{}`                               |
 | `nodeSelector`                    | Node labels to use for scheduling           | `{}`                               |
 

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -26,7 +26,7 @@ The database **must be created before** starting the connector.
 The chart expects that the password used to connect to TimescaleDB is stored in a
 Kubernetes Secret created before the chart is deployed.
 You can set the secret name by modifying the  `connection.password.secretTemplate` value.
-Templating is supported and you can use:
+Templating is supported, and you can use:
 ```yaml
 connection:
   password:
@@ -109,7 +109,7 @@ helm install --name my-release -f myvalues.yaml .
 | `service.port`                    | Port the connector pods will accept connections on | `9201`                      |
 | `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
 | `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |
-| `dropChunk.schedule`              | The schedule with which the drop-chunk Job runs | `0,30 * * * *`                 |
+| `maintenance.schedule`            | The schedule with which the Job, that deletes data outside the retention period, runs | `0,30 * * * *` |
 | `resources`                       | Requests and limits for each of the pods    | `{}`                               |
 | `nodeSelector`                    | Node labels to use for scheduling           | `{}`                               |
 

--- a/helm-chart/templates/config-maintenance.yaml
+++ b/helm-chart/templates/config-maintenance.yaml
@@ -10,8 +10,7 @@ metadata:
 data:
   execute_maintenance.sh: |-
     #!/bin/sh
-    psql  \
-    {{ if .Values.connection.uri.secretTemplate -}} $PROMSCALE_DB_URI \{{- end }}
+    psql $PROMSCALE_DB_URI \
     -e -q -c "CALL prom_api.execute_maintenance();"
     if [ $? -eq 0 ]
     then
@@ -19,4 +18,5 @@ data:
       echo "Retention policies executed."
     else
       echo "Maintenance job failed!"
+      exit 1
     fi

--- a/helm-chart/templates/config-maintenance.yaml
+++ b/helm-chart/templates/config-maintenance.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "connector.fullname" . | trunc 51 }}-maintenance
+  labels:
+    app: {{ template "connector.fullname" . }}
+    chart: {{ template "connector.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  execute_maintenance.sh: |-
+    #!/bin/sh
+    psql  \
+    {{ if .Values.connection.uri.secretTemplate -}} $PROMSCALE_DB_URI \{{- end }}
+    -e -q -c "CALL prom_api.execute_maintenance();"
+    if [ $? -eq 0 ]
+    then
+      echo "Maintenance completed successfully."
+      echo "Retention policies executed."
+    else
+      echo "Maintenance job failed!"
+    fi

--- a/helm-chart/templates/cronjob-maintenance.yaml
+++ b/helm-chart/templates/cronjob-maintenance.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   schedule: {{ .Values.maintenance.schedule }}
   startingDeadlineSeconds: {{ .Values.maintenance.startingDeadlineSeconds }}
+  successfulJobsHistoryLimit: {{ .Values.maintenance.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.maintenance.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
       template:

--- a/helm-chart/templates/cronjob-maintenance.yaml
+++ b/helm-chart/templates/cronjob-maintenance.yaml
@@ -9,6 +9,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.maintenance.schedule }}
+  startingDeadlineSeconds: {{ .Values.maintenance.startingDeadlineSeconds }}
   jobTemplate:
     spec:
       template:

--- a/helm-chart/templates/cronjob-maintenance.yaml
+++ b/helm-chart/templates/cronjob-maintenance.yaml
@@ -1,20 +1,20 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: {{ include "connector.fullname" . | trunc 41 }}-drop-chunk
+  name: {{ include "connector.fullname" . | trunc 51 }}-maintenance
   labels:
     app: {{ template "connector.fullname" . }}
     chart: {{ template "connector.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.dropChunk.schedule }}
+  schedule: {{ .Values.maintenance.schedule }}
   jobTemplate:
     spec:
       template:
         spec:
           containers:
-          - name: {{ .Chart.Name }}-drop-chunk
+          - name: {{ .Chart.Name }}-maintenance
             image: postgres:12-alpine
             args:
             - psql

--- a/helm-chart/templates/cronjob-maintenance.yaml
+++ b/helm-chart/templates/cronjob-maintenance.yaml
@@ -17,14 +17,10 @@ spec:
           - name: {{ .Chart.Name }}-maintenance
             image: postgres:12-alpine
             args:
-            - psql
-            {{- if .Values.connection.dbURI.secretTemplate }}
-            - $(PROMSCALE_DB_URI)
-            {{- end }}
-            - -c
-            - CALL prom_api.execute_maintenance();
+            - sh
+            - ./execute_maintenance.sh
             env:
-              {{- if not .Values.connection.dbURI.secretTemplate }}
+              {{- if not .Values.connection.uri.secretTemplate }}
               - name: PGPORT
                 value: {{ .Values.connection.port | quote }}
               - name: PGUSER
@@ -42,7 +38,15 @@ spec:
               - name: PROMSCALE_DB_URI
                 valueFrom:
                   secretKeyRef:
-                    name: {{ tpl .Values.connection.dbURI.secretTemplate . }}
-                    key: {{ .Values.connection.dbURI.name }}
+                    name: {{ tpl .Values.connection.uri.secretTemplate . }}
+                    key: {{ .Values.connection.uri.key }}
               {{- end }}
+            volumeMounts:
+              - name: script-volume
+                mountPath: /execute_maintenance.sh
+                subPath: execute_maintenance.sh
+          volumes:
+            - name: script-volume
+              configMap:
+                name: {{ include "connector.fullname" . | trunc 51 }}-maintenance
           restartPolicy: OnFailure

--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -38,7 +38,7 @@ spec:
             - containerPort: 9201
               name: connector-port
           env:
-            {{- if not .Values.connection.dbURI.secretTemplate }}
+            {{- if not .Values.connection.uri.secretTemplate }}
             - name: PROMSCALE_DB_PORT
               value: {{ .Values.connection.port | quote }}
             - name: PROMSCALE_DB_USER
@@ -58,8 +58,8 @@ spec:
             - name: PROMSCALE_DB_URI
               valueFrom:
                 secretKeyRef:
-                  name: {{ tpl .Values.connection.dbURI.secretTemplate . }}
-                  key: {{ .Values.connection.dbURI.name }}
+                  name: {{ tpl .Values.connection.uri.secretTemplate . }}
+                  key: {{ .Values.connection.uri.key }}
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -74,9 +74,9 @@ service:
       # service.beta.kubernetes.io/aws-load-balancer-type: nlb            # Use an NLB instead of ELB
       # service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0  # Internal Load Balancer
 
-# settings for the drop-chunk CronJob that deletes data outside of
+# settings for the maintenance CronJob that deletes data outside of
 # the retention period
-dropChunk:
+maintenance:
   schedule: "0,30 * * * *"
 
 # set your own limits

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -14,6 +14,18 @@ args: []
 
 # connection options to connect to a target db
 connection:
+  # connection string settings, it is pulled
+  # from a Secret object. If `secretTemplate` is not
+  # set then the specific user, pass, host, port and
+  # sslMode properties are used.
+  uri:
+    key: db-uri
+    # the template for generating the name of
+    # a Secret object containing the URI to
+    # connect to TimescaleDB. The URI should
+    # be indexed with the key in `connection.uri.key`
+    # used in the above name field.
+    secretTemplate:
   # user used to connect to TimescaleDB
   user: postgres
   password:
@@ -21,15 +33,7 @@ connection:
     # a Secret object containing the password to
     # connect to TimescaleDB. The password should
     # be indexed by the user name (connection.user)
-    secretTemplate: "{{ .release.Name}}-timescaledb-passwords"
-  dbURI:
-    name: db-uri
-    # the template for generating the name of
-    # a Secret object containing the db-uri to
-    # connect to TimescaleDB. The db-uri should
-    # be indexed with the key (db-uri) or with the value
-    # used in the above name field.
-    secretTemplate:
+    secretTemplate: "{{ .Release.Name }}-timescaledb-passwords"
   host:
     # the template for generating the database host
     # location

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -82,7 +82,17 @@ service:
 # the retention period
 maintenance:
   schedule: "0,30 * * * *"
+  # If startingDeadlineSeconds field is set (not null), the CronJob controller counts how
+  # many missed jobs occurred from the value of startingDeadlineSeconds until now.
+  # For example, if it is set to 200, it counts how many missed schedules occurred in the
+  # last 200 seconds. In that case, if there were more than 100 missed schedules in the
+  # last 200 seconds, the cron job is no longer scheduled.
+  # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#starting-deadline
   startingDeadlineSeconds: 200
+  # The number of successful maintenance pods to retain in-cluster
+  successfulJobsHistoryLimit: 3
+  # The number of failed maintenance pods to retain in-cluster
+  failedJobsHistoryLimit: 1
 
 # set your own limits
 resources: {}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -82,6 +82,7 @@ service:
 # the retention period
 maintenance:
   schedule: "0,30 * * * *"
+  startingDeadlineSeconds: 200
 
 # set your own limits
 resources: {}


### PR DESCRIPTION
The drop chunks job is now renamed to maintenance,
to reflect the name change of the underlying function
it called. 

Additionally the call is made more verbose to signify 
what was executed, and if it failed or succeeded. 

Fixes #299, with the solution provided in the issue
(thanks @franck102). And a replacement for #191 is added
with better nomenclature (due to inactivity on that PR) 
(thanks @halfmatthalfcat)