### PR TITLE
Add support for PG14

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -97,6 +97,7 @@ jobs:
         - {name: "Timescaledb 1.x (pg 12)",  shortname: "tsdb1x-pg-12", ext: true,  tsdb: true,  tsdb2: false, tsdboss: false, multi: false, pg: 12}
         - {name: "Plain Postgres (12)",      shortname: "plain-pg-12",  ext: false, tsdb: false, tsdb2: false, tsdboss: false, multi: false, pg: 12}
         - {name: "TimescaleDB-OSS",          shortname: "tsdb-oss",     ext: false, tsdb: true,  tsdb2: true,  tsdboss: true,  multi: false, pg: 13}
+        - {name: "pg 14",                    shortname: "pg14",         ext: true,  tsdb: true,  tsdb2: true,  tsdboss: false, multi: false, pg: 14}
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/pkg/tests/end_to_end_tests/continuous_agg_test.go
+++ b/pkg/tests/end_to_end_tests/continuous_agg_test.go
@@ -461,6 +461,10 @@ func TestContinuousAgg2StepAgg(t *testing.T) {
 	if *useMultinode {
 		t.Skip("continuous aggregates not supported in multinode TimescaleDB setup")
 	}
+	//TODO: remove after pg14 ha image published
+	if *postgresVersion == 14 {
+		t.Skip("PG14 image does not have toolkit")
+	}
 
 	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
 		dbJob := testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_maintenance")

--- a/pkg/tests/end_to_end_tests/main_test.go
+++ b/pkg/tests/end_to_end_tests/main_test.go
@@ -32,13 +32,14 @@ import (
 )
 
 var (
-	testDatabase          = flag.String("database", "tmp_db_timescale_migrate_test", "database to run integration tests on")
-	updateGoldenFiles     = flag.Bool("update", false, "update the golden files of this test")
-	useDocker             = flag.Bool("use-docker", true, "start database using a docker container")
-	useExtension          = flag.Bool("use-extension", true, "use the promscale extension")
-	useTimescaleDB        = flag.Bool("use-timescaledb", true, "use TimescaleDB")
-	useTimescale2         = flag.Bool("use-timescale2", true, "use TimescaleDB 2.0")
-	useTimescaleOSS       = flag.Bool("use-timescaledb-oss", false, "use TimescaleDB-OSS latest")
+	testDatabase      = flag.String("database", "tmp_db_timescale_migrate_test", "database to run integration tests on")
+	updateGoldenFiles = flag.Bool("update", false, "update the golden files of this test")
+	useDocker         = flag.Bool("use-docker", true, "start database using a docker container")
+	useExtension      = flag.Bool("use-extension", true, "use the promscale extension")
+	useTimescaleDB    = flag.Bool("use-timescaledb", true, "use TimescaleDB")
+	useTimescale2     = flag.Bool("use-timescale2", true, "use TimescaleDB 2.0")
+	useTimescaleOSS   = flag.Bool("use-timescaledb-oss", false, "use TimescaleDB-OSS latest")
+	//TODO switch to 14 when pg14 ha image published
 	postgresVersion       = flag.Int("postgres-version-major", 13, "Major version of Postgres")
 	useMultinode          = flag.Bool("use-multinode", false, "use TimescaleDB 2.0 Multinode")
 	useTimescaleDBNightly = flag.Bool("use-timescaledb-nightly", false, "use TimescaleDB nightly images")
@@ -75,6 +76,8 @@ func setExtensionState() {
 	case 12:
 		extensionState.UsePG12()
 	case 13:
+		extensionState.UsePG13()
+	case 14:
 	default:
 		panic("Unknown Postgres version")
 	}

--- a/pkg/tests/end_to_end_tests/main_test.go
+++ b/pkg/tests/end_to_end_tests/main_test.go
@@ -78,6 +78,7 @@ func setExtensionState() {
 	case 13:
 		extensionState.UsePG13()
 	case 14:
+		//this is the default
 	default:
 		panic("Unknown Postgres version")
 	}

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -69,8 +69,10 @@ func TestMain(m *testing.M) {
 /* Prev image is the db image with the old promscale extension. We do NOT test timescaleDB extension upgrades here. */
 func getDBImages(extensionState testhelpers.ExtensionState) (prev string, clean string) {
 	if !extensionState.UsesPG12() {
-		//TODO add tests after release with PG13 support
-		panic("Can't test PG13 yet because haven't had a PG13 release")
+		//using the oldest supported version of PG seems sufficient.
+		//we don't want to use any features in a newer PG version that isn't available in an older one
+		//but migration code that works in an older PG version should generally work in a newer one.
+		panic("Only use pg12 for upgrade tests")
 	}
 	switch {
 	case extensionState.UsesMultinode():

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -45,7 +45,7 @@ var (
 	EarliestUpgradeTestVersion          = "0.1.0"
 	EarliestUpgradeTestVersionMultinode = "0.1.4" //0.1.4 earliest version that supports tsdb 2.0
 
-	PgVersionNumRange       = ">=12.x <14.x" // Corresponds to range within pg 12.0 to pg 13.99
+	PgVersionNumRange       = ">=12.x <15.x" // Corresponds to range within pg 12.0 to pg 14.99
 	pgAcceptedVersionsRange = semver.MustParseRange(PgVersionNumRange)
 
 	TimescaleVersionRangeString = struct {
@@ -61,8 +61,8 @@ var (
 	TimescaleVersionRange           = timescaleVersionSafeRange.OR(timescaleVersionWarnRange)
 
 	// ExtVersionRangeString is a range of required promscale extension versions
-	// support 0.1.x and 0.2.x
-	ExtVersionRangeString = ">=0.1.0 <0.2.99"
+	// support 0.1.x and 0.3.x
+	ExtVersionRangeString = ">=0.1.0 <0.3.99"
 	ExtVersionRange       = semver.MustParseRange(ExtVersionRangeString)
 )
 


### PR DESCRIPTION
This commit mostly just adds test for PostgreSQL 14.
Since the Promscale extension doesn't yet support PG14,
tests with the extension cannot use PG14. This should
be changed as soon as the extension adds support (should
be soon now). TODOs have been added for this.

Also, when all the kinks for testing with PG14 are ironed out,
our default tests should be changed to PG14, both with CLI flags
and with our CI.