### PR TITLE
Remove deprecated TS_PROM_ prefixed env-var support

### DIFF
--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -81,13 +81,6 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	if err := util.ParseEnv("PROMSCALE", fs); err != nil {
 		return nil, fmt.Errorf("error parsing env variables: %w", err)
 	}
-	// Deprecated: TS_PROM is the old prefix which is deprecated and in here
-	// for legacy compatibility. Will be removed in the future. PROMSCALE prefix
-	// takes precedence and will be used if the same variable with both prefixes
-	// exist.
-	if err := util.ParseEnv("TS_PROM", fs); err != nil {
-		return nil, fmt.Errorf("error parsing env variables: %w", err)
-	}
 
 	if err := ff.Parse(fs, args,
 		ff.WithConfigFileFlag("config"),

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -145,13 +145,6 @@ func TestParseFlags(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{
-			name: "invalid env variable type causing parse error, TS_PROM prefix",
-			env: map[string]string{
-				"TS_PROM_INSTALL_EXTENSIONS": "foobar",
-			},
-			shouldError: true,
-		},
 	}
 
 	for _, c := range testCases {
@@ -210,31 +203,9 @@ func TestParseFlagsConfigPrecedence(t *testing.T) {
 			},
 		},
 		{
-			name: "Env variable only, TS_PROM prefix",
-			env: map[string]string{
-				"TS_PROM_WEB_LISTEN_ADDRESS": "localhost:9201",
-			},
-			result: func(c Config) Config {
-				c.ListenAddr = "localhost:9201"
-				return c
-			},
-		},
-		{
 			name: "Env variable only, PROMSCALE prefix",
 			env: map[string]string{
 				"PROMSCALE_WEB_LISTEN_ADDRESS": "localhost:9201",
-			},
-			result: func(c Config) Config {
-				c.ListenAddr = "localhost:9201"
-				return c
-			},
-		},
-		{
-			// In this case, we expect that PROMSCALE prefix gets precedence.
-			name: "Env variable only, both prefixes",
-			env: map[string]string{
-				"PROMSCALE_WEB_LISTEN_ADDRESS": "localhost:9201",
-				"TS_PROM_WEB_LISTEN_ADDRESS":   "127.0.0.1:9201",
 			},
 			result: func(c Config) Config {
 				c.ListenAddr = "localhost:9201"


### PR DESCRIPTION
The TS_PROM_ prefix was deprecated in Promscale release 0.1.4, released
in December 2020.