### PR TITLE
dont panic/segv on no memory cgroup

### DIFF
--- a/pkg/limits/mem/mem_linux.go
+++ b/pkg/limits/mem/mem_linux.go
@@ -68,5 +68,8 @@ func getCGroupV1Memory() uint64 {
 	if err != nil {
 		return 0
 	}
+	if stats.Memory == nil {
+		return 0
+	}
 	return stats.Memory.HierarchicalMemoryLimit
 }


### PR DESCRIPTION

Running promscale on a system without memory cgroups enabled results in a panic / SEGV.

```
~# /opt/promscale/promscale
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x6561f4]

goroutine 1 [running]:
github.com/timescale/promscale/pkg/limits/mem.getCGroupV1Memory(0x0, 0x0)
        /tmp/promscale/pkg/limits/mem/mem_linux.go:71 +0xc8
github.com/timescale/promscale/pkg/limits/mem.getCGroupMemory(0x856a01, 0x1d852c0)
        /tmp/promscale/pkg/limits/mem/mem_linux.go:43 +0x84
github.com/timescale/promscale/pkg/limits/mem.SystemMemory(0x1d85290, 0x91e4f0)
        /tmp/promscale/pkg/limits/mem/mem_linux.go:17 +0x14
github.com/timescale/promscale/pkg/limits.ParseFlags(0x1d85290, 0x1d9c7dc, 0x1d9c784)
        /tmp/promscale/pkg/limits/flags.go:109 +0x14
github.com/timescale/promscale/pkg/runner.ParseFlags(0x1d9c6e0, 0x1c9e110, 0x0, 0x0, 0xd8, 0x81c080, 0x4f701)
        /tmp/promscale/pkg/runner/flags.go:54 +0x138
main.main()
        /tmp/promscale/cmd/promscale/main.go:22 +0xa4
```