### PR TITLE
Add timeout for tests in go-scheduled.yaml

### DIFF
--- a/.github/workflows/go-scheduled.yml
+++ b/.github/workflows/go-scheduled.yml
@@ -82,7 +82,7 @@ jobs:
         fi
 
     - name: Test
-      run: go test -v -race ./...
+      run: go test -v -race ./... -timeout 15m
 
     - name: Test extended dataset
       run: go test -v -race -timeout=30m ./pkg/tests/end_to_end_tests/ -extended-test


### PR DESCRIPTION
Add timeout to go schedule job. As it's failing due to timeout  https://github.com/timescale/promscale/runs/1803289305?check_suite_focus=true

We added the timeout in `go.yml` and missed adding to `go-scheduled.yaml` for running the same tests.