### PR TITLE
Fix cache population when initializing metric batcher

### DIFF
--- a/pkg/pgmodel/ingestor/metric_batcher.go
+++ b/pkg/pgmodel/ingestor/metric_batcher.go
@@ -95,7 +95,7 @@ func initializeMetricBatcher(conn pgxconn.PgxConn, metricName string, completeMe
 		metricName,
 		model.MetricInfo{
 			TableSchema: schema.Data, TableName: tableName,
-			SeriesTable: "",
+			SeriesTable: tableName, // Series table name is always the same for raw metrics.
 		},
 		false,
 	)

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -475,7 +475,7 @@ func (m *MockMetricCache) Get(schema, metric string, isExemplar bool) (MetricInf
 }
 
 func (m *MockMetricCache) Set(schema, metric string, mInfo MetricInfo, isExemplar bool) error {
-	m.MetricCache[schema+"*"+metric] = mInfo
+	m.MetricCache[fmt.Sprintf("%s_%s_%t", schema, metric, isExemplar)] = mInfo
 	return m.SetMetricErr
 }
 


### PR DESCRIPTION
Series table name was not set correctly when initializing the metric batcher
creating issues when trying to query metrics. The issue would resolve itself
once the cache was dropped and recreated.