### PR TITLE
Bump timescaleDB supported range to <2.1.0

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -47,7 +47,7 @@ var (
 	TimescaleVersionRangeString = struct {
 		Safe, Warn string
 	}{
-		Safe: ">=1.7.3 <2.0.0",
+		Safe: ">=1.7.3 <2.1.0",
 		Warn: ">=1.7.0 <1.7.3",
 	}
 	timescaleVersionSafeRange = semver.MustParseRange(TimescaleVersionRangeString.Safe)


### PR DESCRIPTION
Update the supported version range of promscale from `Safe: ">=1.7.3 <2.0.0"` to `Safe: ">=1.7.3 <2.1.0"`

Signed-off-by: Vineeth Pothulapati <vineethpothulapati@outlook.com>