### PR TITLE
Fix failing PromQL tests, fail on error logs and support for negative-offset in enable-features.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -74,6 +74,6 @@ You can also find information on flags with `promscale_<version> -help`.
 
 | Flag | Type | Default | Description |
 |------|:-----:|:-------:|:-----------|
-| promql-enable-feature | string | "" | [EXPERIMENTAL] Enable optional PromQL features, separated by commas. These are disabled by default in Promscale's PromQL engine. Currently, this includes 'promql-at-modifier' only. For more information, see https://github.com/prometheus/prometheus/blob/master/docs/disabled_features.md |
+| promql-enable-feature | string | "" | [EXPERIMENTAL] Enable optional PromQL features, separated by commas. These are disabled by default in Promscale's PromQL engine. Currently, this includes 'promql-at-modifier' and 'promql-negative-offset'. For more information, see https://github.com/prometheus/prometheus/blob/master/docs/disabled_features.md |
 | promql-query-timeout | duration | 2 minutes | Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in '/api/v1/query.*' endpoints. |
 | promql-default-subquery-step-interval | duration | 1 minute | Default step interval to be used for PromQL subquery evaluation. This value is used if the subquery does not specify the step value explicitly. Example: <metric_name>[30m:]. Note: in Prometheus this setting is set by the evaluation_interval option. |

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -110,7 +110,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 
 	// PromQL configuration flags.
 	fs.StringVar(&cfg.EnableFeatures, "promql-enable-feature", "", "[EXPERIMENTAL] Enable optional PromQL features, separated by commas. These are disabled by default in Promscale's PromQL engine. "+
-		"Currently, this includes 'promql-at-modifier' only. For more information, see https://github.com/prometheus/prometheus/blob/master/docs/disabled_features.md")
+		"Currently, this includes 'promql-at-modifier' and 'promql-negative-offset'. For more information, see https://github.com/prometheus/prometheus/blob/master/docs/disabled_features.md")
 	fs.DurationVar(&cfg.MaxQueryTimeout, "promql-query-timeout", 2*time.Minute, "Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in "+
 		"'/api/v1/query.*' endpoints.")
 	fs.DurationVar(&cfg.SubQueryStepInterval, "promql-default-subquery-step-interval", 1*time.Minute, "Default step interval to be used for PromQL subquery evaluation. "+

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -50,6 +51,7 @@ func queryHandler(queryEngine *promql.Engine, queryable promql.Queryable, metric
 		begin := time.Now()
 		qry, err := queryEngine.NewInstantQuery(queryable, r.FormValue("query"), ts)
 		if err != nil {
+			fmt.Println("query=>", r.FormValue("query"))
 			log.Error("msg", "Query error", "err", err.Error())
 			respondError(w, http.StatusBadRequest, err, "bad_data")
 			metrics.FailedQueries.Add(1)
@@ -60,6 +62,7 @@ func queryHandler(queryEngine *promql.Engine, queryable promql.Queryable, metric
 		metrics.QueryDuration.Observe(time.Since(begin).Seconds())
 
 		if res.Err != nil {
+			fmt.Println("actual=>", r.FormValue("query"))
 			log.Error("msg", res.Err, "endpoint", "query")
 			switch res.Err.(type) {
 			case promql.ErrQueryCanceled:

--- a/pkg/api/query.go
+++ b/pkg/api/query.go
@@ -6,7 +6,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -51,7 +50,6 @@ func queryHandler(queryEngine *promql.Engine, queryable promql.Queryable, metric
 		begin := time.Now()
 		qry, err := queryEngine.NewInstantQuery(queryable, r.FormValue("query"), ts)
 		if err != nil {
-			fmt.Println("query=>", r.FormValue("query"))
 			log.Error("msg", "Query error", "err", err.Error())
 			respondError(w, http.StatusBadRequest, err, "bad_data")
 			metrics.FailedQueries.Add(1)
@@ -62,7 +60,6 @@ func queryHandler(queryEngine *promql.Engine, queryable promql.Queryable, metric
 		metrics.QueryDuration.Observe(time.Since(begin).Seconds())
 
 		if res.Err != nil {
-			fmt.Println("actual=>", r.FormValue("query"))
 			log.Error("msg", res.Err, "endpoint", "query")
 			switch res.Err.(type) {
 			case promql.ErrQueryCanceled:

--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -595,7 +595,7 @@ func StartPromContainer(storagePath string, ctx context.Context) (testcontainers
 	}
 	prometheusPort := nat.Port("9090/tcp")
 	req := testcontainers.ContainerRequest{
-		Image:        "prom/prometheus",
+		Image:        "prom/prometheus:main",
 		ExposedPorts: []string{string(prometheusPort)},
 		WaitingFor:   wait.ForListeningPort(prometheusPort),
 		BindMounts: map[string]string{
@@ -608,6 +608,9 @@ func StartPromContainer(storagePath string, ctx context.Context) (testcontainers
 			"--storage.tsdb.path=/prometheus",
 			"--web.console.libraries=/usr/share/prometheus/console_libraries",
 			"--web.console.templates=/usr/share/prometheus/consoles",
+
+			// Enable features.
+			"--enable-feature=promql-at-modifier,promql-negative-offset",
 
 			// This is to stop Prometheus from messing with the data.
 			"--storage.tsdb.retention.time=30y",

--- a/pkg/query/query_engine.go
+++ b/pkg/query/query_engine.go
@@ -26,6 +26,8 @@ func NewEngine(logger log.Logger, queryTimeout time.Duration, subqueryDefaultSte
 		switch feature {
 		case "promql-at-modifier":
 			engineOpts.EnableAtModifier = true
+		case "promql-negative-offset":
+			engineOpts.EnableNegativeOffset = true
 		default:
 			return nil, fmt.Errorf("invalid feature: %s", feature)
 		}

--- a/pkg/tests/end_to_end_tests/promql_label_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_label_endpoint_test.go
@@ -128,7 +128,7 @@ func TestPromQLLabelEndpoint(t *testing.T) {
 			}
 			requestCases = append(requestCases, requestCase{tsReq, promReq, fmt.Sprintf("get label values for %s", label)})
 		}
-		testMethod = testRequestConcurrent(requestCases, client, labelsResultComparator)
+		testMethod = testRequestConcurrent(requestCases, client, labelsResultComparator, true)
 		tester.Run("test label endpoint", testMethod)
 	})
 }

--- a/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
@@ -103,9 +103,9 @@ func genRangeRequest(apiURL, query string, start, end time.Time, step time.Durat
 }
 
 func TestPromQLQueryEndpointRealDataset(t *testing.T) {
-	if testing.Short() || !*extendedTest {
-		t.Skip("skipping integration test")
-	}
+	//if testing.Short() || !*extendedTest {
+	//	t.Skip("skipping integration test")
+	//}
 
 	testCases := []testCase{
 		{
@@ -178,7 +178,7 @@ func TestPromQLQueryEndpointRealDataset(t *testing.T) {
 		},
 		{
 			name:  "real query 18",
-			query: `{__name__=~".*"}`,
+			query: `{__name__=~".*"}`, // This is from promlabs, but this fails on even prometheus. So we can ignore this.
 		},
 		{
 			name:  "real query 19",
@@ -2202,7 +2202,7 @@ func TestPromQLQueryEndpointRealDataset(t *testing.T) {
 		},
 		{
 			name:  "real query 524",
-			query: fmt.Sprintf("sum(demo_cpu_usage_seconds_total[5m] @ %d)", samplesStartTime+30000/1000),
+			query: fmt.Sprintf("sum(demo_cpu_usage_seconds_total @ %d)", samplesStartTime+30000/1000), // Not form promlabs
 		},
 	}
 	start := time.Unix(samplesStartTime/1000, 0)
@@ -2211,9 +2211,9 @@ func TestPromQLQueryEndpointRealDataset(t *testing.T) {
 }
 
 func TestPromQLQueryEndpoint(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
+	//if testing.Short() {
+	//	t.Skip("skipping integration test")
+	//}
 
 	testCases := []testCase{
 		{
@@ -2410,7 +2410,7 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 		},
 		{
 			name:  "query with @ modifier",
-			query: fmt.Sprintf("sum(metric_1[5m] @ %d)", startTime+30000/1000),
+			query: fmt.Sprintf("sum(metric_1 @ %d)", startTime+30000/1000),
 		},
 		{
 			name:  "double name",

--- a/pkg/tests/end_to_end_tests/promql_series_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_series_endpoint_test.go
@@ -159,7 +159,7 @@ func TestPromQLSeriesEndpoint(t *testing.T) {
 			}
 			requestCases = append(requestCases, requestCase{tsReq, promReq, fmt.Sprintf("get no time series for %s", c.name)})
 		}
-		testMethod := testRequestConcurrent(requestCases, client, seriesResultComparator)
+		testMethod := testRequestConcurrent(requestCases, client, seriesResultComparator, true)
 		tester.Run("test series endpoint", testMethod)
 	})
 }


### PR DESCRIPTION
This does 3 tasks:
1. Fix PromQL E2E tests that were showing error logs.
2. Make CI fail if PromQL tests actually fail in logs (other than places not intended, eg: real-dataset tests where we want the output to be in line with Prometheus).
3. Support `promql-negative-offset` as the list of enable-features.