### PR TITLE
Move CODEOWNERS to .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+* @timescale/o11y-eng
+
+# sql related stuff
+*.sql @jgpruitt
+/pkg/migrations/ @jgpruitt
+/pkg/tests/upgrade_tests/ @jgpruitt
+/pkg/tests/testdata/ @jgpruitt
+/pkg/tests/test_migrations/ @jgpruitt

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-/ @timescale/o11y-eng


### PR DESCRIPTION
Move CODEOWNERS to the .github dir since it only applies to GitHub and we want the root dir clean.
Additionally, add more config lines to CODEOWNERS for SQL related portions of the code.