### PR TITLE
Add text format support for ingest pipeline

### DIFF
--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -7,6 +7,8 @@ package pgclient
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
 
 	pgx "github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -165,8 +167,13 @@ func (c *Client) Close() {
 }
 
 // Ingest writes the timeseries object into the DB
-func (c *Client) Ingest(tts []prompb.TimeSeries, req *prompb.WriteRequest) (uint64, error) {
-	return c.ingestor.Ingest(tts, req)
+func (c *Client) IngestProto(tts []prompb.TimeSeries, req *prompb.WriteRequest) (uint64, error) {
+	return c.ingestor.IngestProto(tts, req)
+}
+
+// Ingest writes Prometheus text format data into the DB.
+func (c *Client) IngestText(r io.Reader, contentType string, scrapeTime time.Time) (uint64, error) {
+	return c.ingestor.IngestText(r, contentType, scrapeTime)
 }
 
 // Read returns the promQL query results

--- a/pkg/pgmodel/cache/series_cache.go
+++ b/pkg/pgmodel/cache/series_cache.go
@@ -29,6 +29,7 @@ const GrowFactor = float64(2.0)       // multiply cache size by this factor when
 type SeriesCache interface {
 	Reset()
 	GetSeriesFromProtos(labelPairs []prompb.Label) (series *model.Series, metricName string, err error)
+	GetSeriesFromLabels(ll labels.Labels) (series *model.Series, metricName string, err error)
 	Len() int
 	Cap() int
 	Evictions() uint64
@@ -204,14 +205,13 @@ func generateKey(labels []prompb.Label) (key string, metricName string, error er
 }
 
 // GetSeriesFromLabels converts a labels.Labels to a canonical Labels object
-func (t *SeriesCacheImpl) GetSeriesFromLabels(ls labels.Labels) (*model.Series, error) {
+func (t *SeriesCacheImpl) GetSeriesFromLabels(ls labels.Labels) (*model.Series, string, error) {
 	ll := make([]prompb.Label, len(ls))
 	for i := range ls {
 		ll[i].Name = ls[i].Name
 		ll[i].Value = ls[i].Value
 	}
-	l, _, err := t.GetSeriesFromProtos(ll)
-	return l, err
+	return t.GetSeriesFromProtos(ll)
 }
 
 // GetSeriesFromProtos converts a prompb.Label to a canonical Labels object

--- a/pkg/pgmodel/cache/series_cache_test.go
+++ b/pkg/pgmodel/cache/series_cache_test.go
@@ -25,7 +25,7 @@ func TestBigLables(t *testing.T) {
 		},
 	}
 
-	_, err := cache.GetSeriesFromLabels(l)
+	_, _, err := cache.GetSeriesFromLabels(l)
 	if err == nil {
 		t.Errorf("expected error")
 	}

--- a/pkg/pgmodel/ingestor/handler_test.go
+++ b/pkg/pgmodel/ingestor/handler_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func getSeries(t *testing.T, scache *cache.SeriesCacheImpl, labels labels.Labels) *model.Series {
-	series, err := scache.GetSeriesFromLabels(labels)
+	series, _, err := scache.GetSeriesFromLabels(labels)
 	require.NoError(t, err)
 	return series
 }

--- a/pkg/pgmodel/ingestor/ingestor_interface.go
+++ b/pkg/pgmodel/ingestor/ingestor_interface.go
@@ -4,12 +4,22 @@
 
 package ingestor
 
-import "github.com/timescale/promscale/pkg/prompb"
+import (
+	"io"
+	"time"
+
+	"github.com/timescale/promscale/pkg/prompb"
+)
 
 // DBInserter is responsible for ingesting the TimeSeries protobuf structs and
 // storing them in the database.
 type DBInserter interface {
 	// Ingest takes an array of TimeSeries and attepts to store it into the database.
 	// Returns the number of metrics ingested and any error encountered before finishing.
-	Ingest([]prompb.TimeSeries, *prompb.WriteRequest) (uint64, error)
+	IngestProto([]prompb.TimeSeries, *prompb.WriteRequest) (uint64, error)
+	// Ingest takes a Prometheus exporter text format and attepts to parse and store it into the database.
+	// It also gets the content type used to distinguish which specific text format is used (Prometheus or OpenMetrics)
+	// and also the default scrape time for the entries without specified timestamp.
+	// Returns the number of metrics ingested and any error encountered before finishing.
+	IngestText(r io.Reader, contentType string, scrapeTime time.Time) (uint64, error)
 }

--- a/pkg/pgmodel/ingestor/ingestor_sql_test.go
+++ b/pkg/pgmodel/ingestor/ingestor_sql_test.go
@@ -227,7 +227,7 @@ func TestPGXInserterInsertSeries(t *testing.T) {
 
 			lsi := make([]model.Samples, 0)
 			for _, ser := range c.series {
-				ls, err := scache.GetSeriesFromLabels(ser)
+				ls, _, err := scache.GetSeriesFromLabels(ser)
 				if err != nil {
 					t.Errorf("invalid labels %+v, %v", ls, err)
 				}
@@ -380,7 +380,7 @@ func TestPGXInserterCacheReset(t *testing.T) {
 	makeSamples := func(series []labels.Labels) []model.Samples {
 		lsi := make([]model.Samples, 0)
 		for _, ser := range series {
-			ls, err := scache.GetSeriesFromLabels(ser)
+			ls, _, err := scache.GetSeriesFromLabels(ser)
 			if err != nil {
 				t.Errorf("invalid labels %+v, %v", ls, err)
 			}

--- a/pkg/pgmodel/ingestor/ingestor_test.go
+++ b/pkg/pgmodel/ingestor/ingestor_test.go
@@ -5,16 +5,22 @@
 package ingestor
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"reflect"
 	"testing"
+	"time"
 
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/pgmodel/common/errors"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/prompb"
 )
 
-func TestDBIngestorIngest(t *testing.T) {
+func TestDBIngestorIngestProto(t *testing.T) {
 	testCases := []struct {
 		name            string
 		metrics         []prompb.TimeSeries
@@ -184,7 +190,7 @@ func TestDBIngestorIngest(t *testing.T) {
 				scache: scache,
 			}
 
-			count, err := i.Ingest(c.metrics, NewWriteRequest())
+			count, err := i.IngestProto(c.metrics, NewWriteRequest())
 
 			if err != nil {
 				if c.insertSeriesErr != nil && err != c.insertSeriesErr {
@@ -223,4 +229,382 @@ func TestDBIngestorIngest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDBIngestorIngestText(t *testing.T) {
+	testCases := []struct {
+		name            string
+		input           string
+		contentType     string
+		scrapeTime      time.Time
+		count           uint64
+		countSeries     int
+		returnErr       string
+		insertSeriesErr error
+		insertDataErr   error
+		getSeriesErr    error
+		setSeriesErr    error
+	}{
+		{
+			name:  "Zero metrics",
+			input: "",
+		},
+		{
+			name:        "One metric no timestamp",
+			input:       "test 0.1 ",
+			count:       1,
+			countSeries: 1,
+		},
+		{
+			name:        "One metric with timestamp",
+			input:       "test 0.1 1",
+			count:       1,
+			countSeries: 1,
+		},
+		{
+			name:      "One metric, no sample",
+			input:     `test{test="test"}`,
+			returnErr: `error parsing text entries: expected value after metric, got "MNAME"`,
+		},
+		{
+			name: "Two metrics",
+			input: `test 0.1
+foo{test="test"} 0.1`,
+			count:       2,
+			countSeries: 2,
+		},
+		{
+			name: "Two samples",
+			input: `test 0.1 1
+test 0.1 2`,
+			count:       2,
+			countSeries: 1,
+		},
+		{
+			name:            "Insert series error",
+			input:           "test 0.1 ",
+			count:           0,
+			countSeries:     1,
+			insertSeriesErr: fmt.Errorf("some error"),
+		},
+		{
+			name:          "Insert data error",
+			input:         "test 0.1 ",
+			count:         0,
+			countSeries:   1,
+			insertDataErr: fmt.Errorf("some error"),
+		},
+		{
+			name:      "Invalid metric name",
+			input:     `1`,
+			returnErr: `error parsing text entries: "INVALID" is not a valid start token`,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			scache := cache.NewSeriesCache(cache.DefaultConfig, nil)
+			inserter := model.MockInserter{
+				InsertSeriesErr: c.insertSeriesErr,
+				InsertDataErr:   c.insertDataErr,
+				InsertedSeries:  make(map[string]model.SeriesID),
+			}
+
+			i := DBIngestor{
+				db:     &inserter,
+				scache: scache,
+			}
+
+			count, err := i.IngestText(bytes.NewBuffer([]byte(c.input)), c.contentType, c.scrapeTime)
+
+			if err != nil {
+				switch {
+				case c.returnErr != "":
+					if err.Error() != c.returnErr {
+						t.Errorf("wrong error returned: got\n%s\nwant\n%s\n", err, c.returnErr)
+					}
+				case c.insertSeriesErr != nil:
+					if err != c.insertSeriesErr {
+						t.Errorf("wrong error returned: got\n%s\nwant\n%s\n", err, c.insertSeriesErr)
+					}
+				case c.insertDataErr != nil:
+					if err != c.insertDataErr {
+						t.Errorf("wrong error returned: got\n%s\nwant\n%s\n", err, c.insertDataErr)
+					}
+				case c.getSeriesErr != nil:
+					if err != c.getSeriesErr {
+						t.Errorf("wrong error returned: got\n%s\nwant\n%s\n", err, c.getSeriesErr)
+					}
+				case c.setSeriesErr != nil:
+					if err != c.setSeriesErr {
+						t.Errorf("wrong error returned: got\n%s\nwant\n%s\n", err, c.setSeriesErr)
+					}
+				default:
+					t.Fatalf("unexpected error returned: %s", err)
+				}
+
+				return
+
+			}
+
+			if count != c.count {
+				t.Errorf("invalid number of metrics inserted: got %d, want %d\n", count, c.count)
+			}
+
+			if c.countSeries != len(inserter.InsertedSeries) {
+				t.Errorf("invalid number of series inserted, all series that are not cached must be sent for insertion: got %d, want %d\n%+v\n",
+					len(inserter.InsertedSeries),
+					c.countSeries,
+					inserter.InsertedSeries,
+				)
+			}
+		})
+	}
+}
+
+var scache mockCache
+
+func getModelSamples(l labels.Labels, s []prompb.Sample) []model.Samples {
+	sl, _, _ := scache.GetSeriesFromLabels(l)
+
+	return []model.Samples{
+		model.NewPromSample(sl, s),
+	}
+}
+
+func TestDBIngestorParseTextData(t *testing.T) {
+	defaultScrapeTime := time.Now()
+
+	testCases := []struct {
+		name          string
+		input         string
+		reader        io.Reader
+		contentType   string
+		scrapeTime    time.Time
+		returnErr     string
+		cacheErr      error
+		returnSamples map[string][]model.Samples
+		count         int
+	}{
+		{
+			name: "happy path",
+			input: `# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+#   TYPE go_gc_duration_seconds summary
+# Hrandom comment starting with prefix of HELP
+#
+# comment with escaped \n newline
+# comment with escaped \ escape character
+# HELP nohelp1
+# HELP nohelp2
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+_metric_starting_with_underscore 1`,
+			count: 1,
+			returnSamples: map[string][]model.Samples{
+				"_metric_starting_with_underscore": getModelSamples(
+					labels.Labels{
+						{
+							Name:  model.MetricNameLabelName,
+							Value: "_metric_starting_with_underscore",
+						},
+					},
+					[]prompb.Sample{
+						{
+							Timestamp: timestamp.FromTime(defaultScrapeTime),
+							Value:     1,
+						},
+					},
+				),
+			},
+		},
+		{
+			name: "reader error",
+			reader: &errReader{
+				err: fmt.Errorf("some error"),
+			},
+			returnErr: "error reading request body: some error",
+		},
+		{
+			name:      "cache error",
+			input:     "test 1",
+			cacheErr:  fmt.Errorf("cache error"),
+			returnErr: "cache error",
+		},
+		{
+			name:       "check scrape time",
+			input:      "test_metric 1",
+			count:      1,
+			scrapeTime: defaultScrapeTime.Add(time.Hour),
+			returnSamples: map[string][]model.Samples{
+				"test_metric": getModelSamples(
+					labels.Labels{
+						{
+							Name:  model.MetricNameLabelName,
+							Value: "test_metric",
+						},
+					},
+					[]prompb.Sample{
+						{
+							Timestamp: timestamp.FromTime(defaultScrapeTime.Add(time.Hour)),
+							Value:     1,
+						},
+					},
+				),
+			},
+		},
+		{
+			name:        "open metrics content type",
+			input:       "test_metric 1\n# EOF",
+			count:       1,
+			contentType: "application/openmetrics-text",
+			returnSamples: map[string][]model.Samples{
+				"test_metric": getModelSamples(
+					labels.Labels{
+						{
+							Name:  model.MetricNameLabelName,
+							Value: "test_metric",
+						},
+					},
+					[]prompb.Sample{
+						{
+							Timestamp: timestamp.FromTime(defaultScrapeTime),
+							Value:     1,
+						},
+					},
+				),
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			inserter := model.MockInserter{}
+
+			scache.err = nil
+			if c.cacheErr != nil {
+				scache.err = c.cacheErr
+			}
+
+			i := DBIngestor{
+				db:     &inserter,
+				scache: &scache,
+			}
+
+			var r io.Reader = bytes.NewBuffer([]byte(c.input))
+			if c.reader != nil {
+				r = c.reader
+			}
+
+			now := defaultScrapeTime
+
+			if !c.scrapeTime.IsZero() {
+				now = c.scrapeTime
+			}
+
+			result, count, err := i.parseTextData(r, c.contentType, now)
+
+			if err != nil {
+				if c.returnErr != err.Error() {
+					t.Errorf("wrong error returned: got\n%s\nwant\n%s\n", err, c.returnErr)
+				}
+				return
+			} else {
+				if c.returnErr != "" {
+					t.Fatalf("unexpected error returned: %s", err)
+				}
+			}
+
+			if count != c.count {
+				t.Errorf("invalid number of metrics parsed: got %d, want %d\n", count, c.count)
+			}
+
+			if len(result) != len(c.returnSamples) {
+				t.Errorf("invalid count of samples returned: got %d want %d", len(result), len(c.returnSamples))
+			}
+
+			for k, v := range c.returnSamples {
+				expected, ok := result[k]
+
+				if !ok {
+					t.Fatalf("missing return samples for metric %s", k)
+				}
+
+				if len(expected) != len(v) {
+					t.Fatalf("invalid count of return samples for metric %s: got %d wanted %d", k, len(v), len(expected))
+				}
+
+				for i, s := range expected {
+					if !reflect.DeepEqual(s, v[i]) {
+						t.Fatalf("unexpected value returned for metric %s:\ngot\n%+v\nwanted\n%+v\n", k, v[i], s)
+					}
+				}
+			}
+		})
+	}
+}
+
+type mockCache struct {
+	initialized bool
+	series      map[string]*model.Series
+	metricNames map[string]string
+	err         error
+}
+
+func (m *mockCache) Evictions() uint64 {
+	return 0
+}
+
+func (m *mockCache) Reset() {
+	m.series = make(map[string]*model.Series)
+	m.metricNames = make(map[string]string)
+}
+
+func (m *mockCache) GetSeriesFromProtos(labelPairs []prompb.Label) (*model.Series, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockCache) GetSeriesFromLabels(ll labels.Labels) (*model.Series, string, error) {
+	if !m.initialized {
+		m.Reset()
+	}
+	key := ll.String()
+	if series, ok := m.series[key]; ok {
+		return series, m.metricNames[key], m.err
+	}
+
+	series := model.NewSeries(key, []prompb.Label{})
+	m.series[key] = series
+
+	metricName := ""
+
+	for _, v := range ll {
+		if v.Name == model.MetricNameLabelName {
+			metricName = v.Value
+			break
+		}
+	}
+
+	if metricName == "" {
+		return nil, "", fmt.Errorf("no metric name")
+	}
+
+	m.metricNames[key] = metricName
+
+	return series, metricName, m.err
+}
+
+func (m *mockCache) Len() int {
+	return len(m.series)
+}
+
+func (m *mockCache) Cap() int {
+	return len(m.series)
+}
+
+type errReader struct {
+	err error
+}
+
+func (e *errReader) Read(p []byte) (n int, err error) {
+	return 0, e.err
 }

--- a/pkg/tests/end_to_end_tests/concurrent_sql_test.go
+++ b/pkg/tests/end_to_end_tests/concurrent_sql_test.go
@@ -226,7 +226,7 @@ func testConcurrentInsertSimple(t testing.TB, db *pgxpool.Pool, metric string) {
 		t.Fatal(err)
 	}
 	defer ingestor.Close()
-	_, err = ingestor.Ingest(copyMetrics(metrics), ingstr.NewWriteRequest())
+	_, err = ingestor.IngestProto(copyMetrics(metrics), ingstr.NewWriteRequest())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +286,7 @@ func testConcurrentInsertAdvanced(t testing.TB, db *pgxpool.Pool) {
 	}
 
 	defer ingestor.Close()
-	_, err = ingestor.Ingest(copyMetrics(metrics), ingstr.NewWriteRequest())
+	_, err = ingestor.IngestProto(copyMetrics(metrics), ingstr.NewWriteRequest())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/tests/end_to_end_tests/create_test.go
+++ b/pkg/tests/end_to_end_tests/create_test.go
@@ -165,7 +165,7 @@ func TestSQLChunkInterval(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -422,7 +422,7 @@ func TestSQLIngest(t *testing.T) {
 				}
 				defer ingestor.Close()
 
-				cnt, err := ingestor.Ingest(copyMetrics(tcase.metrics), ingstr.NewWriteRequest())
+				cnt, err := ingestor.IngestProto(copyMetrics(tcase.metrics), ingstr.NewWriteRequest())
 				if err != nil && err != tcase.expectErr {
 					t.Fatalf("got an unexpected error %v", err)
 				}
@@ -514,7 +514,7 @@ func TestInsertCompressedDuplicates(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -545,7 +545,7 @@ func TestInsertCompressedDuplicates(t *testing.T) {
 			},
 		}
 
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -580,7 +580,7 @@ func TestInsertCompressedDuplicates(t *testing.T) {
 		}
 
 		//ingest duplicate after compression
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -633,7 +633,7 @@ func TestInsertCompressed(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -657,7 +657,7 @@ func TestInsertCompressed(t *testing.T) {
 			}
 		}
 		//ingest after compression
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -731,7 +731,7 @@ func insertMultinodeAddNodes(t *testing.T, attachExisting bool) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -771,7 +771,7 @@ func insertMultinodeAddNodes(t *testing.T, attachExisting bool) {
 				t.Fatal(err)
 			}
 			defer ingestor.Close()
-			_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+			_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -856,7 +856,7 @@ func TestCompressionSetting(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -958,7 +958,7 @@ func TestCustomCompressionJob(t *testing.T) {
 		}
 		defer ingestor.Close()
 
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1046,7 +1046,7 @@ func TestCustomCompressionJob(t *testing.T) {
 		}
 
 		// decompress the first chunk
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1179,7 +1179,7 @@ func TestExecuteMaintenanceCompressionJob(t *testing.T) {
 		}
 		defer ingestor.Close()
 
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1242,7 +1242,7 @@ func TestExecuteMaintenanceCompressionJob(t *testing.T) {
 		}
 
 		// decompress the first chunk
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1342,7 +1342,7 @@ func TestExecuteCompressionMetricsLocked(t *testing.T) {
 		}
 		defer ingestor.Close()
 
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/tests/end_to_end_tests/delete_test.go
+++ b/pkg/tests/end_to_end_tests/delete_test.go
@@ -89,7 +89,7 @@ func TestDeleteWithMetricNameEQL(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
+		if _, err := ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
 		pgDelete := &pgDel.PgDelete{Conn: pgxconn.NewPgxConn(db)}
@@ -171,7 +171,7 @@ func TestDeleteWithCompressedChunks(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
+		if _, err := ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
 		err = ingestor.CompleteMetricCreation()
@@ -255,7 +255,7 @@ func TestDeleteWithMetricNameEQLRegex(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
+		if _, err := ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
 		pgDelete := &pgDel.PgDelete{Conn: pgxconn.NewPgxConn(db)}
@@ -379,7 +379,7 @@ func TestDeleteMixins(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
+		if _, err := ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
 		pgDelete := &pgDel.PgDelete{Conn: pgxconn.NewPgxConn(db)}

--- a/pkg/tests/end_to_end_tests/drop_test.go
+++ b/pkg/tests/end_to_end_tests/drop_test.go
@@ -52,7 +52,7 @@ func TestSQLRetentionPeriod(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -154,7 +154,7 @@ func TestSQLDropChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -238,7 +238,7 @@ func TestSQLDropDataWithoutTimescaleDB(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -349,7 +349,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -535,7 +535,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 			},
 		}
 
-		_, err = ingestor.Ingest(copyMetrics(resurrected), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(resurrected), ingstr.NewWriteRequest())
 		if err == nil {
 			t.Error("expected ingest to fail due to old epoch")
 		}
@@ -549,7 +549,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 		}
 		defer ingestor2.Close()
 
-		_, err = ingestor2.Ingest(copyMetrics(resurrected), ingstr.NewWriteRequest())
+		_, err = ingestor2.IngestProto(copyMetrics(resurrected), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -598,7 +598,7 @@ func TestSQLDropAllMetricData(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Error(err)
 		}
@@ -672,7 +672,7 @@ func TestSQLDropAllMetricData(t *testing.T) {
 		}
 
 		defer ingestor2.Close()
-		_, err = ingestor2.Ingest(copyMetrics(ts), ingstr.NewWriteRequest())
+		_, err = ingestor2.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/tests/end_to_end_tests/nan_test.go
+++ b/pkg/tests/end_to_end_tests/nan_test.go
@@ -76,7 +76,7 @@ func TestSQLStaleNaN(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(metrics), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(metrics), ingstr.NewWriteRequest())
 
 		if err != nil {
 			t.Fatalf("unexpected error while ingesting test dataset: %s", err)

--- a/pkg/tests/end_to_end_tests/query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/query_integration_test.go
@@ -648,7 +648,7 @@ func ingestQueryTestDataset(db *pgxpool.Pool, t testing.TB, metrics []prompb.Tim
 		t.Fatal(err)
 	}
 	defer ingestor.Close()
-	cnt, err := ingestor.Ingest(copyMetrics(metrics), ingstr.NewWriteRequest())
+	cnt, err := ingestor.IngestProto(copyMetrics(metrics), ingstr.NewWriteRequest())
 
 	if err != nil {
 		t.Fatalf("unexpected error while ingesting test dataset: %s", err)

--- a/pkg/tests/end_to_end_tests/view_test.go
+++ b/pkg/tests/end_to_end_tests/view_test.go
@@ -162,7 +162,7 @@ func TestSQLView(t *testing.T) {
 		}
 
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(metrics), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(metrics), ingstr.NewWriteRequest())
 
 		if err != nil {
 			t.Fatal(err)
@@ -260,7 +260,7 @@ func TestSQLViewSelectors(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, err = ingestor.Ingest(copyMetrics(metrics), ingstr.NewWriteRequest())
+		_, err = ingestor.IngestProto(copyMetrics(metrics), ingstr.NewWriteRequest())
 
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/tests/end_to_end_tests/zlast_test.go
+++ b/pkg/tests/end_to_end_tests/zlast_test.go
@@ -32,12 +32,12 @@ func TestDeleteMetricSQLAPI(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
+		if _, err := ingestor.IngestProto(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
 		startSnapShot := upgrade_tests.GetDbInfoIgnoringTable(t, container, *testDatabase, testDir, db, "", "label", extensionState)
 		tts := generateSmallTimeseries()
-		if _, err := ingestor.Ingest(copyMetrics(tts), ingstr.NewWriteRequest()); err != nil {
+		if _, err := ingestor.IngestProto(copyMetrics(tts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
 		snapShotAfterNewMetrics := upgrade_tests.GetDbInfoIgnoringTable(t, container, *testDatabase, testDir, db, "", "label", extensionState)

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -470,7 +470,7 @@ func doWrite(t *testing.T, client *http.Client, url string, data ...[]prompb.Tim
 
 func doIngest(t *testing.T, ingestor *ingestor.DBIngestor, data ...[]prompb.TimeSeries) {
 	for _, data := range data {
-		_, err := ingestor.Ingest(copyMetrics(data), &prompb.WriteRequest{})
+		_, err := ingestor.IngestProto(copyMetrics(data), &prompb.WriteRequest{})
 		if err != nil {
 			t.Fatalf("ingest error: %v", err)
 		}

--- a/scripts/end_to_end_tests.sh
+++ b/scripts/end_to_end_tests.sh
@@ -112,6 +112,13 @@ curl -v \
     --data-binary "@${ROOT_DIR}/pkg/tests/testdata/import.json" \
     "${CONNECTOR_URL}/write"
 
+echo "sending text format write request"
+
+curl -v \
+    -H "Content-Type: text/plain" \
+    --data "custom_metric{custom_label=\"custom_value\"} 5" \
+    "${CONNECTOR_URL}/write"
+
 compare_connector_and_prom() {
     QUERY=${1}
     CONNECTOR_OUTPUT=$(curl -s "http://${CONNECTOR_URL}/api/v1/${QUERY}")
@@ -141,8 +148,9 @@ compare_connector_and_prom "query?query=up&time=$START_TIME"
 compare_connector_and_prom "series?match%5B%5D=ts_prom_sent_samples_total"
 
 # Labels endpoint cannot be compared to Prometheus becuase it will always differ due to direct backfilling of the real dataset.
-# We have to compare it to the correct expected output. Note that `namespace` and `node` labels are from JSON import payload.
-EXPECTED_OUTPUT='{"status":"success","data":["__name__","code","handler","instance","job","le","method","mode","namespace","node","path","quantile","status","version"]}'
+# We have to compare it to the correct expected output. Note that `namespace` and `node` labels are from JSON import payload,
+# while `custom_label` label is from text format write request.
+EXPECTED_OUTPUT='{"status":"success","data":["__name__","code","custom_label","handler","instance","job","le","method","mode","namespace","node","path","quantile","status","version"]}'
 LABELS_OUTPUT=$(curl -s "http://${CONNECTOR_URL}/api/v1/labels")
 echo "  labels response: ${LABELS_OUTPUT}"
 echo "expected response: ${EXPECTED_OUTPUT}"


### PR DESCRIPTION
Common usecase necessary for users is to push metrics directly to
Promscale using Prometheus text format or OpenMetrics text format. This
commit uses Prometheus `textparse` library to add support for these formats
to be able to ingest them directly into Promscale.