### PR TITLE
Add alerting & recording rules, series deletion & retention docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ remote storage endpoints. For more information about prom-migrator, visit
   * [Filtering Series](docs/sql_schema.md#filtering-series)
   * [Data Retention](docs/sql_schema.md#data-retention)
 * **[Writing Data to Promscale](docs/writing_to_promscale.md)**
+* **[Alerting & Recording Rules](docs/alerting-recording.md)**
+* **[Deleting Data](docs/metric_deletion_retention.md)**
 * **[Quick Tips](#-quick-tips)**
 * **[High Availability](docs/high-avaliability/prometheus-HA.md)**
 * **[FAQ](docs/faq.md)**

--- a/docs/alerting-recording.md
+++ b/docs/alerting-recording.md
@@ -1,0 +1,65 @@
+# Alerting & Recording Rules
+
+### Alerting Rules
+
+Alerting rules are used to trigger alerts based on the violation of any condition(s). These alerts are fired to external services like slack, mails, etc by the [alert manager](https://prometheus.io/docs/alerting/latest/alertmanager/). Alerting rules are written in a YAML file and paths of these files are mentioned in the Prometheus configuration respectively. It is important to note that the evaluation of these conditional rules are performed at the Prometheus side. The newly formed series for alerting are stored in both Prometheus and Promscale.
+
+```
+groups:
+  - name: <alert-group-name>
+    rules:
+    - alert: <alert-name>
+      expr: <promql_expression>
+      for: <time-interval for how long this to happen to happen to fire an alert>
+      labels:
+        <key>:<value>
+      annotations:
+        summary: <text>
+        description: <description on alert>
+```
+
+Load the above defined alert rule file to your prometheus configuration for evaluation.
+
+```
+rule_files:
+  - "<alert-rules-file>"
+```
+
+Configure the alert manager in prometheus configuration.
+
+```
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - localhost:9093
+```
+
+More details on alerting rules can be found [here](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+
+
+### Recording Rules
+
+The recording rules are for pre-calculating frequently used or computationally expensive queries. PromQL expressions defined in recording rules are evaluated at the Prometheus side. These evaluated rules form a new series that goes by the name of the record field's value and ingested in both Prometheus and Promscale.
+
+Adding recording rules:
+
+```
+groups:
+  - name: my-rules
+    rules:
+    - record: <RECORD_NAME>
+      expr: <PROMQL_EXPR>
+      
+```
+
+Load the above defined recording rule file to your prometheus configuration for evaluation.
+
+```
+rule_files:
+  - "<recording-rules-file>"
+```
+
+More details on recording rules can be found [here](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
+
+**Note**: We recommended setting `read_recent` to `true` in the [Prometheus remote_read configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read) when using recording rules. This tells Prometheus to fetch data from Promscale when evaluating PromQL queries (including recording rules). If `read_recent` is disabled, **only** the data stored in Prometheus's local tsdb will be used when evaluating alerting/recording rules and thus be dependent on the retention period of Prometheus (not Promscale).

--- a/docs/metric_deletion_retention.md
+++ b/docs/metric_deletion_retention.md
@@ -1,0 +1,50 @@
+# Deleting Data
+
+Promscale supports series deletion & metric retention. Series deletion deletes all data for a specified series over the entire time-range. Metric retention deletes data older than a specified duration for a given metric. You can specify a default metric retention period as well as overwrite that default on a particular metric.
+
+## Series Deletion
+
+Promscale exposes an API for deletion of series. This works same as prometheus delete API.
+
+**Note**: The start and end timestamp options are not supported yet. Currently, the `delete_series` API lets you delete the series across the entire time-range.
+
+#### Promscale Delete API
+
+URL query parameters:
+
+* **match[]=<series_selector>**: Repeated label matcher argument that selects the series to delete. At least one match[] argument must be provided.
+
+```
+POST /delete_series
+PUT /delete_series
+```
+
+Example:
+
+```
+curl -X POST -g http://promscale:9201/delete_series?match[]=container_cpu_usage_seconds_total
+```
+
+## Metric Retention
+
+TimescaleDB offers full control over data retentions i.e you can set a default data retention period as well as overwrite the default on a per-metric basis.
+
+SQL command to set the default retention policy to two days for all metrics that do not have custom retention policy already specified.
+
+```
+SELECT prom_api.set_default_retention_period(INTERVAL '1 day' * 2)
+```
+
+SQL command to set a custom retention policy for a specific metric.
+
+```
+SELECT prom_api.set_metric_retention_period(container_cpu_usage_seconds_total, INTERVAL '1 day' * 2)
+```
+
+SQL command to reset specific metric retention to the default metric retention.
+
+```
+SELECT prom_api.reset_metric_retention_period(container_cpu_usage_seconds_total)
+```
+
+The retention policies are executed using a cron job. Please see the Promscale installation instructions for your platform to see how to set up the cron job.


### PR DESCRIPTION
This PR contains docs for

1. Setting up alerting, recording rules at the Prometheus side. 
2. Metric deletion & metric retention using Promscale & TimescaleDB. 