### PR TITLE
Fix delete end-to-end tests

### DIFF
--- a/pkg/tests/end_to_end_tests/delete_test.go
+++ b/pkg/tests/end_to_end_tests/delete_test.go
@@ -92,6 +92,11 @@ func TestDeleteWithMetricNameEQL(t *testing.T) {
 		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
+		err = ingestor.CompleteMetricCreation()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		pgDelete := &pgDel.PgDelete{Conn: pgxconn.NewPgxConn(db)}
 		for _, m := range matchers {
 			var countBeforeDelete, countAfterDelete int
@@ -258,6 +263,10 @@ func TestDeleteWithMetricNameEQLRegex(t *testing.T) {
 		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
+		err = ingestor.CompleteMetricCreation()
+		if err != nil {
+			t.Fatal(err)
+		}
 		pgDelete := &pgDel.PgDelete{Conn: pgxconn.NewPgxConn(db)}
 		for _, m := range matchers {
 			matcher, err := getMatchers(m.matchers)
@@ -382,6 +391,11 @@ func TestDeleteMixins(t *testing.T) {
 		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
+		err = ingestor.CompleteMetricCreation()
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		pgDelete := &pgDel.PgDelete{Conn: pgxconn.NewPgxConn(db)}
 		for _, m := range matchers {
 			matcher, err := getMatchers(m.matchers)

--- a/pkg/tests/end_to_end_tests/zlast_test.go
+++ b/pkg/tests/end_to_end_tests/zlast_test.go
@@ -35,6 +35,10 @@ func TestDeleteMetricSQLAPI(t *testing.T) {
 		if _, err := ingestor.Ingest(copyMetrics(ts), ingstr.NewWriteRequest()); err != nil {
 			t.Fatal(err)
 		}
+		err = ingestor.CompleteMetricCreation()
+		if err != nil {
+			t.Fatal(err)
+		}
 		startSnapShot := upgrade_tests.GetDbInfoIgnoringTable(t, container, *testDatabase, testDir, db, "", "label", extensionState)
 		tts := generateSmallTimeseries()
 		if _, err := ingestor.Ingest(copyMetrics(tts), ingstr.NewWriteRequest()); err != nil {


### PR DESCRIPTION
Some tests were not running metric creation finalization after ingesting
a pretty big dataset which caused test failures from time to time. This commit
adds the missing calls to make tests less flaky.