### PR TITLE
Helm improvements

### DIFF
--- a/helm-chart/templates/deployment-promscale.yaml
+++ b/helm-chart/templates/deployment-promscale.yaml
@@ -19,9 +19,11 @@ spec:
     metadata:
       labels:
         app: {{ template "promscale.fullname" . }}
-      {{ if .Values.prometheus.enabled }}
-      annotations: {{ .Values.prometheus.annotations | toYaml | nindent 8 }}
-      {{ end }}
+      {{- if .Values.prometheus.enabled }}
+      annotations: 
+        checksum/config: {{ printf "%s" .Values.connection | sha256sum -}}
+        {{ .Values.prometheus.annotations | toYaml | nindent 8 }}
+      {{- end }}
     spec:
       containers:
         - image: {{ .Values.image }}
@@ -33,6 +35,10 @@ spec:
               - {{ . }}
             {{- end }}
           {{- end}}
+          envFrom:
+          - secretRef:
+              {{- $secretName := ternary (include "promscale.fullname" .) .Values.connectionSecretName (eq .Values.connectionSecretName "") }}
+              name: {{ $secretName }}
           {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
@@ -44,30 +50,6 @@ spec:
             - containerPort: 9202
               name: traces-port
           {{- end }}
-          env:
-            {{- if .Values.connection.uri.secretTemplate }}
-            - name: PROMSCALE_DB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: {{ tpl .Values.connection.uri.secretTemplate . }}
-                  key: {{ .Values.connection.uri.key }}
-            {{- else }}
-            - name: PROMSCALE_DB_PORT
-              value: {{ .Values.connection.port | quote }}
-            - name: PROMSCALE_DB_USER
-              value: {{ .Values.connection.user }}
-            - name: PROMSCALE_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ tpl .Values.connection.password.secretTemplate . }}
-                  key: {{ .Values.connection.password.timescaleDBSuperUserKey }}
-            - name: PROMSCALE_DB_HOST
-              value: {{ tpl .Values.connection.host.nameTemplate . }}
-            - name: PROMSCALE_DB_NAME
-              value: {{ .Values.connection.dbName }}
-            - name: PROMSCALE_DB_SSL_MODE
-              value: {{ .Values.connection.sslMode }}
-            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 2 }}

--- a/helm-chart/templates/deployment-promscale.yaml
+++ b/helm-chart/templates/deployment-promscale.yaml
@@ -19,11 +19,11 @@ spec:
     metadata:
       labels:
         app: {{ template "promscale.fullname" . }}
-      {{- if .Values.prometheus.enabled }}
       annotations: 
         checksum/config: {{ printf "%s" .Values.connection | sha256sum -}}
+        {{- if .Values.prometheus.enabled }}
         {{ .Values.prometheus.annotations | toYaml | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       containers:
         - image: {{ .Values.image }}

--- a/helm-chart/templates/deployment-promscale.yaml
+++ b/helm-chart/templates/deployment-promscale.yaml
@@ -45,7 +45,13 @@ spec:
               name: traces-port
           {{- end }}
           env:
-            {{- if not .Values.connection.uri.secretTemplate }}
+            {{- if .Values.connection.uri.secretTemplate }}
+            - name: PROMSCALE_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl .Values.connection.uri.secretTemplate . }}
+                  key: {{ .Values.connection.uri.key }}
+            {{- else }}
             - name: PROMSCALE_DB_PORT
               value: {{ .Values.connection.port | quote }}
             - name: PROMSCALE_DB_USER
@@ -61,12 +67,6 @@ spec:
               value: {{ .Values.connection.dbName }}
             - name: PROMSCALE_DB_SSL_MODE
               value: {{ .Values.connection.sslMode }}
-            {{- else }}
-            - name: PROMSCALE_DB_URI
-              valueFrom:
-                secretKeyRef:
-                  name: {{ tpl .Values.connection.uri.secretTemplate . }}
-                  key: {{ .Values.connection.uri.key }}
             {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm-chart/templates/deployment-promscale.yaml
+++ b/helm-chart/templates/deployment-promscale.yaml
@@ -50,6 +50,7 @@ spec:
             - containerPort: 9202
               name: traces-port
           {{- end }}
+      serviceAccountName: {{ template "promscale.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{ toYaml . | indent 2 }}

--- a/helm-chart/templates/secret-connection.yaml
+++ b/helm-chart/templates/secret-connection.yaml
@@ -1,0 +1,23 @@
+{{ if eq .Values.connectionSecretName "" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "promscale.fullname" . }}
+  namespace: {{ template "promscale.namespace" . }}
+  labels:
+    app: {{ template "promscale.fullname" . }}
+    chart: {{ template "promscale.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  {{- if ne .Values.connection.uri "" }}
+  PROMSCALE_DB_URI: {{ .Values.connection.uri }}
+  {{- else }}
+  PROMSCALE_DB_PORT: {{ .Values.connection.port | quote }}
+  PROMSCALE_DB_USER: {{ .Values.connection.user }}
+  PROMSCALE_DB_PASSWORD: {{ .Values.connection.password }}
+  PROMSCALE_DB_HOST: {{ .Values.connection.host }}
+  PROMSCALE_DB_NAME: {{ .Values.connection.dbName }}
+  PROMSCALE_DB_SSL_MODE: {{ .Values.connection.sslMode }}
+  {{- end }}
+{{ end }}

--- a/helm-chart/templates/secret-connection.yaml
+++ b/helm-chart/templates/secret-connection.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: {{ template "promscale.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-data:
+stringData:
   {{- if ne .Values.connection.uri "" }}
   PROMSCALE_DB_URI: {{ .Values.connection.uri }}
   {{- else }}

--- a/helm-chart/templates/service-account.yaml
+++ b/helm-chart/templates/service-account.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: false
+metadata:
+  name: {{ include "promscale.fullname" . }}
+  namespace: {{ template "promscale.namespace" . }}
+  labels:
+    app: {{ template "promscale.fullname" . }}
+    chart: {{ template "promscale.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/helm-chart/templates/service-monitor.yaml
+++ b/helm-chart/templates/service-monitor.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "promscale.fullname" . }}
+  namespace: {{ template "promscale.namespace" . }}
+  labels:
+    app: {{ template "promscale.fullname" . }}
+    chart: {{ template "promscale.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics-port
+    path: /metrics
+  selector:
+    matchLabels:
+      app: {{ template "promscale.fullname" . }}
+      chart: {{ template "promscale.chart" . }}
+      release: {{ .Release.Name }}
+      heritage: {{ .Release.Service }}
+{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -32,38 +32,21 @@ tracing:
   # tracing is only enabled if below field is configured true
   enabled: false
 
+# selector used to provision your own Secret containing connection details
+# Use this option with caution
+connectionSecretName: ""
+
 # connection options to connect to a target db
 connection:
   # connection string settings, it is pulled
   # from a Secret object. If `secretTemplate` is not
   # set then the specific user, pass, host, port and
   # sslMode properties are used.
-  uri:
-    key: db-uri
-    # the template for generating the name of
-    # a Secret object containing the URI to
-    # connect to TimescaleDB. The URI should
-    # be indexed with the key in `connection.uri.key`
-    # used in the above name field.
-    secretTemplate:
+  uri: ""
   # user used to connect to TimescaleDB
   user: postgres
-  password:
-    # the template for generating the name of
-    # a Secret object containing the password to
-    # connect to TimescaleDB. The password should
-    # be indexed by the below key
-    timescaleDBSuperUserKey: PATRONI_SUPERUSER_PASSWORD
-    secretTemplate: "{{ .Release.Name }}-credentials"
-  host:
-    # the template for generating the database host
-    # location
-    # for a hardcoded host name from another release, set:
-    #   nameTemplate: "{{ already-deployed-timescale.default.svc.cluster.local }}"
-    # for a host name of a timescaledb instance
-    # deployed in the same release (without a cluster override) set:
-    #   nameTemplate: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
-    nameTemplate: "{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local"
+  password: secretPassword
+  host: db.timescale.svc.cluster.local
   port: 5432
   sslMode: require
   # database name in which to store the metrics

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -38,15 +38,14 @@ connectionSecretName: ""
 
 # connection options to connect to a target db
 connection:
-  # connection string settings, it is pulled
-  # from a Secret object. If `secretTemplate` is not
+  # Database connection settings. If `uri` is not
   # set then the specific user, pass, host, port and
   # sslMode properties are used.
   uri: ""
   # user used to connect to TimescaleDB
   user: postgres
   password: secretPassword
-  host: db.timescale.svc.cluster.local
+  host: "timescaledb.monitoring.svc.cluster.local"
   port: 5432
   sslMode: require
   # database name in which to store the metrics

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -53,6 +53,10 @@ connection:
   # must be created before start
   dbName: timescale
 
+# Enable ServiceMonitor used by prometheus-operator to configure prometheus for metrics scraping
+serviceMonitor:
+  enabled: false
+
 # Prometheus annotations to configure scraping metrics from the connector
 prometheus:
   enabled: true


### PR DESCRIPTION
Few improvements:
- include creation of ServiceAccount
- allow creation of ServiceMonitor (especially useful for tobs)
- move all connection details into a Secret object and read them with `envFrom`
- allow overriding Secret object and thus provide a hidden way to inject arbitrary environment variables
- use sha256 checksum as pod annotation to force pod recreation when connection values change

breaking changes:
- `connection.password` is no longer a map and now only accepts a string with password value
- `connection.uri` is no longer a map and now only accepts a string with uri value

Sorry for one large PR and not multiple smaller ones. I didn't want to deal with merge conflicts. Different features are implemented in different commits though.