### PR TITLE
Add support for promscale ext 0.2.x

### DIFF
--- a/pkg/pgmodel/querier/query_builder.go
+++ b/pkg/pgmodel/querier/query_builder.go
@@ -471,8 +471,8 @@ func calledByTimestamp(path []parser.Node) bool {
 	return false
 }
 
-var vectorSelectorExtensionRange = semver.MustParseRange(">= 0.1.3-beta")
-var rateIncreaseExtensionRange = semver.MustParseRange(">= 0.1.3-beta")
+var vectorSelectorExtensionRange = semver.MustParseRange(">= 0.2.0")
+var rateIncreaseExtensionRange = semver.MustParseRange(">= 0.2.0")
 
 func callAggregator(hints *storage.SelectHints, funcName string) (*aggregators, error) {
 	queryStart := hints.Start + hints.Range

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -59,7 +59,8 @@ var (
 	TimescaleVersionRange           = timescaleVersionSafeRange.OR(timescaleVersionWarnRange)
 
 	// ExtVersionRangeString is a range of required promscale extension versions
-	ExtVersionRangeString = "=0.1.x"
+	// support 0.1.x and 0.2.x
+	ExtVersionRangeString = ">=0.1.0 <0.2.99"
 	ExtVersionRange       = semver.MustParseRange(ExtVersionRangeString)
 )
 


### PR DESCRIPTION
This is the newest version of the extension.
Start support for pushdowns of vector selector
and rate/increase with this version as the
beta had some correctness issues with rate/increase.