### PR TITLE
Fix the import of vfsgen

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/prometheus/prometheus v1.8.2-0.20210605142932-7bc11dcb0664
 	github.com/schollz/progressbar/v3 v3.7.2
 	github.com/sergi/go-diff v1.0.0
-	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546 // indirect
+	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
 	github.com/stretchr/testify v1.7.0
 	github.com/testcontainers/testcontainers-go v0.10.1-0.20210318151656-2bbeb1e04514
 	github.com/thanos-io/thanos v0.20.1

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -9,3 +9,7 @@ package migrations
 // of the binary
 
 //go:generate go run -tags=dev generate.go
+
+// pin vfsgen version in go mod. It's used in generate.go but that isn't picked up
+// because it uses "ignore" tag. See https://github.com/shurcooL/vfsgen/issues/83
+import _ "github.com/shurcooL/vfsgen"


### PR DESCRIPTION
Right now vfsgen is imported in a file with `+build ignore`.
This cause `go mod tidy` to delete it from go.mod and therefore
breaks dependabot.

This patch simply adds the import to a built file.