### PR TITLE
helm chart - typo in cronjob template

### DIFF
--- a/helm-chart/templates/cronjob-maintenance.yaml
+++ b/helm-chart/templates/cronjob-maintenance.yaml
@@ -57,7 +57,7 @@ spec:
           volumes:
             - name: script-volume
               configMap:
-                name: {{ include "promscal.fullname" . | trunc 51 }}-maintenance
+                name: {{ include "promscale.fullname" . | trunc 51 }}-maintenance
           restartPolicy: OnFailure
           {{- with .Values.maintenance.nodeSelector }}
           nodeSelector:


### PR DESCRIPTION
change `promscal` -> `promscale` on line 60

```
Error: UPGRADE FAILED: template: promscale/templates/cronjob-maintenance.yaml:60:25: executing "promscale/templates/cronjob-maintenance.yaml" at <include "promscal.fullname" .>: error calling include: template: no template "promscal.fullname" associated with template "gotpl"
```




