### PR TITLE
 Use more reliable methods of password masking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require (
 	github.com/hashicorp/go-immutable-radix v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/inhies/go-bytesize v0.0.0-20201103132853-d0aed0d254f8
-	github.com/jackc/pgconn v1.6.3
+	github.com/jackc/pgconn v1.8.1
 	github.com/jackc/pgerrcode v0.0.0-20190803225404-afa3381909a6
-	github.com/jackc/pgproto3/v2 v2.0.2
+	github.com/jackc/pgproto3/v2 v2.0.6
 	github.com/jackc/pgtype v1.4.2
 	github.com/jackc/pgx/v4 v4.8.0
 	github.com/opentracing-contrib/go-stdlib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -846,6 +846,8 @@ github.com/jackc/pgconn v1.5.0/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr
 github.com/jackc/pgconn v1.5.1-0.20200601181101-fa742c524853/go.mod h1:QeD3lBfpTFe8WUnPZWN5KY/mB8FGMIYRdd8P8Jr0fAI=
 github.com/jackc/pgconn v1.6.3 h1:4Ks3RKvSvKPolXZsnLQTDAsokDhgID14Cv4ehECmzlY=
 github.com/jackc/pgconn v1.6.3/go.mod h1:w2pne1C2tZgP+TvjqLpOigGzNqjBgQW9dUw/4Chex78=
+github.com/jackc/pgconn v1.8.1 h1:ySBX7Q87vOMqKU2bbmKbUvtYhauDFclYbNDYIE1/h6s=
+github.com/jackc/pgconn v1.8.1/go.mod h1:JV6m6b6jhjdmzchES0drzCcYcAHS1OPD5xu3OZ/lE2g=
 github.com/jackc/pgerrcode v0.0.0-20190803225404-afa3381909a6 h1:geJ1mgTGd0WQo67wEd+H4OjFG5uA2e3cEBz9D5+pftU=
 github.com/jackc/pgerrcode v0.0.0-20190803225404-afa3381909a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
@@ -863,6 +865,8 @@ github.com/jackc/pgproto3/v2 v2.0.0-rc3.0.20190831210041-4c03ce451f29/go.mod h1:
 github.com/jackc/pgproto3/v2 v2.0.1/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgproto3/v2 v2.0.2 h1:q1Hsy66zh4vuNsajBUF2PNqfAMMfxU5mk594lPE9vjY=
 github.com/jackc/pgproto3/v2 v2.0.2/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
+github.com/jackc/pgproto3/v2 v2.0.6 h1:b1105ZGEMFe7aCvrT1Cca3VoVb4ZFMaFJLJcg/3zD+8=
+github.com/jackc/pgproto3/v2 v2.0.6/go.mod h1:WfJCnwN3HIg9Ish/j3sgWXnAfK8A9Y0bwXYU5xKaEdA=
 github.com/jackc/pgservicefile v0.0.0-20200307190119-3430c5407db8/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b h1:C8S2+VttkHFdOOCXJe+YGfa4vHYwlt4Zx+IVXQ97jYg=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b/go.mod h1:vsD4gTJCa9TptPL8sPkXrLZ+hDuNrZCnj29CQpr4X1E=
@@ -1498,6 +1502,8 @@ golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83 h1:/ZScEX8SfEmUGRHs0gxpqteO5nfNW6axyZbBdw9A12g=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2 h1:It14KIkyBFYkHkwZ7k45minvA9aorojkyjGk9KJ5B/w=
+golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20180807140117-3d87b88a115f/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -35,10 +35,7 @@ func CreateClient(cfg *Config, promMetrics *api.Metrics) (*pgclient.Client, erro
 	// that upgrading TimescaleDB will not break existing connectors.
 	// (upgrading the DB will force-close all existing connections, so we may
 	// add a reconnect check that the DB has an appropriate version)
-	connStr, err := cfg.PgmodelCfg.GetConnectionStr()
-	if err != nil {
-		return nil, err
-	}
+	connStr := cfg.PgmodelCfg.GetConnectionStr()
 	extOptions := extension.ExtensionMigrateOptions{
 		Install:           cfg.InstallExtensions,
 		Upgrade:           cfg.UpgradeExtensions,
@@ -213,10 +210,7 @@ func initElector(cfg *Config, metrics *api.Metrics) (*util.Elector, error) {
 		return nil, fmt.Errorf("Prometheus timeout configuration must be set when using PG advisory lock")
 	}
 
-	connStr, err := cfg.PgmodelCfg.GetConnectionStr()
-	if err != nil {
-		return nil, err
-	}
+	connStr := cfg.PgmodelCfg.GetConnectionStr()
 	lock, err := util.NewPgLeaderLock(cfg.HaGroupLockID, connStr, getSchemaLease)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating advisory lock\nhaGroupLockId: %d\nerr: %s\n", cfg.HaGroupLockID, err)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -27,7 +27,11 @@ var (
 
 func Run(cfg *Config) error {
 	log.Info("msg", "Version:"+version.Promscale+"; Commit Hash: "+version.CommitHash)
-	log.Info("config", util.MaskPassword(fmt.Sprintf("%+v", cfg)))
+
+	redacted := *cfg
+	redacted.PgmodelCfg.Password = "****"
+	redacted.PgmodelCfg.DbUri = "****"
+	log.Info("config", fmt.Sprintf("%+v", redacted))
 
 	if cfg.APICfg.ReadOnly {
 		log.Info("msg", "Migrations disabled for read-only mode")
@@ -37,7 +41,7 @@ func Run(cfg *Config) error {
 
 	client, err := CreateClient(cfg, promMetrics)
 	if err != nil {
-		log.Error("msg", "aborting startup due to error", "err", util.MaskPassword(err.Error()))
+		log.Error("msg", "aborting startup due to error", "err", err.Error())
 		return startupError
 	}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -8,22 +8,13 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
 )
 
 const (
-	PromNamespace              = "promscale"
-	maskPasswordReplaceString1 = "password$1$2$3****$5"
-	/* #nosec */
-	maskPasswordReplaceString2 = "postgres$1://$2****@"
-)
-
-var (
-	maskPasswordRegex1 = regexp.MustCompile(`[p|P]assword(:|=)(\s*)('?)(.*?)('|(&|\s*)\w+[:|=]{1}|$)`)
-	maskPasswordRegex2 = regexp.MustCompile(`postgres([^:]*)://(([^:]*\:){1})([^@]*)@`)
+	PromNamespace = "promscale"
 )
 
 //ThroughputCalc runs on scheduled interval to calculate the throughput per second and sends results to a channel
@@ -76,12 +67,6 @@ func (dt *ThroughputCalc) Start() {
 			}
 		}()
 	}
-}
-
-// MaskPassword is used to mask sensitive password data before outputing to persistent stream like logs.
-func MaskPassword(s string) string {
-	s = maskPasswordRegex1.ReplaceAllString(s, maskPasswordReplaceString1)
-	return maskPasswordRegex2.ReplaceAllString(s, maskPasswordReplaceString2)
 }
 
 // ParseEnv takes a prefix string p and *flag.FlagSet. Each flag

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -63,47 +63,6 @@ func TestThroughputCalc(t *testing.T) {
 	}
 }
 
-func TestMaskPassword(t *testing.T) {
-	testData := map[string]string{
-		"password='foobar' host='localhost'":                                                   "password='****' host='localhost'",
-		"password='foobar&' host='localhost'":                                                  "password='****' host='localhost'",
-		"password='foo bar' host='localhost'":                                                  "password='****' host='localhost'",
-		"Password='foo bar' host='localhost'":                                                  "password='****' host='localhost'",
-		"password='foo'bar' host='localhost'":                                                  "password='****'bar' host='localhost'",
-		"password= 'foobar' host='localhost'":                                                  "password= '****' host='localhost'",
-		"password=  'foobar' host='localhost'":                                                 "password=  '****' host='localhost'",
-		"pass='foobar' host='localhost'":                                                       "pass='foobar' host='localhost'",
-		"host='localhost' password='foobar'":                                                   "host='localhost' password='****'",
-		"password:foobar  host: localhost":                                                     "password:****  host: localhost",
-		"password:foo bar  host: localhost":                                                    "password:****  host: localhost",
-		"password: foobar  host: localhost":                                                    "password: ****  host: localhost",
-		"password:  foobar  host: localhost":                                                   "password:  ****  host: localhost",
-		"password:  foobar&  host: localhost":                                                  "password:  ****  host: localhost",
-		"password:  foobar with spaces host: localhost":                                        "password:  **** host: localhost",
-		"password: foobar with spaces host: localhost":                                         "password: **** host: localhost",
-		"password:foobar with spaces host: localhost":                                          "password:**** host: localhost",
-		"password:\"foo bar\" host: localhost":                                                 "password:**** host: localhost",
-		"Password: \"foo bar\" host: localhost":                                                "password: **** host: localhost",
-		"pass:foobar host: localhost":                                                          "pass:foobar host: localhost",
-		"host: localhost password: foobar":                                                     "host: localhost password: ****",
-		"host: localhost Password: foobar":                                                     "host: localhost password: ****",
-		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword":               "postgres://localhost:5432/postgres?sslmode=allow&password=****",
-		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword&":              "postgres://localhost:5432/postgres?sslmode=allow&password=****",
-		"postgres://localhost:5432/postgres?password=testpassword&sslmode=allow":               "postgres://localhost:5432/postgres?password=****&sslmode=allow",
-		"postgres://localhost:5432/postgres?sslmode=allow&password=testpassword&user=postgres": "postgres://localhost:5432/postgres?sslmode=allow&password=****&user=postgres",
-		"postgres://postgres:password@localhost:5432/postgres?sslmode=allow":                   "postgres://postgres:****@localhost:5432/postgres?sslmode=allow",
-		"postgresql://admin:ohnomypassword@some.domain.name:5432/postgres?sslmode=allow":       "postgresql://admin:****@some.domain.name:5432/postgres?sslmode=allow",
-		"&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: password SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:postgres://postgres:password@localhost:5432/postgres?sslmode=allow} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}": "&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: **** SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:postgres://postgres:****@localhost:5432/postgres?sslmode=allow} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}",
-		"&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: pass SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}":                                                                       "&{ListenAddr::9201 PgmodelCfg:{Host:localhost Port:5432 User:postgres password: **** SslMode:require DbConnectRetries:0 AsyncAcks:false ReportInterval:0 LabelsCacheSize:10000 MetricsCacheSize:10000 SeriesCacheSize:0 WriteConnectionsPerProc:4 MaxConnections:-1 UsesHA:false DbUri:} LogCfg:{Level:debug Format:logfmt} APICfg:{AllowedOrigin:^(?:.*)$ ReadOnly:false AdminAPIEnabled:false TelemetryPath:/metrics Auth:0xc0000a6690} TLSCertFile: TLSKeyFile: HaGroupLockID:0 PrometheusTimeout:-1ns ElectionInterval:5s Migrate:true StopAfterMigrate:false UseVersionLease:true InstallTimescaleDB:true}",
-	}
-
-	for input, expected := range testData {
-		if output := MaskPassword(input); expected != output {
-			t.Errorf("Unexpected masking output for case \"%s\":\ngot    %s\nwanted %s\n", input, output, expected)
-		}
-	}
-}
-
 type flagValues struct {
 	First  string
 	Second string


### PR DESCRIPTION
We have had some issues while trying to correctly mask logged
passwords supplied by the user. This change removes the utility
function used to mask them and using more reliable ways to redact
sensitive connection data. Since `pgconn` is now redacting password
data itself when trying to parse connection strings, we don't need
to manually mask the output errors ourselves.

Fixes #645, #641