### PR TITLE
Move series creation to copier

### DIFF
--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -169,8 +169,8 @@ func (cfg *Config) GetNumConnections() (min int, max int, numCopiers int, err er
 		}
 		// we try to only use 80% the database connections, capped at 50
 		max = int(0.8 * float32(max))
-		if max > 50 {
-			max = 50
+		if max > 100 {
+			max = 100
 		}
 	}
 
@@ -187,7 +187,7 @@ func (cfg *Config) GetNumConnections() (min int, max int, numCopiers int, err er
 	// we try to leave one connection per-core for non-copier usages, otherwise using half the connections.
 	if numCopiers > max-maxProcs {
 		log.Warn("msg", fmt.Sprintf("had to reduce the number of copiers due to connection limits: wanted %v, reduced to %v", numCopiers, max/2))
-		numCopiers = max / 2
+		numCopiers = max - maxProcs
 	}
 	return
 }

--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -100,7 +100,11 @@ func runCopier(conn pgxconn.PgxConn, in chan copyRequest, sw *seriesWriter) {
 
 		err := sw.WriteSeries(copyBatch(insertBatch))
 		if err != nil {
-			fmt.Println(err)
+			for i := range insertBatch {
+				insertBatch[i].data.reportResults(err)
+				insertBatch[i].data.release()
+			}
+			return
 		}
 
 		doInsertOrFallback(conn, insertBatch...)

--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -34,9 +34,32 @@ var (
 	handleDecompression = retryAfterDecompression
 )
 
+type copyBatch []copyRequest
+
+func (c copyBatch) VisitSeries(cb func(s *pgmodel.Series) error) error {
+	for _, req := range c {
+		samples := req.data.batch.GetSeriesSamples()
+		for _, sample := range samples {
+			err := cb(sample.GetSeries())
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c copyBatch) NumSeries() int {
+	i := 0
+	for _, req := range c {
+		i += len(req.data.batch.GetSeriesSamples())
+	}
+	return i
+}
+
 // Handles actual insertion into the DB.
 // We have one of these per connection reserved for insertion.
-func runCopier(conn pgxconn.PgxConn, in chan copyRequest) {
+func runCopier(conn pgxconn.PgxConn, in chan copyRequest, sw *seriesWriter) {
 	// We grab copyRequests off the channel one at a time. This, and the name is
 	// a legacy from when we used CopyFrom to perform the insertions, and may
 	// change in the future.
@@ -74,6 +97,11 @@ func runCopier(conn pgxconn.PgxConn, in chan copyRequest) {
 			}
 		}
 		insertBatch = insertBatch[:dst+1]
+
+		err := sw.WriteSeries(copyBatch(insertBatch))
+		if err != nil {
+			fmt.Println(err)
+		}
 
 		doInsertOrFallback(conn, insertBatch...)
 		for i := range insertBatch {

--- a/pkg/pgmodel/ingestor/handler_test.go
+++ b/pkg/pgmodel/ingestor/handler_test.go
@@ -19,6 +19,10 @@ func getSeries(t *testing.T, scache *cache.SeriesCacheImpl, labels labels.Labels
 	return series
 }
 
+func makeLabelKey(l labels.Label) labelKey {
+	return labelKey{MetricName: "metric", Name: l.Name, Value: l.Value}
+}
+
 func TestLabelArrayCreator(t *testing.T) {
 	scache := cache.NewSeriesCache(cache.DefaultConfig, nil)
 	metricNameLabel := labels.Label{Name: "__name__", Value: "metric"}
@@ -27,9 +31,9 @@ func TestLabelArrayCreator(t *testing.T) {
 	seriesSet := []*model.Series{
 		getSeries(t, scache, labels.Labels{metricNameLabel, valOne}),
 	}
-	labelMap := map[labels.Label]labelInfo{
-		metricNameLabel: {2, 1},
-		valOne:          {3, 2},
+	labelMap := map[labelKey]labelInfo{
+		makeLabelKey(metricNameLabel): {2, 1},
+		makeLabelKey(valOne):          {3, 2},
 	}
 
 	res, _, err := createLabelArrays(seriesSet, labelMap, 2)
@@ -42,7 +46,7 @@ func TestLabelArrayCreator(t *testing.T) {
 	expected = [][]int32{{2, 3}}
 	require.Equal(t, res, expected)
 
-	labelMap[valOne] = labelInfo{3, 3}
+	labelMap[makeLabelKey(valOne)] = labelInfo{3, 3}
 	res, _, err = createLabelArrays(seriesSet, labelMap, 3)
 	require.NoError(t, err)
 	expected = [][]int32{{2, 0, 3}}
@@ -53,10 +57,10 @@ func TestLabelArrayCreator(t *testing.T) {
 		getSeries(t, scache, labels.Labels{metricNameLabel, valOne}),
 		getSeries(t, scache, labels.Labels{metricNameLabel, valTwo}),
 	}
-	labelMap = map[labels.Label]labelInfo{
-		metricNameLabel: {100, 1},
-		valOne:          {1, 5},
-		valTwo:          {2, 5},
+	labelMap = map[labelKey]labelInfo{
+		makeLabelKey(metricNameLabel): {100, 1},
+		makeLabelKey(valOne):          {1, 5},
+		makeLabelKey(valTwo):          {2, 5},
 	}
 
 	res, ser, err := createLabelArrays(seriesSet, labelMap, 5)
@@ -75,10 +79,10 @@ func TestLabelArrayCreator(t *testing.T) {
 		getSeries(t, scache, labels.Labels{metricNameLabel, valOne}),
 		setSeries,
 	}
-	labelMap = map[labels.Label]labelInfo{
-		metricNameLabel: {100, 1},
-		valOne:          {1, 5},
-		valTwo:          {2, 5},
+	labelMap = map[labelKey]labelInfo{
+		makeLabelKey(metricNameLabel): {100, 1},
+		makeLabelKey(valOne):          {1, 5},
+		makeLabelKey(valTwo):          {2, 5},
 	}
 	res, ser, err = createLabelArrays(seriesSet, labelMap, 5)
 	require.NoError(t, err)

--- a/pkg/pgmodel/ingestor/metric_batcher.go
+++ b/pkg/pgmodel/ingestor/metric_batcher.go
@@ -8,19 +8,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jackc/pgtype"
-	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/timescale/promscale/pkg/log"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/pgmodel/common/errors"
 	"github.com/timescale/promscale/pkg/pgmodel/common/schema"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
-	"github.com/timescale/promscale/pkg/pgmodel/model/pgutf8str"
 	"github.com/timescale/promscale/pkg/pgxconn"
 )
 
 const (
-	seriesInsertSQL                 = "SELECT (_prom_catalog.get_or_create_series_id_for_label_array($1, l.elem)).series_id, l.nr FROM unnest($2::prom_api.label_array[]) WITH ORDINALITY l(elem, nr) ORDER BY l.elem"
 	getCreateMetricsTableWithNewSQL = "SELECT table_name, possibly_new FROM " + schema.Catalog + ".get_or_create_metric_table_name($1)"
 )
 
@@ -30,7 +26,6 @@ type metricBatcher struct {
 	pending         *pendingBuffer
 	metricTableName string
 	toCopiers       chan<- copyRequest
-	labelArrayOID   uint32
 }
 
 func metricTableName(conn pgxconn.PgxConn, metric string) (string, bool, error) {
@@ -138,7 +133,6 @@ func runMetricBatcher(conn pgxconn.PgxConn,
 		pending:         NewPendingBuffer(),
 		metricTableName: tableName,
 		toCopiers:       toCopiers,
-		labelArrayOID:   labelArrayOID,
 	}
 
 	handler.handleReq(firstReq)
@@ -210,269 +204,7 @@ func (h *metricBatcher) flush() {
 
 // Set all unset SeriesIds and flush to the next layer
 func (h *metricBatcher) flushPending() {
-	err := h.setSeriesIds(h.pending.batch.GetSeriesSamples())
-	if err != nil {
-		h.pending.reportResults(err)
-		h.pending.release()
-		h.pending = NewPendingBuffer()
-		return
-	}
-
 	MetricBatcherFlushSeries.Observe(float64(h.pending.batch.CountSeries()))
 	h.toCopiers <- copyRequest{h.pending, h.metricTableName}
 	h.pending = NewPendingBuffer()
-}
-
-type labelInfo struct {
-	labelID int32
-	Pos     int32
-}
-
-func labelArrayTranscoder() pgtype.ValueTranscoder { return &pgtype.Int4Array{} }
-
-// Set all seriesIds for a samplesInfo, fetching any missing ones from the DB,
-// and repopulating the cache accordingly.
-// returns: the tableName for the metric being inserted into
-// TODO move up to the rest of insertHandler
-func (h *metricBatcher) setSeriesIds(seriesSamples []model.Samples) error {
-	seriesToInsert := make([]*model.Series, 0, len(seriesSamples))
-	for i, series := range seriesSamples {
-		if !series.GetSeries().IsSeriesIDSet() {
-			seriesToInsert = append(seriesToInsert, seriesSamples[i].GetSeries())
-		}
-	}
-	if len(seriesToInsert) == 0 {
-		return nil
-	}
-
-	metricName := seriesToInsert[0].MetricName()
-	labelMap := make(map[labels.Label]labelInfo, len(seriesToInsert))
-	labelList := model.NewLabelList(len(seriesToInsert))
-	//logically should be a separate function but we want
-	//to prevent labelMap from escaping, so keeping inline.
-	{
-		for _, series := range seriesToInsert {
-			names, values, ok := series.NameValues()
-			if !ok {
-				//was already set
-				continue
-			}
-			for i := range names {
-				key := labels.Label{Name: names[i], Value: values[i]}
-				_, ok = labelMap[key]
-				if !ok {
-					labelMap[key] = labelInfo{}
-					if err := labelList.Add(names[i], values[i]); err != nil {
-						return fmt.Errorf("failed to add label to labelList: %w", err)
-					}
-				}
-			}
-		}
-	}
-	if len(labelMap) == 0 {
-		return nil
-	}
-
-	//labels have to be created before series are since we need a canonical
-	//ordering for label creation to avoid deadlocks. Otherwise, if we create
-	//the labels for multiple series in same txn as we are creating the series,
-	//the ordering of label creation can only be canonical within a series and
-	//not across series.
-	dbEpoch, maxPos, err := h.fillLabelIDs(metricName, labelList, labelMap)
-	if err != nil {
-		return fmt.Errorf("Error setting series ids: %w", err)
-	}
-
-	//create the label arrays
-	labelArraySet, seriesToInsert, err := createLabelArrays(seriesToInsert, labelMap, maxPos)
-	if err != nil {
-		return fmt.Errorf("Error setting series ids: %w", err)
-	}
-	if len(labelArraySet) == 0 {
-		return nil
-	}
-
-	labelArrayArray := pgtype.NewArrayType("prom_api.label_array[]", h.labelArrayOID, labelArrayTranscoder)
-	err = labelArrayArray.Set(labelArraySet)
-	if err != nil {
-		return fmt.Errorf("Error setting series id: cannot set label_array: %w", err)
-	}
-	res, err := h.conn.Query(context.Background(), seriesInsertSQL, metricName, labelArrayArray)
-	if err != nil {
-		return fmt.Errorf("Error setting series_id: cannot query for series_id: %w", err)
-	}
-	defer res.Close()
-
-	count := 0
-	for res.Next() {
-		var (
-			id         model.SeriesID
-			ordinality int64
-		)
-		err := res.Scan(&id, &ordinality)
-		if err != nil {
-			return fmt.Errorf("Error setting series_id: cannot scan series_id: %w", err)
-		}
-		seriesToInsert[int(ordinality)-1].SetSeriesID(id, dbEpoch)
-		count++
-	}
-	if err := res.Err(); err != nil {
-		return fmt.Errorf("Error setting series_id: reading series id rows: %w", err)
-	}
-	if count != len(seriesToInsert) {
-		//This should never happen according to the logic. This is purely defensive.
-		//panic since we may have set the seriesID incorrectly above and may
-		//get data corruption if we continue.
-		panic(fmt.Sprintf("number series returned %d doesn't match expected series %d", count, len(seriesToInsert)))
-	}
-	return nil
-}
-
-func (h *metricBatcher) fillLabelIDs(metricName string, labelList *model.LabelList, labelMap map[labels.Label]labelInfo) (model.SeriesEpoch, int, error) {
-	//we cannot use the label cache here because that maps label ids => name, value.
-	//what we need here is name, value => id.
-	//we may want a new cache for that, at a later time.
-
-	batch := h.conn.NewBatch()
-	var dbEpoch model.SeriesEpoch
-	maxPos := 0
-
-	names, values := labelList.Get()
-	items := len(names.Elements)
-	if items != len(labelMap) {
-		return dbEpoch, 0, fmt.Errorf("Error filling labels: number of items in labelList and labelMap doesn't match")
-	}
-	// The epoch will never decrease, so we can check it once at the beginning,
-	// at worst we'll store too small an epoch, which is always safe
-	batch.Queue("BEGIN;")
-	batch.Queue(getEpochSQL)
-	batch.Queue("COMMIT;")
-
-	//getLabels in batches of 1000 to prevent locks on label creation
-	//from being taken for too long.
-	itemsPerBatch := 1000
-	labelBatches := 0
-	for i := 0; i < len(names.Elements); i += itemsPerBatch {
-		labelBatches++
-		high := i + itemsPerBatch
-		if len(names.Elements) < high {
-			high = len(names.Elements)
-		}
-		namesSlice, err := names.Slice(i, high)
-		if err != nil {
-			return dbEpoch, 0, fmt.Errorf("Error filling labels: slicing names: %w", err)
-		}
-		valuesSlice, err := values.Slice(i, high)
-		if err != nil {
-			return dbEpoch, 0, fmt.Errorf("Error filling labels: slicing values: %w", err)
-		}
-		batch.Queue("BEGIN;")
-		batch.Queue("SELECT * FROM "+schema.Catalog+".get_or_create_label_ids($1, $2, $3)", metricName, namesSlice, valuesSlice)
-		batch.Queue("COMMIT;")
-	}
-	br, err := h.conn.SendBatch(context.Background(), batch)
-	if err != nil {
-		return dbEpoch, 0, fmt.Errorf("Error filling labels: %w", err)
-	}
-	defer br.Close()
-
-	if _, err := br.Exec(); err != nil {
-		return dbEpoch, 0, fmt.Errorf("Error filling labels on begin: %w", err)
-	}
-	err = br.QueryRow().Scan(&dbEpoch)
-	if err != nil {
-		return dbEpoch, 0, fmt.Errorf("Error filling labels: %w", err)
-	}
-	if _, err := br.Exec(); err != nil {
-		return dbEpoch, 0, fmt.Errorf("Error filling labels on commit: %w", err)
-	}
-
-	var count int
-	for i := 0; i < labelBatches; i++ {
-		if _, err := br.Exec(); err != nil {
-			return dbEpoch, 0, fmt.Errorf("Error filling labels on begin label batch: %w", err)
-		}
-
-		err := func() error {
-			var (
-				pos         []int32
-				labelIDs    []int32
-				labelNames  pgutf8str.TextArray
-				labelValues pgutf8str.TextArray
-				names       []string
-				values      []string
-			)
-			err := br.QueryRow().Scan(&pos, &labelIDs, &labelNames, &labelValues)
-			if err != nil {
-				return fmt.Errorf("Error filling labels: %w", err)
-			}
-			names = labelNames.Get().([]string)
-			values = labelValues.Get().([]string)
-
-			for i := range pos {
-				res := labelInfo{Pos: pos[i], labelID: labelIDs[i]}
-				key := labels.Label{Name: names[i], Value: values[i]}
-				_, ok := labelMap[key]
-				if !ok {
-					return fmt.Errorf("Error filling labels: getting a key never sent to the db")
-				}
-				labelMap[key] = res
-				if int(res.Pos) > maxPos {
-					maxPos = int(res.Pos)
-				}
-				count++
-			}
-			return nil
-		}()
-		if err != nil {
-			return dbEpoch, 0, err
-		}
-		if _, err := br.Exec(); err != nil {
-			return dbEpoch, 0, fmt.Errorf("Error filling labels on commit label batch: %w", err)
-		}
-	}
-	if count != items {
-		return dbEpoch, 0, fmt.Errorf("Error filling labels: not filling as many items as expected: %v vs %v", count, items)
-	}
-	return dbEpoch, maxPos, nil
-}
-
-func createLabelArrays(series []*model.Series, labelMap map[labels.Label]labelInfo, maxPos int) ([][]int32, []*model.Series, error) {
-	labelArraySet := make([][]int32, 0, len(series))
-	dest := 0
-	for src := 0; src < len(series); src++ {
-		names, values, ok := series[src].NameValues()
-		if !ok {
-			continue
-		}
-		lArray := make([]int32, maxPos)
-		maxIndex := 0
-		for i := range names {
-			key := labels.Label{Name: names[i], Value: values[i]}
-			res, ok := labelMap[key]
-			if !ok {
-				return nil, nil, fmt.Errorf("Error generating label array: missing key in map")
-			}
-			if res.labelID == 0 {
-				return nil, nil, fmt.Errorf("Error generating label array: missing id for label %v=>%v", names[i], values[i])
-			}
-			//Pos is 1-indexed, slices are 0-indexed
-			sliceIndex := int(res.Pos) - 1
-			lArray[sliceIndex] = int32(res.labelID)
-			if sliceIndex > maxIndex {
-				maxIndex = sliceIndex
-			}
-		}
-		lArray = lArray[:maxIndex+1]
-		labelArraySet = append(labelArraySet, lArray)
-		//this logic is needed for when continue is hit above
-		if src != dest {
-			series[dest] = series[src]
-		}
-		dest++
-	}
-	if len(labelArraySet) != len(series[:dest]) {
-		return nil, nil, fmt.Errorf("Error generating label array: lengths not equal")
-	}
-	return labelArraySet, series[:dest], nil
 }

--- a/pkg/pgmodel/ingestor/metric_batcher.go
+++ b/pkg/pgmodel/ingestor/metric_batcher.go
@@ -189,7 +189,7 @@ func (h *metricBatcher) nonblockingHandleReq() bool {
 func (h *metricBatcher) handleReq(req *insertDataRequest) bool {
 	h.pending.addReq(req)
 	if h.pending.IsFull() {
-		h.flushPending()
+		h.tryFlushOrBatchMore()
 		return true
 	}
 	return false
@@ -199,10 +199,10 @@ func (h *metricBatcher) flush() {
 	if h.pending.IsEmpty() {
 		return
 	}
-	h.flushPending()
+	h.tryFlushOrBatchMore()
 }
 
-func (h *metricBatcher) flushPending() {
+func (h *metricBatcher) tryFlushOrBatchMore() {
 	recvChannel := h.input
 	for {
 		if h.pending.IsFull() {

--- a/pkg/pgmodel/ingestor/series_writer.go
+++ b/pkg/pgmodel/ingestor/series_writer.go
@@ -1,0 +1,358 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package ingestor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgtype"
+	"github.com/timescale/promscale/pkg/pgmodel/common/schema"
+	"github.com/timescale/promscale/pkg/pgmodel/model"
+	"github.com/timescale/promscale/pkg/pgmodel/model/pgutf8str"
+	"github.com/timescale/promscale/pkg/pgxconn"
+)
+
+const (
+	seriesInsertSQL = "SELECT (_prom_catalog.get_or_create_series_id_for_label_array($1, l.elem)).series_id, l.nr FROM unnest($2::prom_api.label_array[]) WITH ORDINALITY l(elem, nr) ORDER BY l.elem"
+)
+
+type seriesWriter struct {
+	conn          pgxconn.PgxConn
+	labelArrayOID uint32
+}
+
+type labelInfo struct {
+	labelID int32
+	Pos     int32
+}
+
+type labelKey struct {
+	MetricName, Name, Value string
+}
+
+type SeriesVisitor interface {
+	VisitSeries(func(s *model.Series) error) error
+	NumSeries() int
+}
+
+func labelArrayTranscoder() pgtype.ValueTranscoder { return &pgtype.Int4Array{} }
+
+func NewSeriesWriter(conn pgxconn.PgxConn, labelArrayOID uint32) *seriesWriter {
+	return &seriesWriter{conn, labelArrayOID}
+}
+
+type perMetricInfo struct {
+	metricName             string
+	series                 []*model.Series
+	labelList              *model.LabelList
+	maxPos                 int
+	labelArraySet          *pgtype.ArrayType
+	labelArraySetNumLabels int
+}
+
+// Set all seriesIds for a samples, fetching any missing ones from the DB,
+// and repopulating the cache accordingly.
+func (h *seriesWriter) WriteSeries(sv SeriesVisitor) error {
+	infos := make(map[string]*perMetricInfo)
+	seriesCount := 0
+	err := sv.VisitSeries(func(series *model.Series) error {
+		if !series.IsSeriesIDSet() {
+			metricName := series.MetricName()
+			info, ok := infos[metricName]
+			if !ok {
+				info = &perMetricInfo{metricName: metricName, labelList: model.NewLabelList(10)}
+				infos[metricName] = info
+			}
+			info.series = append(info.series, series)
+			seriesCount++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(infos) == 0 {
+		return nil
+	}
+
+	labelMap := make(map[labelKey]labelInfo, seriesCount)
+	//logically should be a separate function but we want
+	//to prevent labelMap from escaping, so keeping inline.
+	{
+		for _, info := range infos {
+			for _, series := range info.series {
+				names, values, ok := series.NameValues()
+				if !ok {
+					//was already set
+					continue
+				}
+				for i := range names {
+					key := labelKey{MetricName: series.MetricName(), Name: names[i], Value: values[i]}
+					_, ok = labelMap[key]
+					if !ok {
+						labelMap[key] = labelInfo{}
+						if err := info.labelList.Add(names[i], values[i]); err != nil {
+							return fmt.Errorf("failed to add label to labelList: %w", err)
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(labelMap) == 0 {
+		return nil
+	}
+
+	//labels have to be created before series are since we need a canonical
+	//ordering for label creation to avoid deadlocks. Otherwise, if we create
+	//the labels for multiple series in same txn as we are creating the series,
+	//the ordering of label creation can only be canonical within a series and
+	//not across series.
+	dbEpoch, err := h.fillLabelIDs(infos, labelMap)
+	if err != nil {
+		return fmt.Errorf("error setting series ids: %w", err)
+	}
+
+	//create the label arrays
+	err = h.buildLabelArrays(infos, labelMap)
+	if err != nil {
+		return fmt.Errorf("error setting series ids: %w", err)
+	}
+
+	batch := h.conn.NewBatch()
+	batchInfos := make([]*perMetricInfo, 0, len(infos))
+	for metricName, info := range infos {
+		if info.labelArraySetNumLabels == 0 {
+			continue
+		}
+
+		//transaction per metric to avoid cross-metric locks
+		batch.Queue("BEGIN;")
+		batch.Queue(seriesInsertSQL, metricName, info.labelArraySet)
+		batch.Queue("COMMIT;")
+		batchInfos = append(batchInfos, info)
+	}
+	br, err := h.conn.SendBatch(context.Background(), batch)
+	if err != nil {
+		return fmt.Errorf("error inserting series: %w", err)
+	}
+	defer br.Close()
+
+	for _, info := range batchInfos {
+		//begin
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("error setting series_id begin: %w", err)
+		}
+
+		res, err := br.Query()
+		if err != nil {
+			return fmt.Errorf("error setting series_id: cannot query for series_id: %w", err)
+		}
+		defer res.Close()
+
+		count := 0
+		for res.Next() {
+			var (
+				id         model.SeriesID
+				ordinality int64
+			)
+			err := res.Scan(&id, &ordinality)
+			if err != nil {
+				return fmt.Errorf("error setting series_id: cannot scan series_id: %w", err)
+			}
+			info.series[int(ordinality)-1].SetSeriesID(id, dbEpoch)
+			count++
+		}
+		if err := res.Err(); err != nil {
+			return fmt.Errorf("error setting series_id: reading series id rows: %w", err)
+		}
+		if count != len(info.series) {
+			//This should never happen according to the logic. This is purely defensive.
+			//panic since we may have set the seriesID incorrectly above and may
+			//get data corruption if we continue.
+			panic(fmt.Sprintf("number series returned %d doesn't match expected series %d", count, len(info.series)))
+		}
+		//commit
+		if _, err := br.Exec(); err != nil {
+			return fmt.Errorf("error setting series_id commit: %w", err)
+		}
+	}
+	return nil
+}
+
+func (h *seriesWriter) fillLabelIDs(infos map[string]*perMetricInfo, labelMap map[labelKey]labelInfo) (model.SeriesEpoch, error) {
+	//we cannot use the label cache here because that maps label ids => name, value.
+	//what we need here is name, value => id.
+	//we may want a new cache for that, at a later time.
+
+	batch := h.conn.NewBatch()
+	var dbEpoch model.SeriesEpoch
+
+	/*names, values := labelList.Get()
+	items := len(names.Elements)
+	if items != len(labelMap) {
+		return dbEpoch, 0, fmt.Errorf("error filling labels: number of items in labelList and labelMap doesn't match")
+	}*/
+
+	// The epoch will never decrease, so we can check it once at the beginning,
+	// at worst we'll store too small an epoch, which is always safe
+	batch.Queue("BEGIN;")
+	batch.Queue(getEpochSQL)
+	batch.Queue("COMMIT;")
+
+	infoBatches := make([]*perMetricInfo, 0)
+	items := 0
+	for metricName, info := range infos {
+		names, values := info.labelList.Get()
+		//getLabels in batches of 1000 to prevent locks on label creation
+		//from being taken for too long.
+		itemsPerBatch := 1000
+		for i := 0; i < len(names.Elements); i += itemsPerBatch {
+			high := i + itemsPerBatch
+			if len(names.Elements) < high {
+				high = len(names.Elements)
+			}
+			namesSlice, err := names.Slice(i, high)
+			if err != nil {
+				return dbEpoch, fmt.Errorf("error filling labels: slicing names: %w", err)
+			}
+			valuesSlice, err := values.Slice(i, high)
+			if err != nil {
+				return dbEpoch, fmt.Errorf("error filling labels: slicing values: %w", err)
+			}
+			batch.Queue("BEGIN;")
+			batch.Queue("SELECT * FROM "+schema.Catalog+".get_or_create_label_ids($1, $2, $3)", metricName, namesSlice, valuesSlice)
+			batch.Queue("COMMIT;")
+			infoBatches = append(infoBatches, info)
+			items += len(namesSlice.Elements)
+		}
+	}
+	br, err := h.conn.SendBatch(context.Background(), batch)
+	if err != nil {
+		return dbEpoch, fmt.Errorf("error filling labels: %w", err)
+	}
+	defer br.Close()
+
+	if _, err := br.Exec(); err != nil {
+		return dbEpoch, fmt.Errorf("error filling labels on begin: %w", err)
+	}
+	err = br.QueryRow().Scan(&dbEpoch)
+	if err != nil {
+		return dbEpoch, fmt.Errorf("error filling labels: %w", err)
+	}
+	if _, err := br.Exec(); err != nil {
+		return dbEpoch, fmt.Errorf("error filling labels on commit: %w", err)
+	}
+
+	var count int
+	for _, info := range infoBatches {
+		if _, err := br.Exec(); err != nil {
+			return dbEpoch, fmt.Errorf("error filling labels on begin label batch: %w", err)
+		}
+
+		err := func() error {
+			var (
+				pos         []int32
+				labelIDs    []int32
+				labelNames  pgutf8str.TextArray
+				labelValues pgutf8str.TextArray
+				names       []string
+				values      []string
+			)
+			err := br.QueryRow().Scan(&pos, &labelIDs, &labelNames, &labelValues)
+			if err != nil {
+				return fmt.Errorf("error filling labels: %w", err)
+			}
+			names = labelNames.Get().([]string)
+			values = labelValues.Get().([]string)
+
+			for i := range pos {
+				res := labelInfo{Pos: pos[i], labelID: labelIDs[i]}
+				key := labelKey{MetricName: info.metricName, Name: names[i], Value: values[i]}
+				_, ok := labelMap[key]
+				if !ok {
+					return fmt.Errorf("error filling labels: getting a key never sent to the db")
+				}
+				labelMap[key] = res
+				if int(res.Pos) > info.maxPos {
+					info.maxPos = int(res.Pos)
+				}
+				count++
+			}
+			return nil
+		}()
+		if err != nil {
+			return dbEpoch, err
+		}
+		if _, err := br.Exec(); err != nil {
+			return dbEpoch, fmt.Errorf("error filling labels on commit label batch: %w", err)
+		}
+	}
+	if count != items {
+		return dbEpoch, fmt.Errorf("error filling labels: not filling as many items as expected: %v vs %v", count, items)
+	}
+	return dbEpoch, nil
+}
+
+func (h *seriesWriter) buildLabelArrays(infos map[string]*perMetricInfo, labelMap map[labelKey]labelInfo) error {
+	for _, info := range infos {
+		labelArraySet, newSeries, err := createLabelArrays(info.series, labelMap, info.maxPos)
+		if err != nil {
+			return fmt.Errorf("error building label array: cannot create label_array: %w", err)
+		}
+		info.series = newSeries
+		info.labelArraySet = pgtype.NewArrayType("prom_api.label_array[]", h.labelArrayOID, labelArrayTranscoder)
+		err = info.labelArraySet.Set(labelArraySet)
+		if err != nil {
+			return fmt.Errorf("error setting series id: cannot set label_array: %w", err)
+		}
+		info.labelArraySetNumLabels = len(labelArraySet)
+
+	}
+
+	return nil
+}
+
+func createLabelArrays(series []*model.Series, labelMap map[labelKey]labelInfo, maxPos int) ([][]int32, []*model.Series, error) {
+	labelArraySet := make([][]int32, 0, len(series))
+	dest := 0
+	for src := 0; src < len(series); src++ {
+		names, values, ok := series[src].NameValues()
+		if !ok {
+			continue
+		}
+		lArray := make([]int32, maxPos)
+		maxIndex := 0
+		for i := range names {
+			key := labelKey{MetricName: series[src].MetricName(), Name: names[i], Value: values[i]}
+			res, ok := labelMap[key]
+			if !ok {
+				return nil, nil, fmt.Errorf("error generating label array: missing key in map: %v", key)
+			}
+			if res.labelID == 0 {
+				return nil, nil, fmt.Errorf("error generating label array: missing id for label %v=>%v", names[i], values[i])
+			}
+			//Pos is 1-indexed, slices are 0-indexed
+			sliceIndex := int(res.Pos) - 1
+			lArray[sliceIndex] = int32(res.labelID)
+			if sliceIndex > maxIndex {
+				maxIndex = sliceIndex
+			}
+		}
+		lArray = lArray[:maxIndex+1]
+		labelArraySet = append(labelArraySet, lArray)
+		//this logic is needed for when continue is hit above
+		if src != dest {
+			series[dest] = series[src]
+		}
+		dest++
+	}
+	series = series[:dest]
+	if len(labelArraySet) != len(series) {
+		return nil, nil, fmt.Errorf("error generating label array: lengths not equal")
+	}
+	return labelArraySet, series, nil
+}

--- a/pkg/pgmodel/ingestor/series_writer.go
+++ b/pkg/pgmodel/ingestor/series_writer.go
@@ -191,12 +191,6 @@ func (h *seriesWriter) fillLabelIDs(infos map[string]*perMetricInfo, labelMap ma
 	batch := h.conn.NewBatch()
 	var dbEpoch model.SeriesEpoch
 
-	/*names, values := labelList.Get()
-	items := len(names.Elements)
-	if items != len(labelMap) {
-		return dbEpoch, 0, fmt.Errorf("error filling labels: number of items in labelList and labelMap doesn't match")
-	}*/
-
 	// The epoch will never decrease, so we can check it once at the beginning,
 	// at worst we'll store too small an epoch, which is always safe
 	batch.Queue("BEGIN;")

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -139,7 +139,7 @@ func (r *SqlRecorder) checkQuery(sql string, args ...interface{}) (RowResults, e
 			require.NoError(r.t, err)
 			expected, err := row.Args[i].(pgtype.TextEncoder).EncodeText(ci, nil)
 			require.NoError(r.t, err)
-			require.Equal(r.t, expected, got, "sql args aren't equal for query # %v: %v", idx, sql)
+			require.Equal(r.t, string(expected), string(got), "sql args aren't equal for query # %v: %v", idx, sql)
 		default:
 			if !row.ArgsUnordered {
 				require.Equal(r.t, row.Args[i], args[i], "sql args aren't equal for query # %v: %v", idx, sql)


### PR DESCRIPTION
Previously, series creation was done by the metric batcher.
But there was some performance issues with that:
1) There are lots of metric batchers and thus potentially
   lots of db calls to create series. This did cause the series
   creation to be blocked on waiting for a db connection
   from the pool
2) In general, less batching of series creation calls to the DB

To solve this, we move series creation to the copier and factor it out
into a SeriesWriter class. In addition we had to add logic to handle series
creation across metrics.