### PR TITLE
Add new docker-compose file to use without build dependency

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -1,4 +1,5 @@
 version: '3.0'
+
 services:
   db:
     image: timescaledev/timescaledb-ha:pg12-latest
@@ -19,8 +20,6 @@ services:
     image: timescale/promscale:latest
     ports:
       - 9201:9201/tcp
-    build:
-      context: .
     restart: on-failure
     depends_on:
       - db

--- a/docker-compose/high-availability/docker-compose.yaml
+++ b/docker-compose/high-availability/docker-compose.yaml
@@ -28,8 +28,6 @@ services:
     image: timescale/promscale:latest
     ports:
       - 9201:9201/tcp
-    build:
-      context: .
     restart: on-failure
     depends_on:
       - db

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -38,8 +38,8 @@ This should make Promscale running along with TimescaleDB.
 
 **Example using docker-compose:**
 
-You can also run Promscale also by using docker-compose. The `docker-compose.yml` is available in the
-[build](https://github.com/timescale/promscale/blob/master/build/docker-compose.yml) directory of our repository.
+You can also run Promscale also by using docker-compose. The `docker-compose.yaml` is available in the
+[docker-compose](https://github.com/timescale/promscale/blob/master/docker-compose/docker-compose.yaml) directory of our repository.
 You can start Promscale and related services simply via `docker-compose up`.
 
 For updating Promscale in this method, you need to stop the Promscale that is currently running using


### PR DESCRIPTION
Remove `build: context: .` to drop dependency to build Promscale image on setting up Promscale. i.e. removed from Promscale service.

```
    build:
      context: .
```

Noticed Error:

```
$ docker-compose up
Building promscale
[+] Building 0.0s (1/2)                                                                                  
 => [internal] load build definition from Dockerfile                                                0.0s
 => => transferring dockerfile: 2B                                                                  0.0s
failed to solve with frontend dockerfile.v0: failed to read dockerfile: open /var/lib/docker/tmp/buildkit-mount685150454/Dockerfile: no such file or directory
ERROR: Service 'promscale' failed to build
```

**Note**: This error is observed only when `timescale/promscale:latest` image is not available locally (in docker daemon). Then it tries to build the image in which it fails to find `Dockerfile`