### PR TITLE
Allow pushdown of multiple clauses in a single query

### DIFF
--- a/pkg/promql/engine.go
+++ b/pkg/promql/engine.go
@@ -586,7 +586,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 	}
 	defer querier.Close()
 
-	topNode := ng.populateSeries(querier, s)
+	topNodes := ng.populateSeries(querier, s)
 	prepareSpanTimer.Finish()
 
 	// Modify the offset of vector and matrix selectors for the @ modifier
@@ -604,7 +604,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 			maxSamples:               ng.maxSamplesPerQuery,
 			logger:                   ng.logger,
 			lookbackDelta:            ng.lookbackDelta,
-			topNode:                  topNode,
+			topNodes:                 topNodes,
 			noStepSubqueryIntervalFn: ng.noStepSubqueryIntervalFn,
 		}
 
@@ -656,7 +656,7 @@ func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *parser.Eval
 		logger:                   ng.logger,
 		lookbackDelta:            ng.lookbackDelta,
 		noStepSubqueryIntervalFn: ng.noStepSubqueryIntervalFn,
-		topNode:                  topNode,
+		topNodes:                 topNodes,
 	}
 	val, warnings, err := evaluator.Eval(s.Expr)
 	if err != nil {
@@ -780,14 +780,13 @@ func (ng *Engine) getTimeRangesForSelector(s *parser.EvalStmt, n *parser.VectorS
 	return start, end
 }
 
-func (ng *Engine) populateSeries(querier Querier, s *parser.EvalStmt) parser.Node {
+func (ng *Engine) populateSeries(querier Querier, s *parser.EvalStmt) map[parser.Node]struct{} {
 	var (
 		// Whenever a MatrixSelector is evaluated, evalRange is set to the corresponding range.
 		// The evaluation of the VectorSelector inside then evaluates the given range and unsets
 		// the variable.
-		set       storage.SeriesSet
 		evalRange time.Duration
-		topNode   parser.Node
+		topNodes  map[parser.Node]struct{} = make(map[parser.Node]struct{})
 	)
 
 	parser.Inspect(s.Expr, func(node parser.Node, path []parser.Node) error {
@@ -803,19 +802,17 @@ func (ng *Engine) populateSeries(querier Querier, s *parser.EvalStmt) parser.Nod
 				Func:  extractFuncFromPath(path),
 			}
 
-			/* Only do pushdowns if we don't already have a pushdown. We can't do multiple pushdowns in a single query yet */
-			if topNode == nil {
-				qh = &mq.QueryHints{
-					StartTime:   s.Start,
-					EndTime:     s.End,
-					CurrentNode: n,
-					Lookback:    ng.lookbackDelta,
-				}
+			qh = &mq.QueryHints{
+				StartTime:   s.Start,
+				EndTime:     s.End,
+				CurrentNode: n,
+				Lookback:    ng.lookbackDelta,
 			}
 			evalRange = 0
 			hints.By, hints.Grouping = extractGroupsFromPath(path)
 
-			set, topNode = querier.Select(false, hints, qh, path, n.LabelMatchers...)
+			set, topNode := querier.Select(false, hints, qh, path, n.LabelMatchers...)
+			topNodes[topNode] = struct{}{}
 			n.UnexpandedSeriesSet = set
 
 		case *parser.MatrixSelector:
@@ -823,7 +820,7 @@ func (ng *Engine) populateSeries(querier Querier, s *parser.EvalStmt) parser.Nod
 		}
 		return nil
 	})
-	return topNode
+	return topNodes
 }
 
 // extractFuncFromPath walks up the path and searches for the first instance of
@@ -905,7 +902,7 @@ type evaluator struct {
 	currentSamples           int64
 	logger                   log.Logger
 	lookbackDelta            time.Duration
-	topNode                  parser.Node
+	topNodes                 map[parser.Node]struct{}
 	noStepSubqueryIntervalFn func(rangeMillis int64) int64
 }
 
@@ -1244,7 +1241,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, storage.Warnings) {
 	span, _ := opentracing.StartSpanFromContext(ev.ctx, stats.InnerEvalTime.SpanOperation()+" eval "+reflect.TypeOf(expr).String())
 	defer span.Finish()
 
-	if expr == ev.topNode {
+	if _, isTopNode := ev.topNodes[expr]; isTopNode {
 		/* the storage layer has already processed this node. Just return
 		the result. */
 		var (

--- a/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
@@ -2472,6 +2472,18 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 			name:  "rollup",
 			query: "count by (env)(up)",
 		},
+		{
+			name:  "two pushdowns",
+			query: "rate(metric_2[5m])/rate(metric_3[5m])",
+		},
+		{
+			name:  "two pushdowns with sum",
+			query: "sum(rate(metric_2[5m]))/sum(rate(metric_3[5m]))",
+		},
+		{
+			name:  "two pushdowns, same metric different matchers",
+			query: `sum(rate(metric_2{foo = "bar"}[5m]))/sum(rate(metric_2[5m]))`,
+		},
 	}
 	start := time.Unix(startTime/1000, 0)
 	end := time.Unix(endTime/1000, 0)


### PR DESCRIPTION
This is especially important for comparitive queries like:

sum(rate(requests{error="true"})) / sum(rate(requests))