### PR TITLE
Adds support for TimescaleDB nighty smoke tests.

### DIFF
--- a/.github/workflows/go-scheduled.yml
+++ b/.github/workflows/go-scheduled.yml
@@ -100,11 +100,13 @@ jobs:
     strategy:
       matrix:
         test-setups:
-        - {name: "Multinode",               ext: true,  tsdb: true,  tsdb2: true,  multi: true,  pg: 13}
-        - {name: "W/O Promscale Extension", ext: false, tsdb: true,  tsdb2: true,  multi: false, pg: 13}
-        - {name: "Plain Postgres",          ext: false, tsdb: false, tsdb2: false, multi: false, pg: 13}
-        - {name: "Timescaledb 1.x (pg 12)", ext: true,  tsdb: true,  tsdb2: false, multi: false, pg: 12}
-        - {name: "Plain Postgres (12)",     ext: false, tsdb: false, tsdb2: false, multi: false, pg: 12}
+        - {name: "Multinode",                             ext: true,  tsdb: true,  tsdb2: true,  multi: true,  pg: 13, nightly: false}
+        - {name: "W/O Promscale Extension",               ext: false, tsdb: true,  tsdb2: true,  multi: false, pg: 13, nightly: false}
+        - {name: "Plain Postgres",                        ext: false, tsdb: false, tsdb2: false, multi: false, pg: 13, nightly: false}
+        - {name: "Timescaledb 1.x (pg 12)",               ext: true,  tsdb: true,  tsdb2: false, multi: false, pg: 12, nightly: false}
+        - {name: "Plain Postgres (12)",                   ext: false, tsdb: false, tsdb2: false, multi: false, pg: 12, nightly: false}
+        - {name: "TimescaleDB Nightly (PG-13)",            ext: false, tsdb: true,  tsdb2: true,  multi: false, pg: 13, nightly: true}
+        - {name: "TimescaleDB-Multinode Nightly (PG-13)",  ext: false, tsdb: true,  tsdb2: true,  multi: true,  pg: 13, nightly: true}
     steps:
 
     - name: Set up Go 1.14
@@ -134,9 +136,10 @@ jobs:
 
     - name: Test ${{ matrix.test-setups.name }}
       env:
+        PG: ${{ matrix.test-setups.pg }}
         EXT: ${{ matrix.test-setups.ext }}
         TSDB: ${{ matrix.test-setups.tsdb }}
         TSDB2: ${{ matrix.test-setups.tsdb2 }}
         MULTI: ${{ matrix.test-setups.multi }}
-        PG: ${{ matrix.test-setups.pg }}
-      run: go test ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-multinode=$MULTI -postgres-version-major=$PG
+        NIGHTLY: ${{ matrix.test-setups.nightly }}
+      run: go test ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-multinode=$MULTI -use-timescaledb-nightly=$NIGHTLY -postgres-version-major=$PG

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -143,11 +143,11 @@ jobs:
 
     - name: Test ${{ matrix.test-setups.name }}
       env:
+        PG: ${{ matrix.test-setups.pg }}
         EXT: ${{ matrix.test-setups.ext }}
         TSDB: ${{ matrix.test-setups.tsdb }}
         TSDB2: ${{ matrix.test-setups.tsdb2 }}
         MULTI: ${{ matrix.test-setups.multi }}
-        PG: ${{ matrix.test-setups.pg }}
         SHORTNAME: ${{ matrix.test-setups.shortname }}
       run: go test -race ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-multinode=$MULTI -postgres-version-major=$PG > $SHORTNAME-test-run.log  2>&1
 

--- a/pkg/tests/end_to_end_tests/main_test.go
+++ b/pkg/tests/end_to_end_tests/main_test.go
@@ -31,17 +31,18 @@ import (
 )
 
 var (
-	testDatabase      = flag.String("database", "tmp_db_timescale_migrate_test", "database to run integration tests on")
-	updateGoldenFiles = flag.Bool("update", false, "update the golden files of this test")
-	useDocker         = flag.Bool("use-docker", true, "start database using a docker container")
-	useExtension      = flag.Bool("use-extension", true, "use the promscale extension")
-	useTimescaleDB    = flag.Bool("use-timescaledb", true, "use TimescaleDB")
-	useTimescale2     = flag.Bool("use-timescale2", true, "use TimescaleDB 2.0")
-	postgresVersion   = flag.Int("postgres-version-major", 13, "Major version of Postgres")
-	useMultinode      = flag.Bool("use-multinode", false, "use TimescaleDB 2.0 Multinode")
-	printLogs         = flag.Bool("print-logs", false, "print TimescaleDB logs")
-	extendedTest      = flag.Bool("extended-test", false, "run extended testing dataset and PromQL queries")
-	logLevel          = flag.String("log-level", "debug", "Logging level")
+	testDatabase          = flag.String("database", "tmp_db_timescale_migrate_test", "database to run integration tests on")
+	updateGoldenFiles     = flag.Bool("update", false, "update the golden files of this test")
+	useDocker             = flag.Bool("use-docker", true, "start database using a docker container")
+	useExtension          = flag.Bool("use-extension", true, "use the promscale extension")
+	useTimescaleDB        = flag.Bool("use-timescaledb", true, "use TimescaleDB")
+	useTimescale2         = flag.Bool("use-timescale2", true, "use TimescaleDB 2.0")
+	postgresVersion       = flag.Int("postgres-version-major", 13, "Major version of Postgres")
+	useMultinode          = flag.Bool("use-multinode", false, "use TimescaleDB 2.0 Multinode")
+	useTimescaleDBNightly = flag.Bool("use-timescaledb-nightly", false, "use TimescaleDB nightly images")
+	printLogs             = flag.Bool("print-logs", false, "print TimescaleDB logs")
+	extendedTest          = flag.Bool("extended-test", false, "run extended testing dataset and PromQL queries")
+	logLevel              = flag.String("log-level", "debug", "Logging level")
 
 	pgContainer            testcontainers.Container
 	pgContainerTestDataDir string
@@ -74,7 +75,11 @@ func setExtensionState() {
 
 	if *useTimescale2 {
 		*useTimescaleDB = true
-		extensionState.UseTimescale2()
+		extensionState.UseTimescaleDB2()
+	}
+
+	if *useTimescaleDBNightly {
+		extensionState.UseTimescaleNightly()
 	}
 
 	if *useMultinode {

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 	var code int
 	flag.Parse()
 	baseExtensionState.UseTimescaleDB()
-	baseExtensionState.UseTimescale2()
+	baseExtensionState.UseTimescaleDB2()
 	baseExtensionState.UsePG12()
 	if *useExtension {
 		baseExtensionState.UsePromscale()


### PR DESCRIPTION
Signed-off-by: Harkishen Singh <harkishensingh@hotmail.com>

This PR adds support for smoke testing Promscale against nighty builds of TimescaleDB, both in regular and multi-node modes.