### PR TITLE
Support for warning user on slow data ingestion.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -695,7 +695,6 @@ github.com/jackc/pgconn v0.0.0-20190831204454-2fabfa3c18b7/go.mod h1:ZJKsE/KZfsU
 github.com/jackc/pgconn v1.4.0/go.mod h1:Y2O3ZDF0q4mMacyWV3AstPJpeHXWGEetiFttmq5lahk=
 github.com/jackc/pgconn v1.5.0/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
 github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
-github.com/jackc/pgconn v1.6.3 h1:4Ks3RKvSvKPolXZsnLQTDAsokDhgID14Cv4ehECmzlY=
 github.com/jackc/pgconn v1.6.3/go.mod h1:w2pne1C2tZgP+TvjqLpOigGzNqjBgQW9dUw/4Chex78=
 github.com/jackc/pgconn v1.8.1 h1:ySBX7Q87vOMqKU2bbmKbUvtYhauDFclYbNDYIE1/h6s=
 github.com/jackc/pgconn v1.8.1/go.mod h1:JV6m6b6jhjdmzchES0drzCcYcAHS1OPD5xu3OZ/lE2g=
@@ -714,7 +713,6 @@ github.com/jackc/pgproto3/v2 v2.0.0-alpha1.0.20190609003834-432c2951c711/go.mod 
 github.com/jackc/pgproto3/v2 v2.0.0-rc3/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:ryONWYqW6dqSg1Lw6vXNMXoBJhpzvWKnT95C46ckYeM=
 github.com/jackc/pgproto3/v2 v2.0.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
-github.com/jackc/pgproto3/v2 v2.0.2 h1:q1Hsy66zh4vuNsajBUF2PNqfAMMfxU5mk594lPE9vjY=
 github.com/jackc/pgproto3/v2 v2.0.2/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.6 h1:b1105ZGEMFe7aCvrT1Cca3VoVb4ZFMaFJLJcg/3zD+8=
 github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
@@ -1233,7 +1231,6 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=

--- a/pkg/ewma/ewma.go
+++ b/pkg/ewma/ewma.go
@@ -1,0 +1,61 @@
+// This code has been borrowed from https://github.com/prometheus/prometheus/blob/main/storage/remote/ewma.go
+//
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package ewma
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Rate tracks an exponentially weighted moving average of a per-second rate.
+type Rate struct {
+	newEvents int64
+
+	alpha    float64
+	interval time.Duration
+	lastRate float64
+	init     bool
+	mutex    sync.Mutex
+}
+
+// NewEWMARate always allocates a new ewmaRate, as this guarantees the atomically
+// accessed int64 will be aligned on ARM.  See prometheus#2666.
+func NewEWMARate(alpha float64, interval time.Duration) *Rate {
+	return &Rate{
+		alpha:    alpha,
+		interval: interval,
+	}
+}
+
+// Rate returns the per-second rate.
+func (r *Rate) Rate() float64 {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return r.lastRate
+}
+
+// Tick assumes to be called every r.interval.
+func (r *Rate) Tick() {
+	newEvents := atomic.SwapInt64(&r.newEvents, 0)
+	instantRate := float64(newEvents) / r.interval.Seconds()
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.init {
+		r.lastRate += r.alpha * (instantRate - r.lastRate)
+	} else if newEvents > 0 {
+		r.init = true
+		r.lastRate = instantRate
+	}
+}
+
+// Incr counts incr events.
+func (r *Rate) Incr(incr int64) {
+	atomic.AddInt64(&r.newEvents, incr)
+}

--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -21,7 +21,7 @@ import (
 	"github.com/jackc/pgx/v4/pgxpool"
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/stretchr/testify/require"
-	testcontainers "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"github.com/timescale/promscale/pkg/pgmodel/common/schema"
 )

--- a/pkg/pgmodel/ingestor/dispatcher.go
+++ b/pkg/pgmodel/ingestor/dispatcher.go
@@ -36,7 +36,7 @@ type pgxDispatcher struct {
 	insertedDatapoints     *int64
 	toCopiers              chan copyRequest
 	seriesEpochRefresh     *time.Ticker
-	doneChannel            chan bool
+	doneChannel            chan struct{}
 	doneWG                 sync.WaitGroup
 	labelArrayOID          uint32
 }
@@ -76,8 +76,9 @@ func newPgxDispatcher(conn pgxconn.PgxConn, cache cache.MetricCache, scache cach
 		toCopiers:              toCopiers,
 		// set to run at half our deletion interval
 		seriesEpochRefresh: time.NewTicker(30 * time.Minute),
-		doneChannel:        make(chan bool),
+		doneChannel:        make(chan struct{}),
 	}
+	runThroughputWatcher(inserter.doneChannel)
 	if cfg.AsyncAcks && cfg.ReportInterval > 0 {
 		inserter.insertedDatapoints = new(int64)
 		reportInterval := int64(cfg.ReportInterval)
@@ -194,7 +195,8 @@ func (p *pgxDispatcher) Close() {
 // actually inserted) and any error.
 // Though we may insert data to multiple tables concurrently, if asyncAcks is
 // unset this function will wait until _all_ the insert attempts have completed.
-func (p *pgxDispatcher) InsertData(rows map[string][]model.Samples) (uint64, error) {
+func (p *pgxDispatcher) InsertData(dataTS model.Data) (uint64, error) {
+	rows := dataTS.Rows
 	var numRows uint64
 	workFinished := &sync.WaitGroup{}
 	workFinished.Add(len(rows))
@@ -213,6 +215,8 @@ func (p *pgxDispatcher) InsertData(rows map[string][]model.Samples) (uint64, err
 	var err error
 	if !p.asyncAcks {
 		workFinished.Wait()
+		decBatch(numRows)
+		registerIngestionDuration(dataTS.InTime)
 		select {
 		case err = <-errChan:
 		default:
@@ -221,6 +225,8 @@ func (p *pgxDispatcher) InsertData(rows map[string][]model.Samples) (uint64, err
 	} else {
 		go func() {
 			workFinished.Wait()
+			decBatch(numRows)
+			registerIngestionDuration(dataTS.InTime)
 			select {
 			case err = <-errChan:
 			default:

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -6,6 +6,7 @@ package ingestor
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/timescale/promscale/pkg/clockcache"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
@@ -93,7 +94,8 @@ func (ingestor *DBIngestor) Ingest(r *prompb.WriteRequest) (uint64, error) {
 	// samples) must no longer be reachable from req.
 	FinishWriteRequest(r)
 
-	rowsInserted, err := ingestor.dispatcher.InsertData(dataSamples)
+	incBatch(uint64(totalRows))
+	rowsInserted, err := ingestor.dispatcher.InsertData(model.Data{Rows: dataSamples, InTime: time.Now()})
 	if err == nil && rowsInserted != totalRows {
 		return rowsInserted, fmt.Errorf("failed to insert all the data! Expected: %d, Got: %d", totalRows, rowsInserted)
 	}

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -94,8 +94,7 @@ func (ingestor *DBIngestor) Ingest(r *prompb.WriteRequest) (uint64, error) {
 	// samples) must no longer be reachable from req.
 	FinishWriteRequest(r)
 
-	incBatch(uint64(totalRows))
-	rowsInserted, err := ingestor.dispatcher.InsertData(model.Data{Rows: dataSamples, InTime: time.Now()})
+	rowsInserted, err := ingestor.dispatcher.InsertData(model.Data{Rows: dataSamples, ReceivedTime: time.Now()})
 	if err == nil && rowsInserted != totalRows {
 		return rowsInserted, fmt.Errorf("failed to insert all the data! Expected: %d, Got: %d", totalRows, rowsInserted)
 	}

--- a/pkg/pgmodel/ingestor/ingestor_sql_test.go
+++ b/pkg/pgmodel/ingestor/ingestor_sql_test.go
@@ -767,7 +767,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 			}
 			defer inserter.Close()
 
-			_, err = inserter.InsertData(c.rows)
+			_, err = inserter.InsertData(model.Data{Rows: c.rows})
 
 			var expErr error
 

--- a/pkg/pgmodel/ingestor/watcher.go
+++ b/pkg/pgmodel/ingestor/watcher.go
@@ -1,0 +1,121 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package ingestor
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/timescale/promscale/pkg/log"
+)
+
+const (
+	// reportThreshold is a value above which the warn would be logged. This value is
+	// the value of the ratio between incoming batches vs outgoing batches.
+	reportRatioThreshold = 3
+	refreshIteration     = 10 // This means that values of watcher.incomingBatches and watcher.outgoingBatches gets renewed every (refreshIteration * checkThroughputInterval).
+	checkRatioInterval   = time.Minute
+
+	// Duration warnings constants.
+	reportDurationThreshold        = time.Minute
+	checkIngestionDurationInterval = time.Minute
+)
+
+// throughtputWatcher is a light weight samples batch watching type, that serves as a watching
+// routine and keeps the track of incoming write batches. It keeps a ratio of
+// incoming samples vs outgoing samples and warn about low throughput to the user
+// which might be due to external causes like network latency, resources allocated, etc.
+//
+// We watch the batches than the samples in total, since watching batching is fast
+// and does the same purpose of watching samples, but on a higher-level.
+type throughtputWatcher struct {
+	// Warn based on ratio.
+	incomingBatches uint64
+	outgoingBatches uint64
+
+	// Warn based on ingestion duration.
+	shouldReportLastDuration atomic.Value
+	lastIngestionDuration    atomic.Value
+
+	stop chan struct{}
+}
+
+var watcher *throughtputWatcher
+
+func runThroughputWatcher(stop chan struct{}) {
+	watcher = &throughtputWatcher{
+		incomingBatches: 0,
+		outgoingBatches: 0,
+		stop:            stop,
+	}
+	watcher.shouldReportLastDuration.Store(false)
+	go watcher.watch()
+	go watcher.watchTime()
+}
+
+// watch watches the ratio between incomingBatches and outgoingBatches every checkThroughputInterval.
+func (w *throughtputWatcher) watch() {
+	var (
+		itr uint8
+		t   = time.NewTicker(checkRatioInterval)
+	)
+	for range t.C {
+		select {
+		case <-w.stop:
+			return
+		default:
+		}
+		itr++
+		if w.outgoingBatches > 1 {
+			if ratio := float64(atomic.LoadUint64(&w.incomingBatches)) / float64(atomic.LoadUint64(&w.outgoingBatches)); ratio > reportRatioThreshold {
+				w.warn(ratio)
+			}
+		}
+		if itr > refreshIteration {
+			// refresh every 'refreshIteration' of outgoing ratio checks.
+			atomic.StoreUint64(&watcher.incomingBatches, 0)
+			atomic.StoreUint64(&watcher.outgoingBatches, 0)
+		}
+	}
+}
+
+func (w *throughtputWatcher) warn(ratio float64) {
+	log.Warn("msg", "[WARNING] Incoming samples rate higher than outgoing samples. This may happen due to poor network latency, "+
+		"less resources allocated, or few concurrent writes (shards) from Prometheus. Please tune your resource to improve performance. ",
+		"Throughput ratio", fmt.Sprintf("%.2f", ratio), "Ratio threshold", reportRatioThreshold)
+}
+
+func (w *throughtputWatcher) watchTime() {
+	t := time.NewTicker(checkIngestionDurationInterval)
+	for range t.C {
+		select {
+		case <-w.stop:
+			return
+		default:
+		}
+		if w.shouldReportLastDuration.Load().(bool) {
+			log.Warn("msg", "[WARNING] Ingestion is taking too long", "ingest duration",
+				w.lastIngestionDuration.Load().(time.Duration).String(), "threshold", reportDurationThreshold.String())
+			w.shouldReportLastDuration.Store(false)
+		}
+	}
+}
+
+func incBatch(size uint64) {
+	atomic.AddUint64(&watcher.incomingBatches, size)
+}
+
+func decBatch(size uint64) {
+	atomic.AddUint64(&watcher.outgoingBatches, size)
+}
+
+func registerIngestionDuration(inTime time.Time) {
+	d := time.Since(inTime)
+	if d.Seconds() > reportDurationThreshold.Seconds() {
+		watcher.shouldReportLastDuration.Store(true)
+		watcher.lastIngestionDuration.Store(d)
+	}
+}

--- a/pkg/pgmodel/model/interface.go
+++ b/pkg/pgmodel/model/interface.go
@@ -27,7 +27,7 @@ var (
 
 // Dispatcher is responsible for inserting label, series and data into the storage.
 type Dispatcher interface {
-	InsertData(rows map[string][]Samples) (uint64, error)
+	InsertData(rows Data) (uint64, error)
 	CompleteMetricCreation() error
 	Close()
 }

--- a/pkg/pgmodel/model/samples.go
+++ b/pkg/pgmodel/model/samples.go
@@ -21,8 +21,8 @@ type Samples interface {
 // Data wraps incoming data with its in-timestamp. It is used to warn if the rate
 // of incoming samples vs outgoing samples is too low, based on time.
 type Data struct {
-	Rows   map[string][]Samples
-	InTime time.Time
+	Rows         map[string][]Samples
+	ReceivedTime time.Time
 }
 
 type promSample struct {

--- a/pkg/pgmodel/model/samples.go
+++ b/pkg/pgmodel/model/samples.go
@@ -18,6 +18,13 @@ type Samples interface {
 	getSample(int) *prompb.Sample
 }
 
+// Data wraps incoming data with its in-timestamp. It is used to warn if the rate
+// of incoming samples vs outgoing samples is too low, based on time.
+type Data struct {
+	Rows   map[string][]Samples
+	InTime time.Time
+}
+
 type promSample struct {
 	series  *Series
 	samples []prompb.Sample

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -452,15 +452,16 @@ func (m *MockInserter) Close() {
 
 }
 
-func (m *MockInserter) InsertNewData(rows map[string][]Samples) (uint64, error) {
-	return m.InsertData(rows)
+func (m *MockInserter) InsertNewData(data Data) (uint64, error) {
+	return m.InsertData(data)
 }
 
 func (m *MockInserter) CompleteMetricCreation() error {
 	return nil
 }
 
-func (m *MockInserter) InsertData(rows map[string][]Samples) (uint64, error) {
+func (m *MockInserter) InsertData(data Data) (uint64, error) {
+	rows := data.Rows
 	for _, v := range rows {
 		for i, si := range v {
 			seriesStr := si.GetSeries().String()

--- a/pkg/pgmodel/querier/series_set_test.go
+++ b/pkg/pgmodel/querier/series_set_test.go
@@ -30,26 +30,31 @@ type mockPgxRows struct {
 	err          error
 }
 
+//nolint
 // Close closes the rows, making the connection ready for use again. It is safe
 // to call Close after rows is already closed.
 func (m *mockPgxRows) Close() {
 	m.closeCalled = true
 }
 
+//nolint
 // Err returns any error that occurred while reading.
 func (m *mockPgxRows) Err() error {
 	return nil
 }
 
+//nolint
 // CommandTag returns the command tag from this query. It is only available after Rows is closed.
 func (m *mockPgxRows) CommandTag() pgconn.CommandTag {
 	panic("not implemented")
 }
 
+//nolint
 func (m *mockPgxRows) FieldDescriptions() []pgproto3.FieldDescription {
 	panic("not implemented")
 }
 
+//nolint
 // Next prepares the next row for reading. It returns true if there is another
 // row and false if no more rows are available. It automatically closes rows
 // when all rows are read.
@@ -62,6 +67,7 @@ func (m *mockPgxRows) Next() bool {
 	return m.idx < len(m.results)
 }
 
+//nolint
 // Scan reads the values from the current row into dest values positionally.
 // dest can include pointers to core types, values implementing the Scanner
 // interface, []byte, and nil. []byte will skip the decoding process and directly
@@ -95,11 +101,13 @@ func (m *mockPgxRows) Scan(dest ...interface{}) error {
 	return nil
 }
 
+//nolint
 // Values returns the decoded row values.
 func (m *mockPgxRows) Values() ([]interface{}, error) {
 	panic("not implemented")
 }
 
+//nolint
 // RawValues returns the unparsed bytes of the row values. The returned [][]byte is only valid until the next Next
 // call or the Rows is closed. However, the underlying byte data is safe to retain a reference to and mutate.
 func (m *mockPgxRows) RawValues() [][]byte {

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -499,7 +499,7 @@ func TestExtensionUpgrade(t *testing.T) {
 	var version string
 	ctx := context.Background()
 	buildPromscaleImageFromRepo(t)
-	db, dbContainer, closer := startDB(t, ctx)
+	_, dbContainer, closer := startDB(t, ctx)
 	defer closer.Close()
 
 	defer testhelpers.StopContainer(ctx, dbContainer, false)
@@ -509,7 +509,7 @@ func TestExtensionUpgrade(t *testing.T) {
 	extVersion := "2.0.0-rc2"
 	dropAndCreateExt(t, ctx, extVersion)
 
-	db, err = pgx.Connect(ctx, testhelpers.PgConnectURL("postgres", testhelpers.Superuser))
+	db, err := pgx.Connect(ctx, testhelpers.PgConnectURL("postgres", testhelpers.Superuser))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This commit adds support for warning user if:
1. The ratio between incoming samples and outgoing samples is more than
   the threshold ratio value.
2. The time taken by a batch is above the threshold time alloted.