### PR TITLE
Fix regex anchor

### DIFF
--- a/pkg/pgmodel/querier/querier_sql_test.go
+++ b/pkg/pgmodel/querier/querier_sql_test.go
@@ -350,7 +350,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"WHERE NOT labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $1 and l.value !~ $2)\n\t" +
 						"GROUP BY m.metric_name\n\t" +
 						"ORDER BY m.metric_name",
-					Args:    []interface{}{"__name__", "^$"},
+					Args:    []interface{}{"__name__", "^(?:)$"},
 					Results: model.RowResults{{"foo", []int64{1}}, {"bar", []int64{1}}},
 					Err:     error(nil),
 				},
@@ -520,7 +520,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"WHERE labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $1 and l.value = $2) AND NOT labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $3 and l.value = $4) AND labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $5 and l.value ~ $6) AND NOT labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $7 and l.value ~ $8)\n\t" +
 						"GROUP BY m.metric_name\n\t" +
 						"ORDER BY m.metric_name",
-					Args:    []interface{}{"foo", "bar", "foo1", "bar1", "foo2", "^bar2$", "foo3", "^bar3$"},
+					Args:    []interface{}{"foo", "bar", "foo1", "bar1", "foo2", "^(?:^bar2)$", "foo3", "^(?:bar3$)$"},
 					Results: model.RowResults{{"metric", []int64{1, 4, 5}}},
 					Err:     error(nil),
 				},
@@ -580,7 +580,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"WHERE NOT labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $1 and l.value != $2) AND NOT labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $3 and l.value = $4) AND labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $5 and l.value ~ $6) AND NOT labels && (SELECT COALESCE(array_agg(l.id), array[]::int[]) FROM _prom_catalog.label l WHERE l.key = $7 and l.value ~ $8)\n\t" +
 						"GROUP BY m.metric_name\n\t" +
 						"ORDER BY m.metric_name",
-					Args:    []interface{}{"foo", "", "foo1", "bar1", "foo2", "^bar2$", "foo3", "^bar3$"},
+					Args:    []interface{}{"foo", "", "foo1", "bar1", "foo2", "^(?:^bar2$)$", "foo3", "^(?:bar3)$"},
 					Results: model.RowResults{{"metric", []int64{1, 2}}},
 					Err:     error(nil),
 				},

--- a/pkg/pgmodel/querier/query_builder.go
+++ b/pkg/pgmodel/querier/query_builder.go
@@ -427,25 +427,8 @@ func GetSeriesPerMetric(rows pgx.Rows) ([]string, [][]pgmodel.SeriesID, error) {
 // anchorValue adds anchors to values in regexps since PromQL docs
 // states that "Regex-matches are fully anchored."
 func anchorValue(str string) string {
-	l := len(str)
-
-	if l == 0 {
-		return "^$"
-	}
-
-	if str[0] == '^' && str[l-1] == '$' {
-		return str
-	}
-
-	if str[0] == '^' {
-		return fmt.Sprintf("%s$", str)
-	}
-
-	if str[l-1] == '$' {
-		return fmt.Sprintf("^%s", str)
-	}
-
-	return fmt.Sprintf("^%s$", str)
+	//Reference:  NewFastRegexMatcher in Prometheus source code
+	return "^(?:" + str + ")$"
 }
 
 func toMilis(t time.Time) int64 {

--- a/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
@@ -2204,6 +2204,14 @@ func TestPromQLQueryEndpointRealDataset(t *testing.T) {
 			name:  "real query 524",
 			query: fmt.Sprintf("sum(demo_cpu_usage_seconds_total[5m] @ %d)", samplesStartTime+30000/1000), // Not from promlabs
 		},
+		{
+			name:  "real query 525",
+			query: `demo_disk_usage_bytes{instance=~"|"}`, // Not from promlabs
+		},
+		{
+			name:  "real query 526",
+			query: `demo_disk_usage_bytes{instance=~"demo|"}`, // Not from promlabs
+		},
 	}
 	start := time.Unix(samplesStartTime/1000, 0)
 	end := time.Unix(samplesEndTime/1000, 0)
@@ -2427,6 +2435,34 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 		{
 			name:  "non-contradictory name",
 			query: `{__name__="metric_1", __name__!="metric_2"}`,
+		},
+		{
+			name:  "anchored-regex 1",
+			query: `{__name__="metric_2", foo=~"bar"}`,
+		},
+		{
+			name:  "anchored-regex 2",
+			query: `{__name__="metric_2", foo=~"^bar$"}`,
+		},
+		{
+			name:  "anchored-regex 3",
+			query: `{__name__="metric_2", foo=~"bar|"}`,
+		},
+		{
+			name:  "anchored-regex 4",
+			query: `{__name__="metric_2", foo=~"^bar$|^$"}`,
+		},
+		{
+			name:  "anchored-regex 5",
+			query: `{__name__="metric_2", foo=~"^bar|$"}`,
+		},
+		{
+			name:  "anchored-regex 6",
+			query: `{__name__="metric_2", foo=~""}`,
+		},
+		{
+			name:  "anchored-regex 7",
+			query: `{__name__="metric_2", foo=~"^$"}`,
 		},
 	}
 	start := time.Unix(startTime/1000, 0)


### PR DESCRIPTION
Previously, regex anchoring happened as ^str$, which broke when using
a pipe as it interpreted a|b as (^a)|(b$).  while what we want is
^(a|b)$. Anoher words the precedenc of operators broke. Now we found
the anchoring Prometheus does, and just used that.