### PR TITLE
Remove promscale extension building from CI process

### DIFF
--- a/.github/workflows/go-scheduled.yml
+++ b/.github/workflows/go-scheduled.yml
@@ -30,9 +30,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Build extension image
-      run: git clone https://github.com/timescale/promscale_extension && cd promscale_extension && make -f DockerMakefile docker-image
-
     - name: Get dependencies
       run: |
         go get -v -t -d ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,9 +30,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Build extension image
-      run: git clone https://github.com/timescale/promscale_extension && cd promscale_extension && make -f DockerMakefile docker-image
-
     - name: Get dependencies
       run: |
         go get -v -t -d ./...


### PR DESCRIPTION
Promscale extension was a part of the Promscale repo in the past, that
is the reason why we were running extension building in our CI process.
Removing will speed up the Promscale CI process considerably and the
extension building will be moved to extension repo.