### PR TITLE
Add retry on 422 HTTP status code from Prometheus in end-to-end tests

### DIFF
--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -588,6 +588,18 @@ func StartPromContainer(storagePath string, ctx context.Context) (testcontainers
 			storagePath:    "/prometheus",
 			promConfigFile: "/etc/prometheus/prometheus.yml",
 		},
+		Cmd: []string{
+			// Default configuration.
+			"--config.file=/etc/prometheus/prometheus.yml",
+			"--storage.tsdb.path=/prometheus",
+			"--web.console.libraries=/usr/share/prometheus/console_libraries",
+			"--web.console.templates=/usr/share/prometheus/consoles",
+
+			// This is to stop Prometheus from messing with the data.
+			"--storage.tsdb.retention.time=30y",
+			"--storage.tsdb.min-block-duration=30y",
+			"--storage.tsdb.max-block-duration=30y",
+		},
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -160,6 +160,17 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 					return
 				}
 
+				// If we get a 422 Unprocessable Entity HTTP status code from Prometheus,
+				// let's try one more time.
+				if promResp.StatusCode == http.StatusUnprocessableEntity {
+					promResp, promErr = client.Do(promReq)
+
+					if promErr != nil {
+						t.Errorf("unexpected error returned from Prometheus client when retrying:\n%s\n", promErr.Error())
+						return
+					}
+				}
+
 				compareHTTPHeaders(t, promResp.Header, tsResp.Header)
 
 				promContent, err := ioutil.ReadAll(promResp.Body)


### PR DESCRIPTION
Prometheus can run background processes on its internal database to compact
the dataset, if a query is ran at this time, it is possible to get a 422
HTTP response. In this case, we just retry. This commit also adds some custom
Prometheus configuration to preserve the dataset intact.