### PR TITLE
add flags for upgrade-extensions

### DIFF
--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -93,7 +93,7 @@ func TestParseFlags(t *testing.T) {
 				c.Migrate = false
 				c.StopAfterMigrate = false
 				c.UseVersionLease = false
-				c.InstallTimescaleDB = false
+				c.InstallExtensions = false
 				return c
 			},
 		},

--- a/pkg/tests/end_to_end_tests/main_test.go
+++ b/pkg/tests/end_to_end_tests/main_test.go
@@ -139,7 +139,7 @@ func performMigrate(t testing.TB, connectURL string, superConnectURL string) {
 			// Thus, you have to use the superuser to install TimescaleDB
 			migrateURL = superConnectURL
 		}
-		err := pgmodel.MigrateTimescaleDBExtension(migrateURL)
+		err := pgmodel.InstallUpgradeTimescaleDBExtensions(migrateURL, true, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -155,7 +155,7 @@ func performMigrate(t testing.TB, connectURL string, superConnectURL string) {
 		t.Fatal(err)
 	}
 	defer conn.Release()
-	err = Migrate(conn.Conn(), pgmodel.VersionInfo{Version: version.Version, CommitHash: "azxtestcommit"})
+	err = Migrate(conn.Conn(), pgmodel.VersionInfo{Version: version.Version, CommitHash: "azxtestcommit"}, true, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**--install-extensions**: It installs the extenion if not present. By default set to true.  Formerly this flag was **install-timescaledb**

**--upgrade-extensions**: Upgrade extension to available next version. By default set to true.

**--upgrade-prerelease-extensions**: Upgrade to available highest prerelease if available. By default set to false.

1. Install TimescaleDB & Promscale extensions only if ``--install-extensions`` is enabled.
2. Upgrade TimescaleDB & Promscale to available latest version if ``--upgrade-extensions`` is enabled.
3. Upgrade TimescaleDB & Promscale to available latest `rc` version if --upgrade-prerelease-extensions`` is enabled.

Note:

1. If the current installed version in timescaleDB is an `rc` version we ignore `--upgrade-prerelease-extensions` flag that is set to `false` & will let promscale run with the already installed `rc` version.  


Signed-off-by: Vineeth Pothulapati <vineethpothulapati@outlook.com>