### PR TITLE
Make per timeseries points limit configurable.

### DIFF
--- a/.github/workflows/go-scheduled.yml
+++ b/.github/workflows/go-scheduled.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Lint
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
-        /home/runner/go/bin/golangci-lint run --skip-dirs=pkg/promql --skip-dirs=pkg/promb
+        /home/runner/go/bin/golangci-lint run --timeout=5m --skip-dirs=pkg/promql --skip-dirs=pkg/promb
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Lint
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
-        /home/runner/go/bin/golangci-lint run --skip-dirs=pkg/promql --skip-dirs=pkg/promb
+        /home/runner/go/bin/golangci-lint run --timeout=5m --skip-dirs=pkg/promql --skip-dirs=pkg/promb
 
     - name: Build
       run: go build -v ./...
@@ -84,7 +84,7 @@ jobs:
         fi
 
     - name: Test
-      run: go test -v -race ./... -timeout 15m > complete-test-run.log  2>&1
+      run: go test -v -race ./... -timeout 30m > complete-test-run.log  2>&1
 
     - name: 'Print failure logs'
       if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ go-fmt:
 	gofmt -d .
 
 go-lint:
-	golangci-lint run --skip-dirs=pkg/promql --skip-dirs=pkg/promb
+	golangci-lint run --timeout=5m --skip-dirs=pkg/promql --skip-dirs=pkg/promb
 
 all: build test e2e-test go-fmt go-lint

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,7 +65,7 @@ You can also find information on flags with `promscale_<version> -help`.
 | db-connection-timeout | duration | 60 seconds | Timeout for establishing the connection between Promscale and TimescaleDB. |
 | db-connections-max | integer | 80% of possible connections db | Maximum number of connections to the database that should be opened at once. It defaults to 80% of the maximum connections that the database can handle. |
 | db-ssl-mode | string | require | TimescaleDB/Vanilla Postgres connection ssl mode. If you do not want to use ssl, pass `allow` as value. |
-| db-writer-connection-concurrency | int | 4 | Maximum number of database connections for writing per go process. |
+| db-writer-connection-concurrency | integer | 4 | Maximum number of database connections for writing per go process. |
 | db-uri | string | | TimescaleDB/Vanilla PostgresSQL URI. Example:`postgres://postgres:password@localhost:5432/timescale?sslmode=require` |
 | async-acks | boolean | false | Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss. |
 | db-statements-cache | boolean | true | Whether database connection pool should use cached prepared statements. Disable if using PgBouncer. |
@@ -78,4 +78,5 @@ You can also find information on flags with `promscale_<version> -help`.
 | promql-query-timeout | duration | 2 minutes | Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in '/api/v1/query.*' endpoints. |
 | promql-default-subquery-step-interval | duration | 1 minute | Default step interval to be used for PromQL subquery evaluation. This value is used if the subquery does not specify the step value explicitly. Example: <metric_name>[30m:]. Note: in Prometheus this setting is set by the evaluation_interval option. |
 | promql-lookback-delta | duration | 5 minute | The maximum look-back duration for retrieving metrics during expression evaluations and federation. |
-| promql-max-samples | integer | 50000000 | Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return. |
+| promql-max-samples | integer64 | 50000000 | Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return. |
+| promql-max-points-per-ts  | integer64 | 11000 | Maximum number of points per time-series in a query-range request. This calculation is an estimation, that happens as (start - end)/step where start and end are the 'start' and 'end' timestamps of the query_range. |

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -96,6 +96,7 @@ type Config struct {
 	SubQueryStepInterval time.Duration // Default step interval value if the user has not provided.
 	LookBackDelta        time.Duration
 	MaxSamples           int64
+	MaxPointsPerTs       int64
 }
 
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
@@ -123,6 +124,8 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.Int64Var(&cfg.MaxSamples, "promql-max-samples", 50000000, "Maximum number of samples a single "+
 		"query can load into memory. Note that queries will fail if they try to load more samples than this into memory, "+
 		"so this also limits the number of samples a query can return.")
+	fs.Int64Var(&cfg.MaxPointsPerTs, "promql-max-points-per-ts", 11000, "Maximum number of points per time-series in a query-range request. "+
+		"This calculation is an estimation, that happens as (start - end)/step where start and end are the 'start' and 'end' timestamps of the query_range.")
 	return cfg
 }
 

--- a/pkg/api/query_range_test.go
+++ b/pkg/api/query_range_test.go
@@ -171,7 +171,7 @@ func TestRangedQuery(t *testing.T) {
 				InvalidQueryReqs: invalidQueryReqs,
 				QueryDuration:    queryDuration,
 			}
-			handler := queryRange(engine, query.NewQueryable(tc.querier, nil), metrics)
+			handler := queryRange(&Config{MaxPointsPerTs: 11000}, engine, query.NewQueryable(tc.querier, nil), metrics)
 			queryUrl := constructRangedQuery(tc.metric, tc.start, tc.end, tc.step, tc.timeout)
 			w := doRangedQuery(t, handler, queryUrl, tc.canceled)
 

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -280,6 +280,7 @@ func buildRouter(pool *pgxpool.Pool) (http.Handler, *pgclient.Client, error) {
 		SubQueryStepInterval: time.Minute,
 		EnabledFeaturesList:  []string{"promql-at-modifier", "promql-negative-offset"},
 		MaxSamples:           math.MaxInt32,
+		MaxPointsPerTs:       11000,
 	}
 
 	return buildRouterWithAPIConfig(pool, apiConfig)

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -663,7 +663,7 @@ func TestMigrationFailure(t *testing.T) {
 }
 
 func buildPromscaleImageFromRepo(t *testing.T) {
-	t.Logf("building promscle image from the codebase")
+	t.Logf("building promscale image from the codebase")
 	cmd := exec.Command("docker", "build", "-t", "timescale/promscale:latest", "./../../../", "--file", "./../../../build/Dockerfile")
 	err := cmd.Run()
 	if err != nil {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,16 +16,14 @@ import (
 
 const (
 	PromNamespace              = "promscale"
-	maskPasswordReplaceString1 = "password=$1'****'"
-	maskPasswordReplaceString2 = "password:$1****$3"
+	maskPasswordReplaceString1 = "password$1$2$3****$5"
 	/* #nosec */
-	maskPasswordReplaceString3 = "postgres:$1****"
+	maskPasswordReplaceString2 = "postgres:$1****@"
 )
 
 var (
-	maskPasswordRegex1 = regexp.MustCompile(`[p|P]assword=(\s*?)'([^']+?)'`)
-	maskPasswordRegex2 = regexp.MustCompile(`[p|P]assword:(\s*)(.*?)(\s*\w+:|$)`)
-	maskPasswordRegex3 = regexp.MustCompile(`postgres:(([^:]*\:){1})([^@]*)`)
+	maskPasswordRegex1 = regexp.MustCompile(`[p|P]assword(:|=)(\s*)('?)(.*?)('|(&|\s*)\w+[:|=]{1}|$)`)
+	maskPasswordRegex2 = regexp.MustCompile(`postgres:(([^:]*\:){1})([^@]*)@`)
 )
 
 //ThroughputCalc runs on scheduled interval to calculate the throughput per second and sends results to a channel
@@ -83,8 +81,7 @@ func (dt *ThroughputCalc) Start() {
 // MaskPassword is used to mask sensitive password data before outputing to persistent stream like logs.
 func MaskPassword(s string) string {
 	s = maskPasswordRegex1.ReplaceAllString(s, maskPasswordReplaceString1)
-	s = maskPasswordRegex2.ReplaceAllString(s, maskPasswordReplaceString2)
-	return maskPasswordRegex3.ReplaceAllString(s, maskPasswordReplaceString3)
+	return maskPasswordRegex2.ReplaceAllString(s, maskPasswordReplaceString2)
 }
 
 // ParseEnv takes a prefix string p and *flag.FlagSet. Each flag

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -65,34 +65,40 @@ func TestThroughputCalc(t *testing.T) {
 
 func TestMaskPassword(t *testing.T) {
 	testData := map[string]string{
-		"password='foobar' host='localhost'":                                 "password='****' host='localhost'",
-		"password='foo bar' host='localhost'":                                "password='****' host='localhost'",
-		"Password='foo bar' host='localhost'":                                "password='****' host='localhost'",
-		"password='foo'bar' host='localhost'":                                "password='****'bar' host='localhost'",
-		"password= 'foobar' host='localhost'":                                "password= '****' host='localhost'",
-		"password=  'foobar' host='localhost'":                               "password=  '****' host='localhost'",
-		"pass='foobar' host='localhost'":                                     "pass='foobar' host='localhost'",
-		"host='localhost' password='foobar'":                                 "host='localhost' password='****'",
-		"password:foobar  host: localhost":                                   "password:****  host: localhost",
-		"password:foo bar  host: localhost":                                  "password:****  host: localhost",
-		"password: foobar  host: localhost":                                  "password: ****  host: localhost",
-		"password:  foobar  host: localhost":                                 "password:  ****  host: localhost",
-		"password:  foobar with spaces host: localhost":                      "password:  **** host: localhost",
-		"password: foobar with spaces host: localhost":                       "password: **** host: localhost",
-		"password:foobar with spaces host: localhost":                        "password:**** host: localhost",
-		"password:\"foo bar\" host: localhost":                               "password:**** host: localhost",
-		"Password: \"foo bar\" host: localhost":                              "password: **** host: localhost",
-		"pass:foobar host: localhost":                                        "pass:foobar host: localhost",
-		"host: localhost password: foobar":                                   "host: localhost password: ****",
-		"host: localhost Password: foobar":                                   "host: localhost password: ****",
-		"postgres://postgres:password@localhost:5432/postgres?sslmode=allow": "postgres://postgres:****@localhost:5432/postgres?sslmode=allow",
+		"password='foobar' host='localhost'":                                                   "password='****' host='localhost'",
+		"password='foobar&' host='localhost'":                                                  "password='****' host='localhost'",
+		"password='foo bar' host='localhost'":                                                  "password='****' host='localhost'",
+		"Password='foo bar' host='localhost'":                                                  "password='****' host='localhost'",
+		"password='foo'bar' host='localhost'":                                                  "password='****'bar' host='localhost'",
+		"password= 'foobar' host='localhost'":                                                  "password= '****' host='localhost'",
+		"password=  'foobar' host='localhost'":                                                 "password=  '****' host='localhost'",
+		"pass='foobar' host='localhost'":                                                       "pass='foobar' host='localhost'",
+		"host='localhost' password='foobar'":                                                   "host='localhost' password='****'",
+		"password:foobar  host: localhost":                                                     "password:****  host: localhost",
+		"password:foo bar  host: localhost":                                                    "password:****  host: localhost",
+		"password: foobar  host: localhost":                                                    "password: ****  host: localhost",
+		"password:  foobar  host: localhost":                                                   "password:  ****  host: localhost",
+		"password:  foobar&  host: localhost":                                                  "password:  ****  host: localhost",
+		"password:  foobar with spaces host: localhost":                                        "password:  **** host: localhost",
+		"password: foobar with spaces host: localhost":                                         "password: **** host: localhost",
+		"password:foobar with spaces host: localhost":                                          "password:**** host: localhost",
+		"password:\"foo bar\" host: localhost":                                                 "password:**** host: localhost",
+		"Password: \"foo bar\" host: localhost":                                                "password: **** host: localhost",
+		"pass:foobar host: localhost":                                                          "pass:foobar host: localhost",
+		"host: localhost password: foobar":                                                     "host: localhost password: ****",
+		"host: localhost Password: foobar":                                                     "host: localhost password: ****",
+		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword":               "postgres://localhost:5432/postgres?sslmode=allow&password=****",
+		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword&":              "postgres://localhost:5432/postgres?sslmode=allow&password=****",
+		"postgres://localhost:5432/postgres?password=testpassword&sslmode=allow":               "postgres://localhost:5432/postgres?password=****&sslmode=allow",
+		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword&user=postgres": "postgres://localhost:5432/postgres?sslmode=allow&password=****&user=postgres",
+		"postgres://postgres:password@localhost:5432/postgres?sslmode=allow":                   "postgres://postgres:****@localhost:5432/postgres?sslmode=allow",
 		"&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: password SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:postgres://postgres:password@localhost:5432/postgres?sslmode=allow} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}": "&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: **** SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:postgres://postgres:****@localhost:5432/postgres?sslmode=allow} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}",
 		"&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: pass SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}":                                                                       "&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: **** SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}",
 	}
 
 	for input, expected := range testData {
 		if output := MaskPassword(input); expected != output {
-			t.Errorf("Unexpected masking output:\ngot %s\nwanted %s\n", output, expected)
+			t.Errorf("Unexpected masking output for case \"%s\":\ngot    %s\nwanted %s\n", input, output, expected)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

Fixes: #608 

If we make `max-samples` configurable as per user, then `max-points` should be made configurable as well, with the default being what Prometheus has. Moreover, being fixed at 11,000 based on estimation is smart, but may not be necessary to all systems.