### PR TITLE
Add error handling to env variable parsing

### DIFF
--- a/pkg/runner/client_test.go
+++ b/pkg/runner/client_test.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/timescale/promscale/pkg/api"
+	"github.com/timescale/promscale/pkg/log"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	err := log.Init(log.Config{
+		Level: "debug",
+	})
+
+	if err != nil {
+		fmt.Println("Error initializing logger", err)
+		os.Exit(1)
+	}
+	code := m.Run()
+	os.Exit(code)
+}
+
+func TestInitElector(t *testing.T) {
+	// TODO: refactor the function to be fully testable without using a DB.
+	testCases := []struct {
+		name         string
+		cfg          *Config
+		shouldError  bool
+		electionType reflect.Type
+	}{
+		{
+			name: "Cannot create scheduled elector, no group lock ID and not rest election",
+			cfg: &Config{
+				HaGroupLockID: 0,
+			},
+		},
+		{
+			name: "Prometheus timeout not set for PG advisory lock",
+			cfg: &Config{
+				HaGroupLockID:     1,
+				PrometheusTimeout: -1,
+			},
+			shouldError: true,
+		},
+		{
+			name: "Can't get advisory lock, couldn't connect to DB",
+			cfg: &Config{
+				HaGroupLockID:     1,
+				PrometheusTimeout: 0,
+			},
+			shouldError: true,
+		},
+	}
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			metrics := api.InitMetrics(0)
+			elector, err := initElector(c.cfg, metrics)
+
+			switch {
+			case err != nil && !c.shouldError:
+				t.Errorf("Unexpected error, got %s", err.Error())
+			case err == nil && c.shouldError:
+				t.Errorf("Expected error, got nil")
+			}
+
+			if c.electionType != nil {
+				if elector == nil {
+					t.Fatalf("Expected to create elector, got nil")
+				}
+
+				v := reflect.ValueOf(elector).Elem().Field(0).Elem()
+
+				if v.Type() != c.electionType {
+					t.Errorf("Wrong type of elector created: got %v wanted %v", v.Type(), c.electionType)
+				}
+			}
+		})
+	}
+}

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -62,12 +62,16 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.TLSCertFile, "tls-cert-file", "", "TLS Certificate file for web server, leave blank to disable TLS.")
 	fs.StringVar(&cfg.TLSKeyFile, "tls-key-file", "", "TLS Key file for web server, leave blank to disable TLS.")
 
-	util.ParseEnv("PROMSCALE", fs)
+	if err := util.ParseEnv("PROMSCALE", fs); err != nil {
+		return nil, fmt.Errorf("error parsing env variables: %w", err)
+	}
 	// Deprecated: TS_PROM is the old prefix which is deprecated and in here
 	// for legacy compatibility. Will be removed in the future. PROMSCALE prefix
 	// takes precedence and will be used if the same variable with both prefixes
 	// exist.
-	util.ParseEnv("TS_PROM", fs)
+	if err := util.ParseEnv("TS_PROM", fs); err != nil {
+		return nil, fmt.Errorf("error parsing env variables: %w", err)
+	}
 
 	if err := ff.Parse(fs, args,
 		ff.WithConfigFileFlag("config"),

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -1,34 +1,11 @@
-// This file and its contents are licensed under the Apache License 2.0.
-// Please see the included NOTICE for copyright information and
-// LICENSE for a copy of the license.
-
 package runner
 
 import (
-	"flag"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
-
-	"github.com/timescale/promscale/pkg/api"
-	"github.com/timescale/promscale/pkg/log"
 )
-
-func TestMain(m *testing.M) {
-	flag.Parse()
-	err := log.Init(log.Config{
-		Level: "debug",
-	})
-
-	if err != nil {
-		fmt.Println("Error initializing logger", err)
-		os.Exit(1)
-	}
-	code := m.Run()
-	os.Exit(code)
-}
 
 func TestParseFlags(t *testing.T) {
 	defaultConfig, err := ParseFlags(&Config{}, []string{})
@@ -40,6 +17,7 @@ func TestParseFlags(t *testing.T) {
 	testCases := []struct {
 		name        string
 		args        []string
+		env         map[string]string
 		result      func(Config) Config
 		shouldError bool
 	}{
@@ -55,7 +33,7 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name:        "Invalid config file",
-			args:        []string{"-config", "runner_test.go"},
+			args:        []string{"-config", "flags_test.go"},
 			shouldError: true,
 		},
 		{
@@ -143,10 +121,31 @@ func TestParseFlags(t *testing.T) {
 			},
 			shouldError: true,
 		},
+		{
+			name: "invalid env variable type causing parse error, PROMSCALE prefix",
+			env: map[string]string{
+				"PROMSCALE_INSTALL_EXTENSIONS": "foobar",
+			},
+			shouldError: true,
+		},
+		{
+			name: "invalid env variable type causing parse error, TS_PROM prefix",
+			env: map[string]string{
+				"TS_PROM_INSTALL_EXTENSIONS": "foobar",
+			},
+			shouldError: true,
+		},
 	}
 
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
+			// Clearing environment variables so they don't interfere with the test.
+			os.Clearenv()
+			for name, value := range c.env {
+				if err := os.Setenv(name, value); err != nil {
+					t.Fatalf("unexpected error when setting env variable: name %s, value %s, error %s", name, value, err)
+				}
+			}
 			config, err := ParseFlags(&Config{}, c.args)
 
 			if c.shouldError {
@@ -168,6 +167,8 @@ func TestParseFlags(t *testing.T) {
 }
 
 func TestParseFlagsConfigPrecedence(t *testing.T) {
+	// Clearing environment variables so they don't interfere with the test.
+	os.Clearenv()
 	defaultConfig, err := ParseFlags(&Config{}, []string{})
 
 	if err != nil {
@@ -298,64 +299,6 @@ func TestParseFlagsConfigPrecedence(t *testing.T) {
 
 			if !reflect.DeepEqual(*config, expected) {
 				t.Fatalf("Unexpected config returned\nwanted:\n%+v\ngot:\n%+v\n", expected, *config)
-			}
-		})
-	}
-}
-
-func TestInitElector(t *testing.T) {
-	// TODO: refactor the function to be fully testable without using a DB.
-	testCases := []struct {
-		name         string
-		cfg          *Config
-		shouldError  bool
-		electionType reflect.Type
-	}{
-		{
-			name: "Cannot create scheduled elector, no group lock ID and not rest election",
-			cfg: &Config{
-				HaGroupLockID: 0,
-			},
-		},
-		{
-			name: "Prometheus timeout not set for PG advisory lock",
-			cfg: &Config{
-				HaGroupLockID:     1,
-				PrometheusTimeout: -1,
-			},
-			shouldError: true,
-		},
-		{
-			name: "Can't get advisory lock, couldn't connect to DB",
-			cfg: &Config{
-				HaGroupLockID:     1,
-				PrometheusTimeout: 0,
-			},
-			shouldError: true,
-		},
-	}
-	for _, c := range testCases {
-		t.Run(c.name, func(t *testing.T) {
-			metrics := api.InitMetrics(0)
-			elector, err := initElector(c.cfg, metrics)
-
-			switch {
-			case err != nil && !c.shouldError:
-				t.Errorf("Unexpected error, got %s", err.Error())
-			case err == nil && c.shouldError:
-				t.Errorf("Expected error, got nil")
-			}
-
-			if c.electionType != nil {
-				if elector == nil {
-					t.Fatalf("Expected to create elector, got nil")
-				}
-
-				v := reflect.ValueOf(elector).Elem().Field(0).Elem()
-
-				if v.Type() != c.electionType {
-					t.Errorf("Wrong type of elector created: got %v wanted %v", v.Type(), c.electionType)
-				}
 			}
 		})
 	}


### PR DESCRIPTION
In the case where you set an environment variable with the wrong type
(for example, set a string where an int flag is defined), parsing errors
were ignored. This commit adds proper error handling for that case.