### PR TITLE
Remove unused `db-connect-retries` cli flag

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,6 @@ You can also find information on flags with `promscale_<version> -help`.
 | db-name | string | timescale | Database name. |
 | db-password | string | | Password for connecting to TimescaleDB/Vanilla Postgres. |
 | db-user | string | postgres | TimescaleDB/Vanilla Postgres user. |
-| db-connect-retries | integer | 0 | Number of retries Promscale should make for establishing connection with the database. |
 | db-connection-timeout | duration | 60 seconds | Timeout for establishing the connection between Promscale and TimescaleDB. |
 | db-connections-max | integer | 80% of possible connections db | Maximum number of connections to the database that should be opened at once. It defaults to 80% of the maximum connections that the database can handle. |
 | db-ssl-mode | string | require | TimescaleDB/Vanilla Postgres connection ssl mode. If you do not want to use ssl, pass `allow` as value. |

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -31,7 +31,6 @@ type Config struct {
 	Password                string
 	Database                string
 	SslMode                 string
-	DbConnectRetries        int
 	DbConnectionTimeout     time.Duration
 	IgnoreCompressedChunks  bool
 	AsyncAcks               bool
@@ -72,7 +71,6 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.StringVar(&cfg.Password, "db-password", defaultDBPassword, "Password for connecting to TimescaleDB/Vanilla Postgres.")
 	fs.StringVar(&cfg.Database, "db-name", defaultDBName, "Database name.")
 	fs.StringVar(&cfg.SslMode, "db-ssl-mode", defaultSSLMode, "TimescaleDB/Vanilla Postgres connection ssl mode. If you do not want to use ssl, pass 'allow' as value.")
-	fs.IntVar(&cfg.DbConnectRetries, "db-connect-retries", 0, "Number of retries Promscale should make for establishing connection with the database.")
 	fs.DurationVar(&cfg.DbConnectionTimeout, "db-connection-timeout", defaultConnectionTime, "Timeout for establishing the connection between Promscale and TimescaleDB.")
 	fs.BoolVar(&cfg.IgnoreCompressedChunks, "ignore-samples-written-to-compressed-chunks", false, "Ignore/drop samples that are being written to compressed chunks. "+
 		"Setting this to false allows Promscale to ingest older data by decompressing chunks that were earlier compressed. "+

--- a/pkg/pgclient/config_test.go
+++ b/pkg/pgclient/config_test.go
@@ -22,7 +22,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 		Password                string
 		Database                string
 		SslMode                 string
-		DbConnectRetries        int
 		DbConnectionTimeout     time.Duration
 		AsyncAcks               bool
 		ReportInterval          int
@@ -51,7 +50,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "Timescale123",
 				Database:                "timescale1",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     time.Minute * 2,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -76,7 +74,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "Timescale123",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				AsyncAcks:               false,
 				ReportInterval:          0,
 				LabelsCacheSize:         0,
@@ -100,7 +97,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "Timescale123",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				AsyncAcks:               false,
 				ReportInterval:          0,
 				LabelsCacheSize:         0,
@@ -125,7 +121,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     time.Hour,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -151,7 +146,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -177,7 +171,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -203,7 +196,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                ":/|thi$ i$ a p@$$w0rd #!***",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -229,7 +221,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "password",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -255,7 +246,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "password",
 				Database:                "%~~ $uP3r Funky d@7@b@$$ ~~%",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -281,7 +271,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                "password",
 				Database:                "timescale",
 				SslMode:                 "require",
-				DbConnectRetries:        0,
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
 				ReportInterval:          0,
@@ -313,7 +302,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Password:                tt.fields.Password,
 				Database:                tt.fields.Database,
 				SslMode:                 tt.fields.SslMode,
-				DbConnectRetries:        tt.fields.DbConnectRetries,
 				DbConnectionTimeout:     tt.fields.DbConnectionTimeout,
 				WriteConnectionsPerProc: tt.fields.WriteConnectionsPerProc,
 				MaxConnections:          tt.fields.MaxConnections,


### PR DESCRIPTION
As far as I can tell, this parameter was never used. It was introduced in https://github.com/timescale/promscale/commit/e56974b961180ce33ad8daaba47d5de2df13b4f2, and apparently never used there either.

Perhaps the original intention was that it would flow into the `maxRetries` parameter of [getConn](https://github.com/timescale/promscale/commit/e56974b961180ce33ad8daaba47d5de2df13b4f2#diff-553897b3aa8771440b16199f81fac786b88d9a8bdbe15c95815bfaed2a4c9ed9R51).