### PR TITLE
Fixes to support timescale 2.3.0

### DIFF
--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -287,20 +287,21 @@ func StartPGContainer(
 	}
 	PGTag := "pg" + PGMajor
 
+	promscaleImageBase := "cevian/promscale-extension" //cevian is temporary until we update the timescaledev repo
 	switch extensionState &^ postgres12Bit {
 	case MultinodeAndPromscale:
-		image = "timescaledev/promscale-extension:latest-ts2-" + PGTag
+		image = promscaleImageBase + ":latest-ts2-" + PGTag
 	case Multinode:
 		image = "timescale/timescaledb:latest-" + PGTag
 	case Timescale2AndPromscale:
-		image = "timescaledev/promscale-extension:latest-ts2-" + PGTag
+		image = promscaleImageBase + ":latest-ts2-" + PGTag
 	case Timescale2:
 		image = "timescale/timescaledb:latest-" + PGTag
 	case Timescale1AndPromscale:
 		if PGMajor != "12" {
 			return nil, nil, fmt.Errorf("Timescaledb 1.x requires pg12")
 		}
-		image = "timescaledev/promscale-extension:latest-ts1-pg12"
+		image = promscaleImageBase + ":latest-ts1-pg12"
 	case Timescale1:
 		if PGMajor != "12" {
 			return nil, nil, fmt.Errorf("Timescaledb 1.x requires pg12")

--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -151,7 +151,7 @@ func tryRecovery(conn pgxconn.PgxConn, err error, req copyRequest) error {
 		return err
 	}
 
-	if strings.Contains(pgErr.Message, "insert/update/delete not permitted") {
+	if pgErr.Code == "0A000" || strings.Contains(pgErr.Message, "compressed") || strings.Contains(pgErr.Message, "insert/update/delete not permitted") {
 		// If the error was that the table is already compressed, decompress and try again.
 		return handleDecompression(conn, req)
 	}

--- a/pkg/tests/end_to_end_tests/golden_files_test.go
+++ b/pkg/tests/end_to_end_tests/golden_files_test.go
@@ -17,9 +17,10 @@ import (
 )
 
 var outputDifferWithoutTimescale = map[string]bool{"info_view": true}
-var outputDifferWithMultinode = map[string]bool{"views": true, "info_view": true, "support": true}
+var outputDifferWithMultinode = map[string]bool{"views": true, "info_view": true}
 var outputDifferWithExtension = map[string]bool{"support": true}
 var requiresTimescaleDB = map[string]bool{"views": true, "info_view": true, "support": true}
+var requiresSingleNode = map[string]bool{"support": true}
 
 func TestSQLGoldenFiles(t *testing.T) {
 	if testing.Short() {
@@ -39,6 +40,9 @@ func TestSQLGoldenFiles(t *testing.T) {
 			base = strings.TrimSuffix(base, filepath.Ext(base))
 
 			if !*useTimescaleDB && requiresTimescaleDB[base] {
+				return
+			}
+			if *useMultinode && requiresSingleNode[base] {
 				return
 			}
 

--- a/pkg/tests/testdata/expected/info_view-timescaledb-2-multinode.out
+++ b/pkg/tests/testdata/expected/info_view-timescaledb-2-multinode.out
@@ -55,8 +55,8 @@ SET
 SELECT id , metric_name , table_name, retention_period, chunk_interval > interval '7 hour', compressed_interval > interval '7 hour', before_compression_bytes, after_compression_bytes, label_keys, total_size, total_size_bytes, compression_ratio, total_chunks, compressed_chunks FROM prom_info.metric ORDER BY id;
  id | metric_name | table_name | retention_period | ?column? | ?column? | before_compression_bytes | after_compression_bytes |             label_keys              | total_size | total_size_bytes |  compression_ratio   | total_chunks | compressed_chunks 
 ----+-------------+------------+------------------+----------+----------+--------------------------+-------------------------+-------------------------------------+------------+------------------+----------------------+--------------+-------------------
-  1 | cpu_usage   | cpu_usage  | 90 days          | t        | f        |                    24576 |                   32768 | {__name__,namespace,new_tag,node}   | 64 kB      |            65536 | -33.3333333333333300 |            1 |                 1
-  2 | cpu_total   | cpu_total  | 90 days          | t        | f        |                    24576 |                   32768 | {__name__,namespace,new_tag_2,node} | 64 kB      |            65536 | -33.3333333333333300 |            1 |                 1
+  1 | cpu_usage   | cpu_usage  | 90 days          | t        | t        |                    24576 |                   32768 | {__name__,namespace,new_tag,node}   | 64 kB      |            65536 | -33.3333333333333300 |            1 |                 1
+  2 | cpu_total   | cpu_total  | 90 days          | t        | t        |                    24576 |                   32768 | {__name__,namespace,new_tag_2,node} | 64 kB      |            65536 | -33.3333333333333300 |            1 |                 1
 (2 rows)
 
 SELECT * FROM prom_info.label ORDER BY key;


### PR DESCRIPTION
The biggest change was to fix which error message triggers
decompression. That's the only functional change.

The rest are changes in the golden files to show that the
compression status has been fixed.