### PR TITLE
Fix promQL integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/prometheus/common v0.15.0
 	github.com/prometheus/prometheus v1.8.2-0.20201112142552-bef9d4e18226
 	github.com/schollz/progressbar/v3 v3.7.2
+	github.com/sergi/go-diff v1.0.0
 	github.com/stretchr/testify v1.6.1
 	github.com/testcontainers/testcontainers-go v0.5.1
 	github.com/uber/jaeger-client-go v2.25.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -855,6 +855,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUt
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
+github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shopspring/decimal v0.0.0-20200227202807-02e2044944cc h1:jUIKcSPO9MoMJBbEoyE/RJoE8vz7Mb8AjvifMMwSyvY=

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"net/http"
 	"reflect"
@@ -35,6 +36,7 @@ type sample struct {
 	Raw       string
 	Metric    model.Metric       `json:"metric"`
 	Values    []model.SamplePair `json:"values"`
+	Value     model.SamplePair   `json:"value"`
 }
 
 type dummySample sample
@@ -68,17 +70,30 @@ func (s sample) Equal(other sample) bool {
 		return false
 	}
 
+	valuesAreWiithinThreshold := func(left model.SamplePair, right model.SamplePair) bool {
+		if left.Value.Equal(right.Value) {
+			return true
+		}
+
+		diff := float64(left.Value) - float64(right.Value)
+		return math.Abs(diff) < valueDiffThreshold
+	}
+
+	if !valuesAreWiithinThreshold(s.Value, other.Value) {
+		return false
+	}
+
+	if len(s.Values) != len(other.Values) {
+		return false
+	}
 	for i, v := range s.Values {
 		if v.Timestamp != other.Values[i].Timestamp {
 			return false
 		}
 
-		diff := v.Value - other.Values[i].Value
-
-		if diff > valueDiffThreshold || diff < -valueDiffThreshold {
+		if !valuesAreWiithinThreshold(v, other.Values[i]) {
 			return false
 		}
-
 	}
 
 	return true
@@ -91,6 +106,9 @@ func (s samples) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 func (s samples) Less(i, j int) bool { return s[i].Metric.Before(s[j].Metric) }
 
 func (s samples) Equal(other samples) bool {
+	if len(s) != len(other) {
+		return false
+	}
 	for i, cur := range s {
 		if !cur.Equal(other[i]) {
 			return false
@@ -100,9 +118,9 @@ func (s samples) Equal(other samples) bool {
 	return true
 }
 
-type resultComparator func(promContent []byte, tsContent []byte) error
+type resultComparator func(promContent []byte, tsContent []byte, log string) error
 
-func testRequest(tsReq, promReq *http.Request, client *http.Client, comparator resultComparator) func(*testing.T) {
+func testRequest(tsReq, promReq *http.Request, client *http.Client, comparator resultComparator, log string) func(*testing.T) {
 	return func(t *testing.T) {
 		tsResp, tsErr := client.Do(tsReq)
 
@@ -130,7 +148,7 @@ func testRequest(tsReq, promReq *http.Request, client *http.Client, comparator r
 		}
 		defer tsResp.Body.Close()
 
-		err = comparator(promContent, tsContent)
+		err = comparator(promContent, tsContent, log)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -193,7 +211,7 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 				}
 				defer tsResp.Body.Close()
 
-				err = comparator(promContent, tsContent)
+				err = comparator(promContent, tsContent, log)
 				if err != nil {
 					t.Errorf("%s gives %s", log, err)
 					return

--- a/pkg/tests/end_to_end_tests/promql_label_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_label_endpoint_test.go
@@ -105,7 +105,7 @@ func TestPromQLLabelEndpoint(t *testing.T) {
 			t.Fatalf("unable to create Prometheus PromQL label names request: %v", err)
 		}
 
-		testMethod := testRequest(tsReq, promReq, client, labelsResultComparator)
+		testMethod := testRequest(tsReq, promReq, client, labelsResultComparator, "label endpoint")
 		tester.Run("get label names", testMethod)
 
 		lCache := clockcache.WithMax(100)
@@ -133,7 +133,7 @@ func TestPromQLLabelEndpoint(t *testing.T) {
 	})
 }
 
-func labelsResultComparator(promContent []byte, tsContent []byte) error {
+func labelsResultComparator(promContent []byte, tsContent []byte, log string) error {
 	var got, wanted labelsResponse
 
 	err := json.Unmarshal(tsContent, &got)

--- a/pkg/tests/end_to_end_tests/promql_series_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_series_endpoint_test.go
@@ -164,7 +164,7 @@ func TestPromQLSeriesEndpoint(t *testing.T) {
 	})
 }
 
-func seriesResultComparator(promContent []byte, tsContent []byte) error {
+func seriesResultComparator(promContent []byte, tsContent []byte, log string) error {
 	var got, wanted seriesResponse
 
 	err := json.Unmarshal(tsContent, &got)


### PR DESCRIPTION
Previously the PromQL tests on the real dataset didn't run because
the start and end variables in runPromQLQueryTests were incorrectly
shadowed.

Once that was fixed it was revealed that some of our queried didn't
match Prometheus - this was also a testing (and not real) issue. Turns
out our way of generating prom data was incorrect. Namely, to start up
prom correctly on the data the data should be snapshoted and not simply
left in plain DB mode.

Besides that we have some fixes to equality checking and the like.