### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/ @timescale/o11y-eng


### PR DESCRIPTION
This configures the repo to require an approval from a member of the Timescale Observability Engineering team on PRs