### PR TITLE
Adds support for configuring PromQL engine evaluation via CLI flags.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,11 +1,11 @@
 # Promscale command line doc
 
-This document gives you information about the configuration flags supported by promscale.
+This document gives you information about the configuration flags supported by Promscale.
 You can also find information on flags with `promscale_<version> -help` 
 
 ## General flags
 | Flag | Type | Default | Description |
-|------|:-----:|:-------:|:-----------:|
+|------|:-----:|:-------:|:-----------|
 | config | string | config.yml | YAML configuration file path for Promscale. |
 | install-timescaledb | boolean | true | Install or update TimescaleDB extension. |
 | leader-election-pg-advisory-lock-id | integer | 0 (disabled) | Leader-election based high-availability. It is based on PostgreSQL advisory lock and requires a unique advisory lock ID per high-availability group. Only a single connector in each high-availability group will write data at one time. A value of 0 disables leader election. |
@@ -29,7 +29,7 @@ You can also find information on flags with `promscale_<version> -help`
 ## Auth flags
 
 | Flag | Type | Default | Description |
-|------|:-----:|:-------:|:-----------:|
+|------|:-----:|:-------:|:-----------|
 | auth-username | string | "" | Authentication username used for web endpoint authentication. Disabled by default. |
 | auth-password | string | "" | Authentication password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password-file and bearer-token methods. |
 | auth-password-file | string | "" | Path for auth password file containing the actual password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password and bearer-token methods. |
@@ -39,7 +39,7 @@ You can also find information on flags with `promscale_<version> -help`
 ## Database flags
 
 | Flag | Type | Default | Description |
-|------|:-----:|:-------:|:-----------:|
+|------|:-----:|:-------:|:-----------|
 | db-host | string | localhost | Host for TimescaleDB/Vanilla Postgres. |
 | db-port | int | 5432 | TimescaleDB/Vanilla Postgres connection password. |
 | db-name | string | timescale | Database name. |
@@ -51,3 +51,10 @@ You can also find information on flags with `promscale_<version> -help`
 | db-writer-connection-concurrency | int | 4 | Maximum number of database connections for writing per go process. |
 | db-uri | string | | TimescaleDB/Vanilla PostgresSQL URI. Example:`postgres://postgres:password@localhost:5432/timescale?sslmode=require` |
 | async-acks | boolean | false | Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss. |
+
+## PromQL engine evaluation flags
+
+| Flag | Type | Default | Description |
+|------|:-----:|:-------:|:-----------|
+| promql-query-timeout | duration | 2 minutes | Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in '/api/v1/query.*' endpoints. |
+| promql-default-subquery-step-interval | duration | 1 minute | Default step interval to be used for PromQL subquery evaluation. This value is used if the subquery does not specify the step value explicitly. Example: <metric_name>[30m:]. Note: in Prometheus this setting is set by the evaluation_interval option. |

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -87,6 +87,10 @@ type Config struct {
 	TelemetryPath   string
 
 	Auth *Auth
+
+	// PromQL configuration.
+	MaxQueryTimeout      time.Duration
+	SubQueryStepInterval time.Duration // Default step interval value if the user has not provided.
 }
 
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
@@ -101,6 +105,12 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.StringVar(&cfg.Auth.BasicAuthPasswordFile, "auth-password-file", "", "Path for auth password file containing the actual password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password and bearer-token methods.")
 	fs.StringVar(&cfg.Auth.BearerToken, "bearer-token", "", "Bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token-file and basic auth methods.")
 	fs.StringVar(&cfg.Auth.BearerTokenFile, "bearer-token-file", "", "Path of the file containing the bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token and basic auth methods.")
+
+	// PromQL configuration flags.
+	fs.DurationVar(&cfg.MaxQueryTimeout, "promql-query-timeout", 2*time.Minute, "Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in "+
+		"'/api/v1/query.*' endpoints.")
+	fs.DurationVar(&cfg.SubQueryStepInterval, "promql-default-subquery-step-interval", 1*time.Minute, "Default step interval to be used for PromQL subquery evaluation. "+
+		"This value is used if the subquery does not specify the step value explicitly. Example: <metric_name>[30m:]. Note: in Prometheus this setting is set by the evaluation_interval option.")
 	return cfg
 }
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -44,7 +44,7 @@ func GenerateRouter(apiConf *Config, metrics *Metrics, client *pgclient.Client, 
 	router.Post("/delete_series", deleteHandler)
 
 	queryable := client.Queryable()
-	queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
+	queryEngine := query.NewEngine(log.GetLogger(), apiConf.MaxQueryTimeout, apiConf.SubQueryStepInterval)
 	queryHandler := timeHandler(metrics.HTTPRequestDuration, "query", Query(apiConf, queryEngine, queryable))
 	router.Get("/api/v1/query", queryHandler)
 	router.Post("/api/v1/query", queryHandler)

--- a/pkg/query/query_engine.go
+++ b/pkg/query/query_engine.go
@@ -13,14 +13,14 @@ import (
 	"github.com/timescale/promscale/pkg/promql"
 )
 
-func NewEngine(logger log.Logger, queryTimeout time.Duration) *promql.Engine {
+func NewEngine(logger log.Logger, queryTimeout time.Duration, subqueryDefaultStepInterval time.Duration) *promql.Engine {
 	return promql.NewEngine(
 		promql.EngineOpts{
 			Logger:                   logger,
 			Reg:                      prometheus.NewRegistry(),
 			MaxSamples:               math.MaxInt32,
 			Timeout:                  queryTimeout,
-			NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(1 * time.Minute) },
+			NoStepSubqueryIntervalFn: func(int64) int64 { return durationMilliseconds(subqueryDefaultStepInterval) },
 		},
 	)
 }

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -247,8 +247,10 @@ func dateHeadersMatch(expected, actual []string) bool {
 // buildRouter builds a testing router from a connection pool.
 func buildRouter(pool *pgxpool.Pool) (http.Handler, *pgclient.Client, error) {
 	apiConfig := &api.Config{
-		AllowedOrigin: regexp.MustCompile(".*"),
-		TelemetryPath: "/metrics",
+		AllowedOrigin:        regexp.MustCompile(".*"),
+		TelemetryPath:        "/metrics",
+		MaxQueryTimeout:      time.Minute * 2,
+		SubQueryStepInterval: time.Minute,
 	}
 
 	return buildRouterWithAPIConfig(pool, apiConfig)

--- a/pkg/tests/end_to_end_tests/query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/query_integration_test.go
@@ -1029,7 +1029,7 @@ func TestPushdown(t *testing.T) {
 		labelsReader := pgmodel.NewLabelsReader(dbConn, lCache)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader)
 		queryable := query.NewQueryable(r, labelsReader)
-		queryEngine := query.NewEngine(log.GetLogger(), time.Minute)
+		queryEngine := query.NewEngine(log.GetLogger(), time.Minute, time.Minute)
 
 		for _, c := range testCases {
 			tc := c


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Fixes: #426
Fixes: #255

This commits adds support for configuring PromQL engine evaluation.
This widens our PromQL support in order to evaluate queries
that require some specific conditions.