### PR TITLE
Store test logs as GA artifacts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -84,8 +84,19 @@ jobs:
         fi
 
     - name: Test
-      run: go test -v -race ./... -timeout 15m
+      run: go test -v -race ./... -timeout 15m > complete-test-run.log  2>&1
 
+    - name: 'Print failure logs'
+      if: ${{ failure() }}
+      run: grep "^[- F]" complete-test-run.log
+
+    - name: 'Upload Log Artifact'
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: complete-test-run.log 
+        path: complete-test-run.log
+        retention-days: 5
 
     - name: Generated
       run: |
@@ -98,11 +109,11 @@ jobs:
     strategy:
       matrix:
         test-setups:
-        - {name: "Multinode",               ext: true,  tsdb: true,  tsdb2: true,  multi: true,  pg: 13}
-        - {name: "W/O Promscale Extension", ext: false, tsdb: true,  tsdb2: true,  multi: false, pg: 13}
-        - {name: "Plain Postgres",          ext: false, tsdb: false, tsdb2: false, multi: false, pg: 13}
-        - {name: "Timescaledb 1.x (pg 12)", ext: true,  tsdb: true,  tsdb2: false, multi: false, pg: 12}
-        - {name: "Plain Postgres (12)",     ext: false, tsdb: false, tsdb2: false, multi: false, pg: 12}
+        - {name: "Multinode",               shortname: "multinode",    ext: true,  tsdb: true,  tsdb2: true,  multi: true,  pg: 13}
+        - {name: "W/O Promscale Extension", shortname: "wo-prom-ext",  ext: false, tsdb: true,  tsdb2: true,  multi: false, pg: 13}
+        - {name: "Plain Postgres",          shortname: "plain-pg",     ext: false, tsdb: false, tsdb2: false, multi: false, pg: 13}
+        - {name: "Timescaledb 1.x (pg 12)", shortname: "tsdb1x-pg-12", ext: true,  tsdb: true,  tsdb2: false, multi: false, pg: 12}
+        - {name: "Plain Postgres (12)",     shortname: "plain-pg-12",  ext: false, tsdb: false, tsdb2: false, multi: false, pg: 12}
     steps:
 
     - name: Set up Go 1.14
@@ -137,4 +148,19 @@ jobs:
         TSDB2: ${{ matrix.test-setups.tsdb2 }}
         MULTI: ${{ matrix.test-setups.multi }}
         PG: ${{ matrix.test-setups.pg }}
-      run: go test ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-multinode=$MULTI -postgres-version-major=$PG
+        SHORTNAME: ${{ matrix.test-setups.shortname }}
+      run: go test ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-multinode=$MULTI -postgres-version-major=$PG > $SHORTNAME-test-run.log  2>&1
+
+    - name: 'Print failure logs'
+      if: ${{ failure() }}
+      env:
+        SHORTNAME: ${{ matrix.test-setups.shortname }}
+      run: grep "^[- F]" $SHORTNAME-test-run.log
+
+    - name: 'Upload Log Artifact'
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ matrix.test-setups.shortname }}-test-run.log 
+        path: ${{ matrix.test-setups.shortname }}-test-run.log
+        retention-days: 5

--- a/pkg/tests/end_to_end_tests/golden_files_test.go
+++ b/pkg/tests/end_to_end_tests/golden_files_test.go
@@ -104,7 +104,7 @@ func TestSQLGoldenFiles(t *testing.T) {
 			}
 
 			if string(expected) != string(actual) {
-				t.Fatalf("Golden file does not match result: diff %s %s", expectedFile, actualFile)
+				t.Fatalf("Golden file does not match result: diff\nexpected\n%s\nactual\n%s\n", expected, actual)
 			}
 
 		})


### PR DESCRIPTION
Log output from our test runs can be too verbose and slows down development
work when searching through them. This change stores complete logs into individual
files and stores them as GA artifacts while also filtering out the output to the
essential failure messages.