### PR TITLE
Optimize memory usage: samples

### DIFF
--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -62,7 +62,7 @@ func (p *pendingBuffer) release() {
 	pendingBuffers.Put(p)
 }
 
-func (p *pendingBuffer) addReq(req insertDataRequest) bool {
+func (p *pendingBuffer) addReq(req *insertDataRequest) bool {
 	p.needsResponse = append(p.needsResponse, insertDataTask{finished: req.finished, errChan: req.errChan})
 	p.batch.SampleInfos = append(p.batch.SampleInfos, req.data...)
 	return len(p.batch.SampleInfos) > flushSize

--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -26,16 +26,28 @@ const (
 
 type pendingBuffer struct {
 	needsResponse []insertDataTask
-	batch         model.SampleInfoIterator
+	batch         model.SamplesBatch
 }
 
 var pendingBuffers = sync.Pool{
 	New: func() interface{} {
 		pb := new(pendingBuffer)
 		pb.needsResponse = make([]insertDataTask, 0)
-		pb.batch = model.NewSampleInfoIterator()
+		pb.batch = model.NewSamplesBatch()
 		return pb
 	},
+}
+
+func NewPendingBuffer() *pendingBuffer {
+	return pendingBuffers.Get().(*pendingBuffer)
+}
+
+func (p *pendingBuffer) IsFull() bool {
+	return p.batch.CountSeries() > flushSize
+}
+
+func (p *pendingBuffer) IsEmpty() bool {
+	return p.batch.CountSeries() == 0
 }
 
 // Report completion of an insert batch to all goroutines that may be waiting
@@ -52,23 +64,16 @@ func (p *pendingBuffer) release() {
 		p.needsResponse[i] = insertDataTask{}
 	}
 	p.needsResponse = p.needsResponse[:0]
-
-	for i := 0; i < len(p.batch.SampleInfos); i++ {
-		// nil all pointers to prevent memory leaks
-		p.batch.SampleInfos[i] = nil
-	}
-	p.batch = model.SampleInfoIterator{SampleInfos: p.batch.SampleInfos[:0]}
-	p.batch.ResetPosition()
+	p.batch.Reset()
 	pendingBuffers.Put(p)
 }
 
-func (p *pendingBuffer) addReq(req *insertDataRequest) bool {
+func (p *pendingBuffer) addReq(req *insertDataRequest) {
 	p.needsResponse = append(p.needsResponse, insertDataTask{finished: req.finished, errChan: req.errChan})
-	p.batch.SampleInfos = append(p.batch.SampleInfos, req.data...)
-	return len(p.batch.SampleInfos) > flushSize
+	p.batch.AppendSlice(req.data)
 }
 
 func (p *pendingBuffer) absorb(other *pendingBuffer) {
 	p.needsResponse = append(p.needsResponse, other.needsResponse...)
-	p.batch.SampleInfos = append(p.batch.SampleInfos, other.batch.SampleInfos...)
+	p.batch.Absorb(other.batch)
 }

--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -55,7 +55,7 @@ func (p *pendingBuffer) release() {
 
 	for i := 0; i < len(p.batch.SampleInfos); i++ {
 		// nil all pointers to prevent memory leaks
-		p.batch.SampleInfos[i] = model.SamplesInfo{}
+		p.batch.SampleInfos[i] = nil
 	}
 	p.batch = model.SampleInfoIterator{SampleInfos: p.batch.SampleInfos[:0]}
 	p.batch.ResetPosition()

--- a/pkg/pgmodel/ingestor/handler.go
+++ b/pkg/pgmodel/ingestor/handler.go
@@ -15,7 +15,7 @@ import (
 
 type insertHandler struct {
 	conn            pgxconn.PgxConn
-	input           chan insertDataRequest
+	input           chan *insertDataRequest
 	pending         *pendingBuffer
 	metricTableName string
 	toCopiers       chan copyRequest
@@ -46,7 +46,7 @@ func (h *insertHandler) nonblockingHandleReq() bool {
 	}
 }
 
-func (h *insertHandler) handleReq(req insertDataRequest) bool {
+func (h *insertHandler) handleReq(req *insertDataRequest) bool {
 	needsFlush := h.pending.addReq(req)
 	if needsFlush {
 		h.flushPending()

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -75,8 +75,8 @@ func (i *DBIngestor) CompleteMetricCreation() error {
 // returns: map[metric name][]SamplesInfo, total rows to insert
 // NOTE: req will be added to our WriteRequest pool in this function, it must
 //       not be used afterwards.
-func (ingestor *DBIngestor) parseData(tts []prompb.TimeSeries, req *prompb.WriteRequest) (map[string][]model.SamplesInfo, int, error) {
-	dataSamples := make(map[string][]model.SamplesInfo)
+func (ingestor *DBIngestor) parseData(tts []prompb.TimeSeries, req *prompb.WriteRequest) (map[string][]model.Samples, int, error) {
+	dataSamples := make(map[string][]model.Samples)
 	rows := 0
 
 	for i := range tts {
@@ -94,10 +94,7 @@ func (ingestor *DBIngestor) parseData(tts []prompb.TimeSeries, req *prompb.Write
 		if metricName == "" {
 			return nil, rows, errors.ErrNoMetricName
 		}
-		sample := model.SamplesInfo{
-			Series:  seriesLabels,
-			Samples: t.Samples,
-		}
+		sample := model.NewPromSample(seriesLabels, t.Samples)
 		rows += len(t.Samples)
 
 		dataSamples[metricName] = append(dataSamples[metricName], sample)

--- a/pkg/pgmodel/ingestor/insert.go
+++ b/pkg/pgmodel/ingestor/insert.go
@@ -322,7 +322,7 @@ func doInsert(conn pgxconn.PgxConn, reqs ...copyRequest) (err error) {
 		req := &reqs[r]
 		numRows := 0
 		for i := range req.data.batch.SampleInfos {
-			numRows += len(req.data.batch.SampleInfos[i].Samples)
+			numRows += req.data.batch.SampleInfos[i].CountSamples()
 		}
 		// flatten the various series into arrays.
 		// there are four main bottlenecks for insertion:

--- a/pkg/pgmodel/ingestor/insert.go
+++ b/pkg/pgmodel/ingestor/insert.go
@@ -60,9 +60,9 @@ func initializeInserterRoutine(conn pgxconn.PgxConn, metricName string, complete
 	return tableName, err
 }
 
-func runInserterRoutine(conn pgxconn.PgxConn, input chan insertDataRequest, metricName string, completeMetricCreationSignal chan struct{}, metricTableNames cache.MetricCache, toCopiers chan copyRequest) {
+func runInserterRoutine(conn pgxconn.PgxConn, input chan *insertDataRequest, metricName string, completeMetricCreationSignal chan struct{}, metricTableNames cache.MetricCache, toCopiers chan copyRequest) {
 	var tableName string
-	var firstReq insertDataRequest
+	var firstReq *insertDataRequest
 	firstReqSet := false
 	for firstReq = range input {
 		var err error

--- a/pkg/pgmodel/model/interface.go
+++ b/pkg/pgmodel/model/interface.go
@@ -27,7 +27,7 @@ var (
 
 // inserter is responsible for inserting label, series and data into the storage.
 type Inserter interface {
-	InsertNewData(rows map[string][]SamplesInfo) (uint64, error)
+	InsertNewData(rows map[string][]Samples) (uint64, error)
 	CompleteMetricCreation() error
 	Close()
 }

--- a/pkg/pgmodel/model/samples.go
+++ b/pkg/pgmodel/model/samples.go
@@ -12,15 +12,37 @@ import (
 	"github.com/timescale/promscale/pkg/prompb"
 )
 
-type SamplesInfo struct {
-	Series  *Series
-	Samples []prompb.Sample
+type Samples interface {
+	GetSeries() *Series
+	CountSamples() int
+	getSample(int) *prompb.Sample
+}
+
+type promSample struct {
+	series  *Series
+	samples []prompb.Sample
+}
+
+func NewPromSample(series *Series, samples []prompb.Sample) *promSample {
+	return &promSample{series, samples}
+}
+
+func (t *promSample) GetSeries() *Series {
+	return t.series
+}
+
+func (t *promSample) CountSamples() int {
+	return len(t.samples)
+}
+
+func (t *promSample) getSample(index int) *prompb.Sample {
+	return &t.samples[index]
 }
 
 // SampleInfoIterator is an iterator over a collection of sampleInfos that returns
 // data in the format expected for the data table row.
 type SampleInfoIterator struct {
-	SampleInfos     []SamplesInfo
+	SampleInfos     []Samples
 	SampleInfoIndex int
 	SampleIndex     int
 	MinSeen         int64
@@ -29,13 +51,13 @@ type SampleInfoIterator struct {
 
 // NewSampleInfoIterator is the constructor
 func NewSampleInfoIterator() SampleInfoIterator {
-	si := SampleInfoIterator{SampleInfos: make([]SamplesInfo, 0)}
+	si := SampleInfoIterator{SampleInfos: make([]Samples, 0)}
 	si.ResetPosition()
 	return si
 }
 
 //Append adds a sample info to the back of the iterator
-func (t *SampleInfoIterator) Append(s SamplesInfo) {
+func (t *SampleInfoIterator) Append(s Samples) {
 	t.SampleInfos = append(t.SampleInfos, s)
 }
 
@@ -51,7 +73,7 @@ func (t *SampleInfoIterator) ResetPosition() {
 // has occurred it returns false.
 func (t *SampleInfoIterator) Next() bool {
 	t.SampleIndex++
-	if t.SampleInfoIndex < len(t.SampleInfos) && t.SampleIndex >= len(t.SampleInfos[t.SampleInfoIndex].Samples) {
+	if t.SampleInfoIndex < len(t.SampleInfos) && t.SampleIndex >= t.SampleInfos[t.SampleInfoIndex].CountSamples() {
 		t.SampleInfoIndex++
 		t.SampleIndex = 0
 	}
@@ -61,11 +83,11 @@ func (t *SampleInfoIterator) Next() bool {
 // Values returns the values for the current row
 func (t *SampleInfoIterator) Values() (time.Time, float64, SeriesID, SeriesEpoch) {
 	info := t.SampleInfos[t.SampleInfoIndex]
-	sample := info.Samples[t.SampleIndex]
+	sample := info.getSample(t.SampleIndex)
 	if t.MinSeen > sample.Timestamp {
 		t.MinSeen = sample.Timestamp
 	}
-	sid, eid, err := info.Series.GetSeriesID()
+	sid, eid, err := info.GetSeries().GetSeriesID()
 	if t.err == nil {
 		t.err = err
 	}


### PR DESCRIPTION
Previously samples were stored in the SampleInfoIterator
as an slice of structs. Change this to be a slice of interfaces
and have the interface be fulfilled by a pointer instead of a struct.

This improves memory usage and introduces a cleaner api through use
of an interface. This interface will also be useful if we start
supporting samples other than prometheus.