### PR TITLE
Make db driver statement cache be configurable

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,6 +68,7 @@ You can also find information on flags with `promscale_<version> -help`.
 | db-writer-connection-concurrency | int | 4 | Maximum number of database connections for writing per go process. |
 | db-uri | string | | TimescaleDB/Vanilla PostgresSQL URI. Example:`postgres://postgres:password@localhost:5432/timescale?sslmode=require` |
 | async-acks | boolean | false | Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss. |
+| simple-protocol | boolean | false | Setting 'simple-protocol' to true disables the implicit prepared statement usage by the db driver. Do this when using PGBouncer. |
 
 ## PromQL engine evaluation flags
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,7 @@ You can also find information on flags with `promscale_<version> -help`.
 | db-writer-connection-concurrency | int | 4 | Maximum number of database connections for writing per go process. |
 | db-uri | string | | TimescaleDB/Vanilla PostgresSQL URI. Example:`postgres://postgres:password@localhost:5432/timescale?sslmode=require` |
 | async-acks | boolean | false | Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss. |
-| simple-protocol | boolean | false | Setting 'simple-protocol' to true disables the implicit prepared statement usage by the db driver. Do this when using PGBouncer. |
+| db-statements-cache | boolean | true | Whether database connection pool should use cached prepared statements. Disable if using PgBouncer. |
 
 ## PromQL engine evaluation flags
 

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -77,14 +77,16 @@ func getPgConfig(cfg *Config) (*pgxpool.Config, int, error) {
 		return nil, numCopiers, err
 	}
 
-	var pgConfig *pgxpool.Config
-	var connectionArgsFmt string
+	var (
+		pgConfig          *pgxpool.Config
+		connectionArgsFmt string
+	)
 	if cfg.DbUri == defaultDBUri {
-		connectionArgsFmt = "%s pool_max_conns=%d pool_min_conns=%d"
+		connectionArgsFmt = "%s pool_max_conns=%d pool_min_conns=%d statement_cache_capacity=%d"
 	} else {
-		connectionArgsFmt = "%s&pool_max_conns=%d&pool_min_conns=%d"
+		connectionArgsFmt = "%s&pool_max_conns=%d&pool_min_conns=%d&statement_cache_capacity=%d"
 	}
-	connectionStringWithArgs := fmt.Sprintf(connectionArgsFmt, connectionStr, maxConnections, minConnections)
+	connectionStringWithArgs := fmt.Sprintf(connectionArgsFmt, connectionStr, maxConnections, minConnections, cfg.MetricsCacheSize)
 	pgConfig, err = pgxpool.ParseConfig(connectionStringWithArgs)
 	if err != nil {
 		log.Error("msg", "configuring connection", "err", util.MaskPassword(err.Error()))

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -93,21 +93,26 @@ func getPgConfig(cfg *Config) (*pgxpool.Config, int, error) {
 		log.Error("msg", "configuring connection", "err", util.MaskPassword(err.Error()))
 		return nil, numCopiers, err
 	}
+
+	var statementCacheLog string
 	if cfg.EnableStatementsCache {
 		pgConfig.AfterRelease = observeStatementCacheState
 		statementCacheEnabled.Set(1)
 		statementCacheCap.Set(float64(statementCacheCapacity))
+		statementCacheLog = fmt.Sprintf("%d statements", statementCacheCapacity)
 	} else {
 		log.Info("msg", "Statements cached disabled, using simple protocol for database connections.")
 		pgConfig.ConnConfig.PreferSimpleProtocol = true
 		statementCacheEnabled.Set(0)
 		statementCacheCap.Set(0)
+		statementCacheLog = "disabled"
+
 	}
 	log.Info("msg", util.MaskPassword(connectionStr),
 		"numCopiers", numCopiers,
 		"pool_max_conns", maxConnections,
 		"pool_min_conns", minConnections,
-		"statement_cache", cfg.EnableStatementsCache,
+		"statement_cache", statementCacheLog,
 	)
 	return pgConfig, numCopiers, nil
 }

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -75,7 +75,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.IntVar(&cfg.WriteConnectionsPerProc, "db-writer-connection-concurrency", 4, "Maximum number of database connections for writing per go process.")
 	fs.IntVar(&cfg.MaxConnections, "db-connections-max", -1, "Maximum number of connections to the database that should be opened at once. It defaults to 80% of the maximum connections that the database can handle.")
 	fs.StringVar(&cfg.DbUri, "db-uri", defaultDBUri, "TimescaleDB/Vanilla Postgres DB URI. Example DB URI `postgres://postgres:password@localhost:5432/timescale?sslmode=require`")
-	fs.BoolVar(&cfg.PreferSimpleProtocol, "simple-protocol", defaultUseSimpleProtocol, "simple-protocol disables implicit prepared statement usage by the db driver. Set to true if using PGBouncer")
+	fs.BoolVar(&cfg.PreferSimpleProtocol, "simple-protocol", defaultUseSimpleProtocol, "Setting 'simple-protocol' to true disables the implicit prepared statement usage by the db driver. Do this when using PGBouncer.")
 	return cfg
 }
 

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -37,17 +37,19 @@ type Config struct {
 	MaxConnections          int
 	UsesHA                  bool
 	DbUri                   string
+	PreferSimpleProtocol    bool
 }
 
 const (
-	defaultDBUri          = ""
-	defaultDBHost         = "localhost"
-	defaultDBPort         = 5432
-	defaultDBUser         = "postgres"
-	defaultDBName         = "timescale"
-	defaultDBPassword     = ""
-	defaultSSLMode        = "require"
-	defaultConnectionTime = time.Minute
+	defaultDBUri             = ""
+	defaultDBHost            = "localhost"
+	defaultDBPort            = 5432
+	defaultDBUser            = "postgres"
+	defaultDBName            = "timescale"
+	defaultDBPassword        = ""
+	defaultSSLMode           = "require"
+	defaultConnectionTime    = time.Minute
+	defaultUseSimpleProtocol = false
 )
 
 var (
@@ -73,6 +75,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.IntVar(&cfg.WriteConnectionsPerProc, "db-writer-connection-concurrency", 4, "Maximum number of database connections for writing per go process.")
 	fs.IntVar(&cfg.MaxConnections, "db-connections-max", -1, "Maximum number of connections to the database that should be opened at once. It defaults to 80% of the maximum connections that the database can handle.")
 	fs.StringVar(&cfg.DbUri, "db-uri", defaultDBUri, "TimescaleDB/Vanilla Postgres DB URI. Example DB URI `postgres://postgres:password@localhost:5432/timescale?sslmode=require`")
+	fs.BoolVar(&cfg.PreferSimpleProtocol, "simple-protocol", defaultUseSimpleProtocol, "simple-protocol disables implicit prepared statement usage by the db driver. Set to true if using PGBouncer")
 	return cfg
 }
 

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -37,7 +37,7 @@ type Config struct {
 	MaxConnections          int
 	UsesHA                  bool
 	DbUri                   string
-	PreferSimpleProtocol    bool
+	EnableStatementsCache   bool
 }
 
 const (
@@ -49,7 +49,7 @@ const (
 	defaultDBPassword        = ""
 	defaultSSLMode           = "require"
 	defaultConnectionTime    = time.Minute
-	defaultUseSimpleProtocol = false
+	defaultDbStatementsCache = true
 )
 
 var (
@@ -75,7 +75,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.IntVar(&cfg.WriteConnectionsPerProc, "db-writer-connection-concurrency", 4, "Maximum number of database connections for writing per go process.")
 	fs.IntVar(&cfg.MaxConnections, "db-connections-max", -1, "Maximum number of connections to the database that should be opened at once. It defaults to 80% of the maximum connections that the database can handle.")
 	fs.StringVar(&cfg.DbUri, "db-uri", defaultDBUri, "TimescaleDB/Vanilla Postgres DB URI. Example DB URI `postgres://postgres:password@localhost:5432/timescale?sslmode=require`")
-	fs.BoolVar(&cfg.PreferSimpleProtocol, "simple-protocol", defaultUseSimpleProtocol, "Setting 'simple-protocol' to true disables the implicit prepared statement usage by the db driver. Do this when using PGBouncer.")
+	fs.BoolVar(&cfg.EnableStatementsCache, "db-statements-cache", defaultDbStatementsCache, "Whether database connection pool should use cached prepared statements. Disable if using PgBouncer")
 	return cfg
 }
 

--- a/pkg/pgclient/metrics.go
+++ b/pkg/pgclient/metrics.go
@@ -135,7 +135,7 @@ func InitClientMetrics(client *Client) {
 func createStatementCacheLengthHistogramMetric(client *Client) prometheus.Histogram {
 	// we know the upper bound of the cache, so we want
 	// to make that the last bucket of the histogram
-	statementCacheUpperBound := client.metricCache.Cap()
+	statementCacheUpperBound := client.metricCache.Cap() * 2
 	// we want to increase the buckets by a factor of 2
 	histogramBucketFactor := 2.0
 	// we want 10 total buckets

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -51,14 +51,14 @@ func NewPgxIngestor(conn pgxconn.PgxConn) (*DBIngestor, error) {
 //     tts the []Timeseries to insert
 //     req the WriteRequest backing tts. It will be added to our WriteRequest
 //         pool when it is no longer needed.
-func (i *DBIngestor) Ingest(tts []prompb.TimeSeries, req *prompb.WriteRequest) (uint64, error) {
-	data, totalRows, err := i.parseData(tts, req)
+func (ingestor *DBIngestor) Ingest(tts []prompb.TimeSeries, req *prompb.WriteRequest) (uint64, error) {
+	data, totalRows, err := ingestor.parseData(tts, req)
 
 	if err != nil {
 		return 0, err
 	}
 
-	rowsInserted, err := i.db.InsertNewData(data)
+	rowsInserted, err := ingestor.db.InsertNewData(data)
 	if err == nil && int(rowsInserted) != totalRows {
 		return rowsInserted, fmt.Errorf("failed to insert all the data! Expected: %d, Got: %d", totalRows, rowsInserted)
 	}
@@ -66,8 +66,8 @@ func (i *DBIngestor) Ingest(tts []prompb.TimeSeries, req *prompb.WriteRequest) (
 }
 
 // Parts of metric creation not needed to insert data
-func (i *DBIngestor) CompleteMetricCreation() error {
-	return i.db.CompleteMetricCreation()
+func (ingestor *DBIngestor) CompleteMetricCreation() error {
+	return ingestor.db.CompleteMetricCreation()
 }
 
 // Parse data into a set of samplesInfo infos per-metric.
@@ -114,6 +114,6 @@ func (ingestor *DBIngestor) parseData(tts []prompb.TimeSeries, req *prompb.Write
 }
 
 // Close closes the ingestor
-func (i *DBIngestor) Close() {
-	i.db.Close()
+func (ingestor *DBIngestor) Close() {
+	ingestor.db.Close()
 }

--- a/pkg/pgmodel/ingestor/inserter.go
+++ b/pkg/pgmodel/ingestor/inserter.go
@@ -121,7 +121,9 @@ func (p *pgxInserter) runSeriesEpochSync() {
 		select {
 		case <-p.seriesEpochRefresh.C:
 			epoch, err = p.refreshSeriesEpoch(epoch)
-			log.Error("msg", "error refreshing the series cache", "err", err)
+			if err != nil {
+				log.Error("msg", "error refreshing the series cache", "err", err)
+			}
 		case <-p.doneChannel:
 			return
 		}


### PR DESCRIPTION
By default pgx uses prepared statements implicitly.
But this makes it incompatible with PGBouncer. 

The statements used are cached in each pgx connection
separately, and the size of the statement cache is
configurable. This statement cache helps with query 
performance, disabling it (by preferring the simple
protocol) reduces performance by more than 20%. But 
not having a large enough statement cache can hurt 
performance by up to 50%. 

This PR adds an option for the user to select whether they
want to disable the statement cache by setting the 
`--db-statements-cache` flag to false. The PR also makes 
the statement cache depend on the size of the configured
metrics cache, as the expected number of metrics is a good
estimator for the required statements to be cached.