### PR TITLE
Prom-migrator: Fix gaps in graphs when migrating on time-based storages.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,5 +38,4 @@ require (
 	github.com/testcontainers/testcontainers-go v0.10.1-0.20210318151656-2bbeb1e04514
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	go.uber.org/goleak v1.1.10
-	gotest.tools v2.2.0+incompatible // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1076,8 +1076,6 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
-github.com/testcontainers/testcontainers-go v0.10.0 h1:ASWe0nwTNg5z8K3WSQ8aBNB6j5vrNJocFPEZF4NS0qI=
-github.com/testcontainers/testcontainers-go v0.10.0/go.mod h1:zFYk0JndthnMHEwtVRHCpLwIP/Ik1G7mvIAQ2MdZ+Ig=
 github.com/testcontainers/testcontainers-go v0.10.1-0.20210318151656-2bbeb1e04514 h1:Gw0AVZdk8yF5sJL50bGWv8cZqYZn55JisAdT9rrvJVc=
 github.com/testcontainers/testcontainers-go v0.10.1-0.20210318151656-2bbeb1e04514/go.mod h1:zFYk0JndthnMHEwtVRHCpLwIP/Ik1G7mvIAQ2MdZ+Ig=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/pkg/migration-tool/utils/client.go
+++ b/pkg/migration-tool/utils/client.go
@@ -152,8 +152,8 @@ type PrompbResponse struct {
 	NumBytesUncompressed int
 }
 
-// ReadChannels calls the Read and responds on the channels.
-func (c *Client) ReadChannels(ctx context.Context, query *prompb.Query, shardID int, desc string, responseChan chan<- interface{}) {
+// ReadConcurrent calls the Read and responds on the channels.
+func (c *Client) ReadConcurrent(ctx context.Context, query *prompb.Query, shardID int, desc string, responseChan chan<- interface{}) {
 	result, numBytesCompressed, numBytesUncompressed, err := c.Read(ctx, query, desc)
 	if err != nil {
 		responseChan <- fmt.Errorf("read-channels: %w", err)


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Solves gaps created during the migration process, when using concurrent fetch. The issue was that while we fetch a slab concurrently (dividing into sub-slabs in terms of time-ranges and pulling them concurrently), we need to combine them into a single large time-series before pushing to the writer. However, the combination process did not care about the time order i.e., the order in which concurrent sub-slabs were fetched and combined randomly. This is now fixed and we combine only in the order of creating sub-slabs.