### PR TITLE
helm-chart: allow numbers to be passed as connection parameters

### DIFF
--- a/helm-chart/templates/secret-connection.yaml
+++ b/helm-chart/templates/secret-connection.yaml
@@ -10,14 +10,14 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 stringData:
-  {{- if ne .Values.connection.uri "" }}
-  PROMSCALE_DB_URI: {{ .Values.connection.uri }}
+  {{- if ne (.Values.connection.uri | toString) "" }}
+  PROMSCALE_DB_URI: {{ .Values.connection.uri | toString | quote }}
   {{- else }}
-  PROMSCALE_DB_PORT: {{ .Values.connection.port | quote }}
-  PROMSCALE_DB_USER: {{ .Values.connection.user }}
-  PROMSCALE_DB_PASSWORD: {{ .Values.connection.password }}
-  PROMSCALE_DB_HOST: {{ .Values.connection.host }}
-  PROMSCALE_DB_NAME: {{ .Values.connection.dbName }}
-  PROMSCALE_DB_SSL_MODE: {{ .Values.connection.sslMode }}
+  PROMSCALE_DB_PORT: {{ .Values.connection.port | toString | quote }}
+  PROMSCALE_DB_USER: {{ .Values.connection.user | toString | quote }}
+  PROMSCALE_DB_PASSWORD: {{ .Values.connection.password | toString | quote }}
+  PROMSCALE_DB_HOST: {{ .Values.connection.host | toString | quote }}
+  PROMSCALE_DB_NAME: {{ .Values.connection.dbName | toString | quote }}
+  PROMSCALE_DB_SSL_MODE: {{ .Values.connection.sslMode | toString | quote }}
   {{- end }}
 {{ end }}


### PR DESCRIPTION
This prevents failure in the unlikely event of passing some connection parameters as numbers.

cc @VineethReddy02 @JamesGuthrie 