### PR TITLE
Fix sample throughput report interval

### DIFF
--- a/pkg/api/metrics_test.go
+++ b/pkg/api/metrics_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCreateMetrics(t *testing.T) {
+	testCases := []struct {
+		name             string
+		tickInterval     int
+		expectedInterval time.Duration
+	}{
+		{
+			name:             "tick interval less than default",
+			tickInterval:     0,
+			expectedInterval: defaultTickInterval,
+		},
+		{
+			name:             "tick interval more than default",
+			tickInterval:     5,
+			expectedInterval: 5 * time.Second,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			metrics := createMetrics(c.tickInterval)
+
+			if metrics.WriteThroughput.GetTickInterval() != c.expectedInterval {
+				t.Errorf("wrong write throughput tick interval, got %s, wanted %s",
+					metrics.WriteThroughput.GetTickInterval().String(),
+					c.expectedInterval.String())
+			}
+
+		})
+	}
+}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -153,7 +153,7 @@ func Run(cfg *Config) error {
 		log.Info("msg", "Migrations disabled for read-only mode")
 	}
 
-	promMetrics := api.InitMetrics()
+	promMetrics := api.InitMetrics(cfg.PgmodelCfg.ReportInterval)
 
 	client, err := CreateClient(cfg, promMetrics)
 	if err != nil {

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -331,7 +331,7 @@ func TestInitElector(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
-			metrics := api.InitMetrics()
+			metrics := api.InitMetrics(0)
 			elector, err := initElector(c.cfg, metrics)
 
 			switch {

--- a/pkg/tests/end_to_end_tests/migrate_test.go
+++ b/pkg/tests/end_to_end_tests/migrate_test.go
@@ -80,7 +80,7 @@ func TestMigrateLock(t *testing.T) {
 			},
 		}
 		conn.Release()
-		metrics := api.InitMetrics()
+		metrics := api.InitMetrics(0)
 		reader, err := runner.CreateClient(&cfg, metrics)
 		// reader on its own should start
 		if err != nil {

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -253,7 +253,7 @@ func buildRouter(pool *pgxpool.Pool) (http.Handler, *pgclient.Client, error) {
 // buildRouterWithAPIConfig builds a testing router from a connection pool and
 // an API config.
 func buildRouterWithAPIConfig(pool *pgxpool.Pool, cfg *api.Config) (http.Handler, *pgclient.Client, error) {
-	metrics := api.InitMetrics()
+	metrics := api.InitMetrics(0)
 	conf := &pgclient.Config{
 		AsyncAcks:               false,
 		ReportInterval:          0,

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -43,6 +43,11 @@ func NewThroughputCalc(interval time.Duration) *ThroughputCalc {
 	return &ThroughputCalc{tickInterval: interval, current: make(chan float64, 1), Values: make(chan float64, 1)}
 }
 
+// GetTickInterval returns the tick interval of the throughput calculator.
+func (dt *ThroughputCalc) GetTickInterval() time.Duration {
+	return dt.tickInterval
+}
+
 // SetCurrent sets the value of the counter
 func (dt *ThroughputCalc) SetCurrent(value float64) {
 	select {


### PR DESCRIPTION
Applied the `-tput-report` flag value to the write throughput calculator in
the exposed Prometheus metrics.

Fixes #367 