### PR TITLE
WIP: PoC for reformatted usage

### DIFF
--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -110,11 +110,21 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.BoolVar(&cfg.AdminAPIEnabled, "web-enable-admin-api", false, "Allow operations via API that are for advanced users. Currently, these operations are limited to deletion of series.")
 	fs.StringVar(&cfg.TelemetryPath, "web-telemetry-path", "/metrics", "Web endpoint for exposing Promscale's Prometheus metrics.")
 
-	fs.StringVar(&cfg.Auth.BasicAuthUsername, "auth-username", "", "Authentication username used for web endpoint authentication. Disabled by default.")
-	fs.StringVar(&cfg.Auth.BasicAuthPassword, "auth-password", "", "Authentication password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password-file and bearer-token flags.")
-	fs.StringVar(&cfg.Auth.BasicAuthPasswordFile, "auth-password-file", "", "Path for auth password file containing the actual password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password and bearer-token methods.")
-	fs.StringVar(&cfg.Auth.BearerToken, "bearer-token", "", "Bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token-file and basic auth methods.")
-	fs.StringVar(&cfg.Auth.BearerTokenFile, "bearer-token-file", "", "Path of the file containing the bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token and basic auth methods.")
+	fs.StringVar(&cfg.Auth.BasicAuthUsername, "auth-username", "", `Authentication username used for web endpoint authentication.
+Disabled by default.`)
+	fs.StringVar(&cfg.Auth.BasicAuthPassword, "auth-password", "", `Authentication password used for web endpoint authentication.
+This flag should be set together with auth-username.
+Mutually exclusive with auth-password-file and bearer-token flags.`)
+	fs.StringVar(&cfg.Auth.BasicAuthPasswordFile, "auth-password-file", "", `Path to file containing password used for web endpoint authentication.
+This flag should be set together with auth-username.
+Mutually exclusive with auth-password and bearer-token methods.`)
+	fs.StringVar(&cfg.Auth.BearerToken, "bearer-token", "", `Bearer token (JWT) used for web endpoint authentication.
+Disabled by default.
+Mutually exclusive with bearer-token-file and basic auth methods.`)
+	fs.StringVar(&cfg.Auth.BearerTokenFile, "bearer-token-file", "", `Path to file containing bearer token (JWT) used for web endpoint
+authentication.
+Disabled by default.
+Mutually exclusive with bearer-token and basic auth methods.`)
 
 	// PromQL configuration flags.
 	fs.StringVar(&cfg.EnableFeatures, "promql-enable-feature", "", "[EXPERIMENTAL] Enable optional PromQL features, separated by commas. These are disabled by default in Promscale's PromQL engine. "+

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -64,24 +64,27 @@ var (
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	cache.ParseFlags(fs, &cfg.CacheConfig)
 
-	fs.StringVar(&cfg.AppName, "app", DefaultApp, "'app' sets application_name in database connection string. "+
-		"This is helpful during debugging when looking at pg_stat_activity.")
+	fs.StringVar(&cfg.AppName, "app", DefaultApp, `Sets application_name in database connection string.
+This is helpful during debugging when looking at pg_stat_activity.
+`)
 	fs.StringVar(&cfg.Host, "db-host", defaultDBHost, "Host for TimescaleDB/Vanilla Postgres.")
 	fs.IntVar(&cfg.Port, "db-port", defaultDBPort, "TimescaleDB/Vanilla Postgres connection password.")
 	fs.StringVar(&cfg.User, "db-user", defaultDBUser, "TimescaleDB/Vanilla Postgres user.")
 	fs.StringVar(&cfg.Password, "db-password", defaultDBPassword, "Password for connecting to TimescaleDB/Vanilla Postgres.")
 	fs.StringVar(&cfg.Database, "db-name", defaultDBName, "Database name.")
-	fs.StringVar(&cfg.SslMode, "db-ssl-mode", defaultSSLMode, "TimescaleDB/Vanilla Postgres connection ssl mode. If you do not want to use ssl, pass 'allow' as value.")
-	fs.IntVar(&cfg.DbConnectRetries, "db-connect-retries", 0, "Number of retries Promscale should make for establishing connection with the database.")
-	fs.DurationVar(&cfg.DbConnectionTimeout, "db-connection-timeout", defaultConnectionTime, "Timeout for establishing the connection between Promscale and TimescaleDB.")
+	fs.StringVar(&cfg.SslMode, "db-ssl-mode", defaultSSLMode, `TimescaleDB connection ssl mode.
+If you do not want to use ssl, pass 'allow' as value.`)
+	fs.IntVar(&cfg.DbConnectRetries, "db-connect-retries", 0, "Number of connect retries Promscale will make to the database.")
+	fs.DurationVar(&cfg.DbConnectionTimeout, "db-connection-timeout", defaultConnectionTime, "Timeout for establishing the connection to TimescaleDB.")
 	fs.BoolVar(&cfg.IgnoreCompressedChunks, "ignore-samples-written-to-compressed-chunks", false, "Ignore/drop samples that are being written to compressed chunks. "+
 		"Setting this to false allows Promscale to ingest older data by decompressing chunks that were earlier compressed. "+
 		"However, setting this to true will save your resources that may be required during decompression. ")
 	fs.IntVar(&cfg.WriteConnectionsPerProc, "db-writer-connection-concurrency", 4, "Maximum number of database connections for writing per go process.")
-	fs.IntVar(&cfg.MaxConnections, "db-connections-max", -1, "Maximum number of connections to the database that should be opened at once. "+
-		"It defaults to 80% of the maximum connections that the database can handle.")
-	fs.StringVar(&cfg.DbUri, "db-uri", defaultDBUri, "TimescaleDB/Vanilla Postgres DB URI. "+
-		"Example DB URI `postgres://postgres:password@localhost:5432/timescale?sslmode=require`")
+	fs.IntVar(&cfg.MaxConnections, "db-connections-max", -1, `Maximum number of open connections to the database.
+Defaults to 80% of the database's 'max_connections' configuration.`)
+	fs.StringVar(&cfg.DbUri, "db-uri", defaultDBUri, `TimescaleDB connection DB URI. Can be used in lieu of setting host,
+port, user etc.
+Example: 'postgres://postgres:password@localhost:5432/timescale?sslmode=require'`)
 	fs.BoolVar(&cfg.EnableStatementsCache, "db-statements-cache", defaultDbStatementsCache, "Whether database connection pool should use cached prepared statements. "+
 		"Disable if using PgBouncer")
 	return cfg

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -60,7 +60,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	limits.ParseFlags(fs, &cfg.LimitsCfg)
 	tenancy.ParseFlags(fs, &cfg.TenancyCfg)
 
-	fs.StringVar(&cfg.ConfigFile, "config", "config.yml", "YAML configuration file path for Promscale.")
+	fs.StringVar(&cfg.ConfigFile, "config", "config.yml", "Path to Promscale configuration file.")
 	fs.StringVar(&cfg.ListenAddr, "web-listen-address", ":9201", "Address to listen on for web endpoints.")
 	fs.StringVar(&cfg.ThanosStoreAPIListenAddr, "thanos-store-api-listen-address", "", "Address to listen on for Thanos Store API endpoints.")
 	fs.StringVar(&cfg.OTLPGRPCListenAddr, "otlp-grpc-server-listen-address", "", "Address to listen on for OTLP GRPC server.")
@@ -73,7 +73,10 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.BoolVar(&cfg.UseVersionLease, "use-schema-version-lease", true, "Use schema version lease to prevent race conditions during migration.")
 	fs.BoolVar(&cfg.InstallExtensions, "install-extensions", true, "Install TimescaleDB, Promscale extension.")
 	fs.BoolVar(&cfg.UpgradeExtensions, "upgrade-extensions", true, "Upgrades TimescaleDB, Promscale extensions.")
-	fs.BoolVar(&cfg.AsyncAcks, "async-acks", false, "Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss.")
+	fs.BoolVar(&cfg.AsyncAcks, "async-acks", false, `Acknowledge asynchronous inserts.
+If set, the inserter will not wait after insertion of metric data
+in the database. This increases throughput at the cost of a small
+chance of data loss.`)
 	fs.BoolVar(&cfg.UpgradePrereleaseExtensions, "upgrade-prerelease-extensions", false, "Upgrades to pre-release TimescaleDB, Promscale extensions.")
 	fs.StringVar(&cfg.TLSCertFile, "tls-cert-file", "", "TLS Certificate file used for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 	fs.StringVar(&cfg.TLSKeyFile, "tls-key-file", "", "TLS Key file for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")


### PR DESCRIPTION
This "cheap" change adds line breaks and small reformulations to the first ~15 CLI flags as a proof-of-concept for how this could look.

Before:
```
Usage of ./dist/promscale:
  -app string
    	'app' sets application_name in database connection string. This is helpful during debugging when looking at pg_stat_activity. [PROMSCALE_APP] [TS_PROM_APP] (default "promscale@0.7.0-beta.1.dev.1")
  -async-acks
    	Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss. [PROMSCALE_ASYNC_ACKS] [TS_PROM_ASYNC_ACKS]
  -auth-password string
    	Authentication password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password-file and bearer-token flags. [PROMSCALE_AUTH_PASSWORD] [TS_PROM_AUTH_PASSWORD]
  -auth-password-file string
    	Path for auth password file containing the actual password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password and bearer-token methods. [PROMSCALE_AUTH_PASSWORD_FILE] [TS_PROM_AUTH_PASSWORD_FILE]
  -auth-username string
    	Authentication username used for web endpoint authentication. Disabled by default. [PROMSCALE_AUTH_USERNAME] [TS_PROM_AUTH_USERNAME]
  -bearer-token string
    	Bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token-file and basic auth methods. [PROMSCALE_BEARER_TOKEN] [TS_PROM_BEARER_TOKEN]
```

After:
```
Usage of ./dist/promscale:
  -app string
    	Sets application_name in database connection string.
    	This is helpful during debugging when looking at pg_stat_activity.
    	 [PROMSCALE_APP] [TS_PROM_APP] (default "promscale@0.7.0-beta.1.dev.1")
  -async-acks
    	Acknowledge asynchronous inserts.
    	If set, the inserter will not wait after insertion of metric data
    	in the database. This increases throughput at the cost of a small
    	chance of data loss. [PROMSCALE_ASYNC_ACKS] [TS_PROM_ASYNC_ACKS]
  -auth-password string
    	Authentication password used for web endpoint authentication.
    	This flag should be set together with auth-username.
    	Mutually exclusive with auth-password-file and bearer-token flags. [PROMSCALE_AUTH_PASSWORD] [TS_PROM_AUTH_PASSWORD]
  -auth-password-file string
    	Path to file containing password used for web endpoint authentication.
    	This flag should be set together with auth-username.
    	Mutually exclusive with auth-password and bearer-token methods. [PROMSCALE_AUTH_PASSWORD_FILE] [TS_PROM_AUTH_PASSWORD_FILE]
  -auth-username string
    	Authentication username used for web endpoint authentication.
    	Disabled by default. [PROMSCALE_AUTH_USERNAME] [TS_PROM_AUTH_USERNAME]
  -bearer-token string
    	Bearer token (JWT) used for web endpoint authentication.
    	Disabled by default.
    	Mutually exclusive with bearer-token-file and basic auth methods. [PROMSCALE_BEARER_TOKEN] [TS_PROM_BEARER_TOKEN]
```

Two things which still bother me are:
- The environment variable names make the formatting bad.
- The default value seems to be in the wrong place. (hacked onto the end of the string).