### PR TITLE
jaeger-proxy: small gosec fixes

### DIFF
--- a/pkg/jaeger/proxy/proxy.go
+++ b/pkg/jaeger/proxy/proxy.go
@@ -78,8 +78,12 @@ func New(config ProxyConfig, logger hclog.Logger) (*Proxy, error) {
 	}, nil
 }
 
-func (p *Proxy) Close() {
-	p.conn.Close()
+func (p *Proxy) Close() error {
+	err := p.conn.Close()
+	if err != nil {
+		return fmt.Errorf("error closing connection to Promscale GRPC server: %w", err)
+	}
+	return nil
 }
 
 func (p *Proxy) GetDependencies(ctx context.Context, r *storage_v1.GetDependenciesRequest) (*storage_v1.GetDependenciesResponse, error) {


### PR DESCRIPTION
Let's sanitize input and handle errors on connection closure.

// side note - can we make `gosec` CI test a required one? It would have prevented merge of https://github.com/timescale/promscale/pull/767 and clearly show what are the problems.