### PR TITLE
Improve password masking utility

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,16 +16,14 @@ import (
 
 const (
 	PromNamespace              = "promscale"
-	maskPasswordReplaceString1 = "password=$1'****'"
-	maskPasswordReplaceString2 = "password:$1****$3"
+	maskPasswordReplaceString1 = "password$1$2$3****$5"
 	/* #nosec */
-	maskPasswordReplaceString3 = "postgres:$1****"
+	maskPasswordReplaceString2 = "postgres:$1****@"
 )
 
 var (
-	maskPasswordRegex1 = regexp.MustCompile(`[p|P]assword=(\s*?)'([^']+?)'`)
-	maskPasswordRegex2 = regexp.MustCompile(`[p|P]assword:(\s*)(.*?)(\s*\w+:|$)`)
-	maskPasswordRegex3 = regexp.MustCompile(`postgres:(([^:]*\:){1})([^@]*)`)
+	maskPasswordRegex1 = regexp.MustCompile(`[p|P]assword(:|=)(\s*)('?)(.*?)('|(&|\s*)\w+[:|=]{1}|$)`)
+	maskPasswordRegex2 = regexp.MustCompile(`postgres:(([^:]*\:){1})([^@]*)@`)
 )
 
 //ThroughputCalc runs on scheduled interval to calculate the throughput per second and sends results to a channel
@@ -83,8 +81,7 @@ func (dt *ThroughputCalc) Start() {
 // MaskPassword is used to mask sensitive password data before outputing to persistent stream like logs.
 func MaskPassword(s string) string {
 	s = maskPasswordRegex1.ReplaceAllString(s, maskPasswordReplaceString1)
-	s = maskPasswordRegex2.ReplaceAllString(s, maskPasswordReplaceString2)
-	return maskPasswordRegex3.ReplaceAllString(s, maskPasswordReplaceString3)
+	return maskPasswordRegex2.ReplaceAllString(s, maskPasswordReplaceString2)
 }
 
 // ParseEnv takes a prefix string p and *flag.FlagSet. Each flag

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -65,34 +65,40 @@ func TestThroughputCalc(t *testing.T) {
 
 func TestMaskPassword(t *testing.T) {
 	testData := map[string]string{
-		"password='foobar' host='localhost'":                                 "password='****' host='localhost'",
-		"password='foo bar' host='localhost'":                                "password='****' host='localhost'",
-		"Password='foo bar' host='localhost'":                                "password='****' host='localhost'",
-		"password='foo'bar' host='localhost'":                                "password='****'bar' host='localhost'",
-		"password= 'foobar' host='localhost'":                                "password= '****' host='localhost'",
-		"password=  'foobar' host='localhost'":                               "password=  '****' host='localhost'",
-		"pass='foobar' host='localhost'":                                     "pass='foobar' host='localhost'",
-		"host='localhost' password='foobar'":                                 "host='localhost' password='****'",
-		"password:foobar  host: localhost":                                   "password:****  host: localhost",
-		"password:foo bar  host: localhost":                                  "password:****  host: localhost",
-		"password: foobar  host: localhost":                                  "password: ****  host: localhost",
-		"password:  foobar  host: localhost":                                 "password:  ****  host: localhost",
-		"password:  foobar with spaces host: localhost":                      "password:  **** host: localhost",
-		"password: foobar with spaces host: localhost":                       "password: **** host: localhost",
-		"password:foobar with spaces host: localhost":                        "password:**** host: localhost",
-		"password:\"foo bar\" host: localhost":                               "password:**** host: localhost",
-		"Password: \"foo bar\" host: localhost":                              "password: **** host: localhost",
-		"pass:foobar host: localhost":                                        "pass:foobar host: localhost",
-		"host: localhost password: foobar":                                   "host: localhost password: ****",
-		"host: localhost Password: foobar":                                   "host: localhost password: ****",
-		"postgres://postgres:password@localhost:5432/postgres?sslmode=allow": "postgres://postgres:****@localhost:5432/postgres?sslmode=allow",
+		"password='foobar' host='localhost'":                                                   "password='****' host='localhost'",
+		"password='foobar&' host='localhost'":                                                  "password='****' host='localhost'",
+		"password='foo bar' host='localhost'":                                                  "password='****' host='localhost'",
+		"Password='foo bar' host='localhost'":                                                  "password='****' host='localhost'",
+		"password='foo'bar' host='localhost'":                                                  "password='****'bar' host='localhost'",
+		"password= 'foobar' host='localhost'":                                                  "password= '****' host='localhost'",
+		"password=  'foobar' host='localhost'":                                                 "password=  '****' host='localhost'",
+		"pass='foobar' host='localhost'":                                                       "pass='foobar' host='localhost'",
+		"host='localhost' password='foobar'":                                                   "host='localhost' password='****'",
+		"password:foobar  host: localhost":                                                     "password:****  host: localhost",
+		"password:foo bar  host: localhost":                                                    "password:****  host: localhost",
+		"password: foobar  host: localhost":                                                    "password: ****  host: localhost",
+		"password:  foobar  host: localhost":                                                   "password:  ****  host: localhost",
+		"password:  foobar&  host: localhost":                                                  "password:  ****  host: localhost",
+		"password:  foobar with spaces host: localhost":                                        "password:  **** host: localhost",
+		"password: foobar with spaces host: localhost":                                         "password: **** host: localhost",
+		"password:foobar with spaces host: localhost":                                          "password:**** host: localhost",
+		"password:\"foo bar\" host: localhost":                                                 "password:**** host: localhost",
+		"Password: \"foo bar\" host: localhost":                                                "password: **** host: localhost",
+		"pass:foobar host: localhost":                                                          "pass:foobar host: localhost",
+		"host: localhost password: foobar":                                                     "host: localhost password: ****",
+		"host: localhost Password: foobar":                                                     "host: localhost password: ****",
+		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword":               "postgres://localhost:5432/postgres?sslmode=allow&password=****",
+		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword&":              "postgres://localhost:5432/postgres?sslmode=allow&password=****",
+		"postgres://localhost:5432/postgres?password=testpassword&sslmode=allow":               "postgres://localhost:5432/postgres?password=****&sslmode=allow",
+		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword&user=postgres": "postgres://localhost:5432/postgres?sslmode=allow&password=****&user=postgres",
+		"postgres://postgres:password@localhost:5432/postgres?sslmode=allow":                   "postgres://postgres:****@localhost:5432/postgres?sslmode=allow",
 		"&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: password SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:postgres://postgres:password@localhost:5432/postgres?sslmode=allow} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}": "&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: **** SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:postgres://postgres:****@localhost:5432/postgres?sslmode=allow} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}",
 		"&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: pass SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}":                                                                       "&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: **** SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}",
 	}
 
 	for input, expected := range testData {
 		if output := MaskPassword(input); expected != output {
-			t.Errorf("Unexpected masking output:\ngot %s\nwanted %s\n", output, expected)
+			t.Errorf("Unexpected masking output for case \"%s\":\ngot    %s\nwanted %s\n", input, output, expected)
 		}
 	}
 }


### PR DESCRIPTION
Previous implementation did not cover all possible cases that needed.
This change also reduces the number of regexes necessary to mask all
combinations.

Fixes #605 