### PR TITLE
Fix memory leak with SamplesQuerier

### DIFF
--- a/pkg/api/label_values.go
+++ b/pkg/api/label_values.go
@@ -34,6 +34,8 @@ func labelValues(queryable promql.Queryable) http.HandlerFunc {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
+		defer querier.Close()
+
 		var values labelsValue
 		values, warnings, err := querier.LabelValues(name)
 		if err != nil {

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -39,6 +39,7 @@ func labelsHandler(queryable promql.Queryable) http.HandlerFunc {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return
 		}
+		defer querier.Close()
 		var names labelsValue
 		names, warnings, err := querier.LabelNames()
 		if err != nil {

--- a/pkg/api/series.go
+++ b/pkg/api/series.go
@@ -73,6 +73,8 @@ func series(queryable promql.Queryable) http.HandlerFunc {
 			respondError(w, http.StatusUnprocessableEntity, err, "execution")
 			return
 		}
+		defer q.Close()
+
 		var sets []storage.SeriesSet
 		var warnings storage.Warnings
 		for _, mset := range matcherSets {

--- a/pkg/promql/engine.go
+++ b/pkg/promql/engine.go
@@ -66,7 +66,7 @@ type SamplesQuerier interface {
 	LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error)
 
 	// Close releases the resources of the Querier.
-	Close() error
+	Close()
 
 	// Select returns a set of series that matches the given label matchers.
 	// Caller can specify if it requires returned series to be sorted. Prefer not requiring sorting for better performance.

--- a/pkg/promql/engine_test.go
+++ b/pkg/promql/engine_test.go
@@ -203,7 +203,7 @@ func (*errQuerier) LabelValues(string) ([]string, storage.Warnings, error) {
 func (*errQuerier) LabelNames(...*labels.Matcher) ([]string, storage.Warnings, error) {
 	return nil, nil, nil
 }
-func (*errQuerier) Close() error { return nil }
+func (*errQuerier) Close() {}
 
 // errSeriesSet implements storage.SeriesSet which always returns error.
 type errSeriesSet struct {

--- a/pkg/promql/test.go
+++ b/pkg/promql/test.go
@@ -119,6 +119,10 @@ func (t *QuerierWrapper) LabelValues(n string) ([]string, storage.Warnings, erro
 	return nil, nil, nil
 }
 
+func (t *QuerierWrapper) Close() {
+	_ = t.Querier.Close()
+}
+
 // Test is a sequence of read and write commands that are run
 // against a test storage.
 type Test struct {

--- a/pkg/query/queryable.go
+++ b/pkg/query/queryable.go
@@ -59,11 +59,10 @@ func (q samplesQuerier) LabelNames(_ ...*labels.Matcher) ([]string, storage.Warn
 	return lNames, nil, err
 }
 
-func (q *samplesQuerier) Close() error {
+func (q *samplesQuerier) Close() {
 	for _, ss := range q.seriesSets {
 		ss.Close()
 	}
-	return nil
 }
 
 func (q *samplesQuerier) Select(sortSeries bool, hints *storage.SelectHints, qh *pgQuerier.QueryHints, path []parser.Node, matchers ...*labels.Matcher) (storage.SeriesSet, parser.Node) {

--- a/pkg/thanos/store.go
+++ b/pkg/thanos/store.go
@@ -39,6 +39,7 @@ func (fc *Storage) Series(req *storepb.SeriesRequest, srv storepb.Store_SeriesSe
 	if err != nil {
 		return err
 	}
+	defer q.Close()
 
 	ss, _ := q.Select(false, nil, nil, nil, matchers...)
 
@@ -98,6 +99,7 @@ func (fc *Storage) LabelNames(ctx context.Context, req *storepb.LabelNamesReques
 	if err != nil {
 		return nil, err
 	}
+	defer q.Close()
 
 	names, warnings, err := q.LabelNames()
 	if err != nil {
@@ -120,6 +122,7 @@ func (fc *Storage) LabelValues(ctx context.Context, req *storepb.LabelValuesRequ
 	if err != nil {
 		return nil, err
 	}
+	defer q.Close()
 
 	values, warnings, err := q.LabelValues(req.Label)
 	if err != nil {


### PR DESCRIPTION
Fixes memory leak by adding Close() calls to SampleQuerier instances
This matters whenever Select is called as in those cases the Close
trickles down to sampleRow.Close() calls which returns memory to pools.

Fixes timescale#933.