### PR TITLE
Update Promscale helmchart

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -111,6 +111,7 @@ helm install --name my-release -f myvalues.yaml .
 | `service.port`                    | Port the connector pods will accept connections on | `9201`                      |
 | `service.loadBalancer.enabled`    | If enabled will create an LB for the connector, ClusterIP otherwise | `true`     |
 | `service.loadBalancer.annotations`| Annotations to set to the LB service        | `service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "4000"` |
+| `maintenance.enabled`             | Option to enable maintenance cronjob, Enable maintenance cronjob only if you are using TimescaleDB < `2.0`   | `false` |
 | `maintenance.schedule`            | The schedule with which the Job, that deletes data outside the retention period, runs | `0,30 * * * *` |
 | `maintenance.startingDeadlineSeconds` | If set, CronJob controller counts how many missed jobs occurred from the set value until now | `200` |
 | `maintenance.successfulJobsHistoryLimit` | The number of successful maintenance pods to retain in-cluster | `3`      |
@@ -118,8 +119,10 @@ helm install --name my-release -f myvalues.yaml .
 | `maintenance.resources` | Requests and limits for maintenance cronjob | `{}`              |
 | `maintenance.nodeSelector`                    | Node labels to use for scheduling maintenance cronjob          | `{}`                               |
 | `maintenance.tolerations`                     | Tolerations to use for scheduling maintenance cronjob          | `[]`                               |
+| `maintenance.affinity`                        | PodAffinity and PodAntiAffinity for scheduling maintenance cronjob          | `{}`                               |
 | `resources`                       | Requests and limits for each of the pods    | `{}`                               |
 | `nodeSelector`                    | Node labels to use for scheduling           | `{}`                               |
 | `tolerations`                     | Tolerations to use for scheduling           | `[]`                               |
+| `affinity`                        | PodAffinity and PodAntiAffinity for scheduling           | `{}`                               |
 
 [docker-image]: https://hub.docker.com/timescale/promscale

--- a/helm-chart/templates/config-maintenance.yaml
+++ b/helm-chart/templates/config-maintenance.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.maintenance.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -20,3 +21,4 @@ data:
       echo "Maintenance job failed!"
       exit 1
     fi
+{{- end -}}

--- a/helm-chart/templates/cronjob-maintenance.yaml
+++ b/helm-chart/templates/cronjob-maintenance.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.maintenance.enabled -}}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -64,3 +65,7 @@ spec:
           {{- with .Values.maintenance.tolerations }}
           tolerations: {{ toYaml . | nindent 10 }}
           {{- end }}
+          {{- with .Values.maintenance.affinity }}
+          affinity: {{ toYaml . | nindent 12 }}
+          {{- end }}
+{{- end -}}

--- a/helm-chart/templates/deployment-connector.yaml
+++ b/helm-chart/templates/deployment-connector.yaml
@@ -70,3 +70,6 @@ spec:
       {{- with .Values.tolerations }}
       tolerations: {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -89,6 +89,10 @@ service:
 # settings for the maintenance CronJob that deletes data outside of
 # the retention period
 maintenance:
+  # if you are using >= TimescaleDB 2.0 you
+  # do not need maintenance job, so by default
+  # maintenance job is disabled
+  enabled: false
   schedule: "0,30 * * * *"
   # If startingDeadlineSeconds field is set (not null), the CronJob controller counts how
   # many missed jobs occurred from the value of startingDeadlineSeconds until now.
@@ -105,6 +109,7 @@ maintenance:
   resources: {}
   nodeSelector: {}
   tolerations: []
+  affinity: {}
 
 # set your own limits
 resources: {}
@@ -114,3 +119,6 @@ nodeSelector: {}
 
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
+
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}


### PR DESCRIPTION
Disable maintenance cronjob by default as we expect all users to use >= TimescaleDB `2.0` and Also added an option to configure podAffinity & podAntiAffinity rules for Promscale deployment & Maintenance cronjob.