### PR TITLE
Fix Promscale deployment upgrade from Rollingupgrade to Recreate strategy

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -98,6 +98,7 @@ helm install --name my-release -f myvalues.yaml .
 |-----------------------------------|---------------------------------------------|------------------------------------|
 | `image`                           | The image (with tag) to pull                | `timescale/promscale`   |
 | `replicaCount`                    | Number of pods for the connector            | `1`                                |
+| `upgradeStrategy`                 | Promscale deployment upgrade strategy, By default set to `Recreate` as during Promscale upgrade we expect no Promscale to be connected to TimescaleDB       | `Recreate`                                |
 | `connection.user`                 | Username to connect to TimescaleDB with     | `postgres`                         |
 | `connection.password.timescaleDBSuperUserKey`| The DB password key in secret object which will hold the db password for `postgres`  user | `PATRONI_SUPERUSER_PASSWORD` |
 | `connection.password.secretTemplate`| The template for generating the name of a secret object which will hold the db password | `{{ .Release.Name }}-credentials` |

--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -9,6 +9,8 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.upgradeStrategy }}
   selector:
     matchLabels:
       app: {{ template "connector.fullname" . }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -2,6 +2,13 @@ image: timescale/promscale
 # number of connector pods to spawn
 replicaCount: 1
 
+# Promscale deployment upgrade strategy
+# as Promscale upgrade requires no existing Promscale
+# connected with TimescaleDB. Recreate strategy helps
+# scale down to 0 and recreate the new version.
+upgradeStrategy: Recreate
+
+
 # Arguments that will be passed onto deployment pods
 # The list of available cli flags is available at
 # https://github.com/timescale/promscale/blob/master/docs/cli.md


### PR DESCRIPTION
Update Promscale deployment upgrade strategy to Recreate as we expect no Promscale pod to be connected to TimescaleDB during the upgrade.