### PR TITLE
HA service returns minimum accepted timestamp

### DIFF
--- a/pkg/api/write_test.go
+++ b/pkg/api/write_test.go
@@ -290,7 +290,11 @@ func TestWrite(t *testing.T) {
 			responseCode: http.StatusInternalServerError,
 			inserterErr:  fmt.Errorf("some error"),
 			requestBody: writeRequestToString(
-				&prompb.WriteRequest{},
+				&prompb.WriteRequest{
+					Timeseries: []prompb.TimeSeries{
+						{},
+					},
+				},
 			),
 		},
 		{

--- a/pkg/ha/ha_parser_test.go
+++ b/pkg/ha/ha_parser_test.go
@@ -18,56 +18,57 @@ func Test_haParser_ParseData(t *testing.T) {
 		tts []prompb.TimeSeries
 	}
 
+	leaseStart := time.Unix(1, 0)
+	leaseUntil := leaseStart.Add(2 * time.Second)
+	// As Prometheus remote write sends sample timestamps
+	// in milli-seconds converting the test samples to milliseconds
+	inLeaseTimestamp := leaseStart.Add(time.Second).UnixNano() / 1000000
+	behindLeaseTimestamp := leaseStart.Add(-time.Second).UnixNano() / 1000000
+	aheadLeaseTimestamp := leaseUntil.Add(time.Second).UnixNano() / 1000000
 	clusterInfo := []*haLockState{
 		{
 			cluster:    "cluster1",
 			leader:     "replica1",
-			leaseStart: time.Now().Add(-5 * time.Minute),
-			leaseUntil: time.Now().Add(2 * time.Minute),
+			leaseStart: leaseStart,
+			leaseUntil: leaseUntil,
 		},
 		{
 			cluster:    "cluster2",
 			leader:     "replica1",
-			leaseStart: time.Now().Add(-5 * time.Minute),
-			leaseUntil: time.Now().Add(2 * time.Minute),
+			leaseStart: leaseStart,
+			leaseUntil: leaseUntil,
 		},
 		{
 			cluster:    "cluster3",
 			leader:     "replica1",
-			leaseStart: time.Now().Add(-5 * time.Minute),
-			leaseUntil: time.Now().Add(2 * time.Minute),
+			leaseStart: leaseStart,
+			leaseUntil: leaseUntil,
 		},
 		{
 			cluster:    "cluster4",
-			leader:     "replica1",
-			leaseStart: time.Now().Add(-5 * time.Minute),
-			leaseUntil: time.Now().Add(2 * time.Minute),
+			leader:     "replica2",
+			leaseStart: leaseStart,
+			leaseUntil: leaseUntil,
 		},
 		{
 			cluster:    "cluster5",
-			leader:     "replica1",
-			leaseStart: time.Now().Add(-5 * time.Minute),
-			leaseUntil: time.Now().Add(2 * time.Minute),
+			leader:     "replica2",
+			leaseStart: leaseStart,
+			leaseUntil: leaseUntil,
 		},
 	}
 
 	mockService := MockNewHAService(clusterInfo)
 
-	// As Prometheus remote write sends sample timestamps
-	// in milli-seconds converting the test samples to milliseconds
-	sampleTimestamp := time.Now().UnixNano() / 1000000
-	behindLeaseTimestamp := time.Now().Add(-10 * time.Minute).UnixNano() / 1000000
-	aheadLeaseTimestamp := time.Now().Add(5 * time.Minute).UnixNano() / 1000000
-
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		want    map[string][]model.SamplesInfo
-		want1   int
-		wantErr bool
-		error   error
-		cluster string
+		name        string
+		fields      fields
+		args        args
+		wantSamples map[string][]model.SamplesInfo
+		wantNumRows int
+		wantErr     bool
+		error       error
+		cluster     string
 	}{
 		{
 			name:   "Test: HA enabled but __replica__ && __cluster__ are empty.",
@@ -78,7 +79,7 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.MetricNameLabelName, Value: "test"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
@@ -96,7 +97,7 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.ClusterNameLabel, Value: "cluster1"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
@@ -114,7 +115,7 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.ReplicaNameLabel, Value: "replica1"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
@@ -132,12 +133,12 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.ClusterNameLabel, Value: "cluster1"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
 			wantErr: false,
-			want: map[string][]model.SamplesInfo{
+			wantSamples: map[string][]model.SamplesInfo{
 				"test": {
 					{
 						Labels: &model.Labels{
@@ -150,14 +151,14 @@ func Test_haParser_ParseData(t *testing.T) {
 						Samples: []prompb.Sample{
 							{
 								Value:     0.1,
-								Timestamp: sampleTimestamp,
+								Timestamp: inLeaseTimestamp,
 							},
 						},
 					},
 				},
 			},
-			want1:   1,
-			cluster: "cluster1",
+			wantNumRows: 1,
+			cluster:     "cluster1",
 		},
 		{
 			name:   "Test: HA enabled parse samples from standby prom instance.",
@@ -170,14 +171,14 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.ClusterNameLabel, Value: "cluster2"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
-			wantErr: false,
-			want:    nil,
-			want1:   0,
-			cluster: "cluster2",
+			wantErr:     false,
+			wantSamples: nil,
+			wantNumRows: 0,
+			cluster:     "cluster2",
 		},
 		{
 			name:   "Test: HA enabled parse samples from leader prom instance.",
@@ -190,12 +191,12 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.ClusterNameLabel, Value: "cluster3"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
 			wantErr: false,
-			want: map[string][]model.SamplesInfo{
+			wantSamples: map[string][]model.SamplesInfo{
 				"test": {
 					{
 						Labels: &model.Labels{
@@ -208,17 +209,17 @@ func Test_haParser_ParseData(t *testing.T) {
 						Samples: []prompb.Sample{
 							{
 								Value:     0.1,
-								Timestamp: sampleTimestamp,
+								Timestamp: inLeaseTimestamp,
 							},
 						},
 					},
 				},
 			},
-			want1:   1,
-			cluster: "cluster3",
+			wantNumRows: 1,
+			cluster:     "cluster3",
 		},
 		{
-			name:   "Test: HA enabled parse samples from leader prom instance & samples are out of lease interval 1.",
+			name:   "Test: HA enabled parse from leader & samples are in interval [leaseStart-X, leaseUntil]",
 			fields: fields{service: mockService},
 			args: args{tts: []prompb.TimeSeries{
 				{
@@ -232,13 +233,13 @@ func Test_haParser_ParseData(t *testing.T) {
 					},
 				},
 			}},
-			wantErr: false,
-			want:    nil,
-			want1:   0,
-			cluster: "cluster3",
+			wantErr:     false,
+			wantSamples: map[string][]model.SamplesInfo{},
+			wantNumRows: 0,
+			cluster:     "cluster3",
 		},
 		{
-			name:   "Test: HA enabled parse samples from leader prom instance & samples are out of lease interval 2.",
+			name:   "Test: HA enabled parse from leader & samples are in interval [leaseStart, leaseUntil+X].",
 			fields: fields{service: mockService},
 			args: args{tts: []prompb.TimeSeries{
 				{
@@ -253,7 +254,7 @@ func Test_haParser_ParseData(t *testing.T) {
 				},
 			}},
 			wantErr: false,
-			want:    map[string][]model.SamplesInfo{
+			wantSamples: map[string][]model.SamplesInfo{
 				"test": {
 					{
 						Labels: &model.Labels{
@@ -272,11 +273,49 @@ func Test_haParser_ParseData(t *testing.T) {
 					},
 				},
 			},
-			want1:   1,
-			cluster: "cluster3",
+			wantNumRows: 1,
+			cluster:     "cluster3",
 		},
 		{
-			name:   "Test: HA enabled parse samples from standby prom instance. readLockState returns the updated leader as standby prom instance but samples aren't part lease range.",
+			name:   "Test: HA enabled, parse samples from standby instance. readLockState returns the updated leader as standby prom instance.",
+			fields: fields{service: mockService},
+			args: args{tts: []prompb.TimeSeries{
+				{
+					Labels: []prompb.Label{
+						{Name: model.MetricNameLabelName, Value: "test"},
+						{Name: model.ReplicaNameLabel, Value: "replica2"},
+						{Name: model.ClusterNameLabel, Value: "cluster4"},
+					},
+					Samples: []prompb.Sample{
+						{Timestamp: inLeaseTimestamp, Value: 0.1},
+					},
+				},
+			}},
+			wantErr: false,
+			wantSamples: map[string][]model.SamplesInfo{
+				"test": {
+					{
+						Labels: &model.Labels{
+							Names:      []string{model.ClusterNameLabel, model.MetricNameLabelName, model.ReplicaNameLabel},
+							Values:     []string{"cluster4", "test", "replica2"},
+							MetricName: "test",
+							Str:        "\v\u0000__cluster__\b\u0000cluster4\b\u0000__name__\u0004\u0000test\v\u0000__replica__\b\u0000replica2",
+						},
+						SeriesID: -1,
+						Samples: []prompb.Sample{
+							{
+								Value:     0.1,
+								Timestamp: inLeaseTimestamp,
+							},
+						},
+					},
+				},
+			},
+			wantNumRows: 1,
+			cluster:     "cluster4",
+		},
+		{
+			name:   "Test: HA enabled parse from standby. readLockState returns the updated leader as standby prom instance but samples aren't part lease range.",
 			fields: fields{service: mockService},
 			args: args{tts: []prompb.TimeSeries{
 				{
@@ -286,47 +325,46 @@ func Test_haParser_ParseData(t *testing.T) {
 						{Name: model.ClusterNameLabel, Value: "cluster5"},
 					},
 					Samples: []prompb.Sample{
-						{Timestamp: sampleTimestamp, Value: 0.1},
+						{Timestamp: behindLeaseTimestamp, Value: 0.1},
 					},
 				},
 			}},
-			wantErr: false,
-			want:    nil,
-			want1:   0,
-			cluster: "cluster5",
+			wantErr:     false,
+			wantSamples: map[string][]model.SamplesInfo{},
+			wantNumRows: 0,
+			cluster:     "cluster5",
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := &haParser{
 				service: tt.fields.service,
 			}
-			got, got1, err := h.ParseData(tt.args.tts)
+			gotSamplesPerMetric, gotTotalRows, err := h.ParseData(tt.args.tts)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ParseData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseData() got = %v, want %v", got, tt.want)
+			if !reflect.DeepEqual(gotSamplesPerMetric, tt.wantSamples) {
+				t.Errorf("ParseData() gotSamplesPerMetric = %v, wantSamples %v", gotSamplesPerMetric, tt.wantSamples)
 			}
-			if got1 != tt.want1 {
-				t.Errorf("ParseData() got1 = %v, want %v", got1, tt.want1)
+			if gotTotalRows != tt.wantNumRows {
+				t.Errorf("ParseData() gotTotalRows = %v, wantSamples %v", gotTotalRows, tt.wantNumRows)
 			}
 
 			// If we are ingesting data means we are updating the maxTimeSeen & maxTimeSeenInstance details
 			// Also make sure again that only samples from current leader are ingested.
 			// validate whether the details are updated.
 			//time.Sleep(2*time.Second)
-			if got1 > 0 {
+			if gotTotalRows > 0 {
 				for _, obj := range tt.args.tts[0].Labels {
 					if obj.Name == "__replica__" {
-						f := tt.want["test"]
+						f := tt.wantSamples["test"]
 						if f != nil {
 							s, _ := h.service.state.Load(tt.cluster)
 							state := s.(*State)
 							stateView := state.clone()
-							if obj.Value != stateView.leader || f[0].Samples[0].Timestamp != stateView.maxTimeSeen.UnixNano() / 1000000 {
+							if obj.Value != stateView.leader || f[0].Samples[0].Timestamp != stateView.maxTimeSeen.UnixNano()/1000000 {
 								t.Errorf("max time seen isn't updated to latest samples info")
 							}
 						}

--- a/pkg/ha/mock_ha_service.go
+++ b/pkg/ha/mock_ha_service.go
@@ -2,9 +2,9 @@ package ha
 
 import (
 	"context"
-	"sync"
-
 	"golang.org/x/sync/semaphore"
+	"sync"
+	"time"
 )
 
 func MockNewHAService(clusterInfo []*haLockState) *Service {
@@ -23,4 +23,13 @@ func MockNewHAService(clusterInfo []*haLockState) *Service {
 		_leaderChangeLock: semaphore.NewWeighted(1),
 	}
 	return service
+}
+
+func SetLeaderInMockService(service *Service, cluster, leader string, minT, maxT time.Time) {
+	service.lockClient.(*mockLockClient).leadersPerCluster[cluster] = &haLockState{
+		cluster:    cluster,
+		leader:     leader,
+		leaseStart: minT,
+		leaseUntil: maxT,
+	}
 }


### PR DESCRIPTION
Instead of just returning a boolean accepting or denying
the insert from an instance, the HA service can now
accept an insert but specify a minimum accepted timestamp
so the parser can filter out samples outside of the lease
interval.