### PR TITLE
Change warning log to debug log 

### DIFF
--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -150,11 +150,10 @@ func CreateClient(cfg *Config, promMetrics *api.Metrics) (*pgclient.Client, erro
 		return nil, fmt.Errorf("elector init error: %w", err)
 	}
 
-	if elector == nil && !cfg.APICfg.ReadOnly {
-		log.Warn(
+	if (elector == nil && !cfg.APICfg.HighAvailability) && !cfg.APICfg.ReadOnly {
+		log.Info(
 			"msg",
-			"No adapter leader election. Group lock id is not set. "+
-				"Possible duplicate write load if running multiple connectors",
+			"Prometheus HA is not enabled",
 		)
 	}
 


### PR DESCRIPTION
Move warning log to debug log, as it confuses the users. On Promscale start-up users see the warning log by default stating the older HA system is disabled. 

`
level=warn ts=2021-07-28T17:31:24.279Z caller=client.go:154 msg="No adapter leader election. Group lock id is not set. Possible duplicate write load if running multiple connectors"
`