### PR TITLE
Fix bad check for error in MetricTableName

### DIFF
--- a/pkg/pgmodel/ingestor/metric_batcher_test.go
+++ b/pkg/pgmodel/ingestor/metric_batcher_test.go
@@ -1,0 +1,78 @@
+package ingestor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/timescale/promscale/pkg/pgmodel/model"
+)
+
+func TestMetricTableName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		tableName   string
+		errExpected bool
+		sqlQueries  []model.SqlQuery
+	}{
+		{
+			name:      "no error",
+			tableName: "res1",
+			sqlQueries: []model.SqlQuery{
+				{
+					Sql:     "SELECT table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
+					Args:    []interface{}{"t1"},
+					Results: model.RowResults{{"res1", true}},
+				},
+			},
+		},
+		{
+			name:      "no error2",
+			tableName: "res2",
+			sqlQueries: []model.SqlQuery{
+				{
+					Sql:     "SELECT table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
+					Args:    []interface{}{"t1"},
+					Results: model.RowResults{{"res2", true}},
+				},
+			},
+		},
+		{
+			name:        "error",
+			tableName:   "res1",
+			errExpected: true,
+			sqlQueries: []model.SqlQuery{
+				{
+					Sql:  "SELECT table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
+					Args: []interface{}{"t1"},
+					Err:  fmt.Errorf("test"),
+				},
+			},
+		},
+		{
+			name:        "empty table name",
+			tableName:   "res2",
+			errExpected: true,
+			sqlQueries: []model.SqlQuery{
+				{
+					Sql:     "SELECT table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
+					Args:    []interface{}{"t1"},
+					Results: model.RowResults{{"", true}},
+				},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+			mock := model.NewSqlRecorder(c.sqlQueries, t)
+
+			name, _, err := metricTableName(mock, "t1")
+			require.Equal(t, c.errExpected, err != nil)
+
+			if err == nil {
+				require.Equal(t, c.tableName, name)
+			}
+		})
+	}
+}

--- a/pkg/tests/end_to_end_tests/concurrent_sql_test.go
+++ b/pkg/tests/end_to_end_tests/concurrent_sql_test.go
@@ -23,11 +23,11 @@ import (
 func testConcurrentMetricTable(t testing.TB, db *pgxpool.Pool, metricName string) int64 {
 	var id *int64
 	var name *string
-	err := db.QueryRow(context.Background(), "SELECT id, table_name FROM _prom_catalog.create_metric_table($1)", metricName).Scan(&id, &name)
+	err := db.QueryRow(context.Background(), "SELECT id, table_name FROM _prom_catalog.get_or_create_metric_table_name($1)", metricName).Scan(&id, &name)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if id == nil || name == nil {
+	if id == nil || name == nil || *name == "" {
 		t.Fatalf("NULL found")
 	}
 	return *id


### PR DESCRIPTION
Previously, bad error checking logic in MetricTableName could
have returned a blank table name on error which eventually
led to the following postgres error:

"ERROR: zero-length delimited identifier at or near \"\"\"\" (SQLSTATE 42601)"

As reported in issue #668

This fixes that and adds defensive checks to avoid blank table name.

It's not clear what the underlying error was though.