### PR TITLE
Fix new HA read path by dropping __replica__ labelset

### DIFF
--- a/pkg/api/read_test.go
+++ b/pkg/api/read_test.go
@@ -77,6 +77,7 @@ func TestRead(t *testing.T) {
 				response: c.readerResponse,
 				err:      c.readerErr,
 			}
+			config := &Config{}
 			receivedQueriesCounter := &mockMetric{}
 			queryDurationHist := &mockMetric{}
 			failedQueriesCounter := &mockMetric{}
@@ -87,7 +88,7 @@ func TestRead(t *testing.T) {
 				ReceivedQueries:    receivedQueriesCounter,
 				InvalidReadReqs:    invalidReadReqs,
 			}
-			handler := Read(mockReader, metrics)
+			handler := Read(config, mockReader, metrics)
 
 			test := GenerateReadHandleTester(t, handler, c.name == "bad header")
 

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -53,7 +53,7 @@ func GenerateRouter(apiConf *Config, metrics *Metrics, client *pgclient.Client, 
 
 	router.Post("/write", writeHandler)
 
-	readHandler := timeHandler(metrics.HTTPRequestDuration, "read", Read(client, metrics))
+	readHandler := timeHandler(metrics.HTTPRequestDuration, "read", Read(apiConf, client, metrics))
 	router.Get("/read", readHandler)
 	router.Post("/read", readHandler)
 

--- a/pkg/ha/filter.go
+++ b/pkg/ha/filter.go
@@ -54,7 +54,7 @@ func (h *Filter) Process(_ *http.Request, wr *prompb.WriteRequest) error {
 		return fmt.Errorf("could not check ha lease: %#v", err)
 	}
 	if !allowInsert {
-		log.Debug("the samples aren't from the leader prom instance. skipping the insert")
+		log.Debug("msg", "the samples aren't from the leader prom instance. skipping the insert")
 		wr.Timeseries = wr.Timeseries[:0]
 		return nil
 	}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -38,7 +38,7 @@ type Config struct {
 
 // ParseFlags parses the configuration flags for logging.
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
-	fs.StringVar(&cfg.Level, "log-level", "debug", "Log level to use from [ 'error', 'warn', 'info', 'debug' ].")
+	fs.StringVar(&cfg.Level, "log-level", "info", "Log level to use from [ 'error', 'warn', 'info', 'debug' ].")
 	fs.StringVar(&cfg.Format, "log-format", "logfmt", "The log format to use [ 'logfmt', 'json' ].")
 	return cfg
 }


### PR DESCRIPTION
In the new HA setup read path fails when the read query comes from prometheus as promethues appends replica labelset from external labelset for readRead requests. So dropping the __replica__ labelSet in labelmatchers for read requests, when Promscale is in HA mode.