### PR TITLE
helm: Simplifying enablement of otel tracing

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -113,11 +113,11 @@ helm install --name my-release -f myvalues.yaml .
 | `imagePullPolicy`                 | The image pull policy                       | `IfNotPresent`                     |
 | `replicaCount`                    | Number of pods for the connector            | `1`                                |
 | `upgradeStrategy`                 | Promscale deployment upgrade strategy, By default set to `Recreate` as during Promscale upgrade we expect no Promscale to be connected to TimescaleDB       | `Recreate` |
-| `args`                            | Additional promscale CLI arguments          | `[]`                               |
 | `resources`                       | Requests and limits for each of the pods    | `{}`                               |
 | `nodeSelector`                    | Node labels to use for scheduling           | `{}`                               |
 | `tolerations`                     | Tolerations to use for scheduling           | `[]`                               |
 | `affinity`                        | PodAffinity and PodAntiAffinity settings    | `{}`                               |
+| `extraArgs`                       | Additional promscale CLI arguments          | `[]`                               |
 | `connection.uri`                  | DB uri string used for database connection. When not empty it takes priority over other settings in `connection` map. | `""` |
 | `connection.user`                 | Username to connect to TimescaleDB with     | `postgres`                         |
 | `connection.password`             | The DB password for user specified in `connection.user` | `""`                   |
@@ -127,8 +127,8 @@ helm install --name my-release -f myvalues.yaml .
 | `connection.sslMode`              | SSL mode for connection                     | `require`                          |
 | `prometheus.port`                 | Port the connector Service accepts prometheus remote_write connections on | `9201`              |
 | `prometheus.annotations`          | Annotations to allow prometheus metrics collection. | `{ "prometheus.io/scrape": 'true', "prometheus.io/port": '9201', "prometheus.io/path": '/metrics'}` |
-| `tracing.enabled`                 | Enable tracing support in Promscale, exposes container (in future releases tracing support will be enabled by default) | `false` |
-| `tracing.port`                    | Port the connector Service will accept otlp connections on | `9202`               |
+| `openTelemetry.enabled`           | Enable OpenTelemetry tracing support in Promscale (in future releases tracing support will be enabled by default) | `false` |
+| `openTelemetry.port`              | Port the connector Service will accept otlp connections on | `9202`               |
 | `service.type`                    | Type of Service to be used                  | `ClusterIP`                        |
 | `service.annotations`             | Annotations to set to the Service           | `{}`                               |
 | `serviceMonitor.enabled`          | Enable creation of serviceMonitor object used by prometheus-operator. `prometheus.annotations` should be set to `{}` when using this option.| `false` |

--- a/helm-chart/templates/deployment-promscale.yaml
+++ b/helm-chart/templates/deployment-promscale.yaml
@@ -29,12 +29,16 @@ spec:
         - image: {{ .Values.image }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           name: promscale-connector
-          {{- if .Values.args }}
+          {{- if or (.Values.openTelemetry.enabled) (.Values.extraArgs) }}
           args:
-            {{- range .Values.args }}
-              - {{ . }}
-            {{- end }}
-          {{- end}}
+          {{- if .Values.openTelemetry.enabled }}
+          - --enable-feature=tracing
+          - --otlp-grpc-server-listen-address=:9202
+          {{- end }}
+          {{- with .Values.extraArgs }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
+          {{- end }}
           envFrom:
           - secretRef:
               {{- $secretName := ternary (include "promscale.fullname" .) .Values.connectionSecretName (eq .Values.connectionSecretName "") }}
@@ -46,9 +50,9 @@ spec:
           ports:
             - containerPort: 9201
               name: metrics-port
-          {{- if .Values.tracing.enabled }}
+          {{- if .Values.openTelemetry.enabled }}
             - containerPort: 9202
-              name: traces-port
+              name: otel-port
           {{- end }}
       serviceAccountName: {{ template "promscale.fullname" . }}
       {{- with .Values.nodeSelector }}

--- a/helm-chart/templates/svc-promscale.yaml
+++ b/helm-chart/templates/svc-promscale.yaml
@@ -20,8 +20,8 @@ spec:
   - name: metrics-port
     port: {{ .Values.prometheus.port }}
     protocol: TCP
-  {{- if .Values.tracing.enabled }}
-  - name: traces-port
-    port: {{ .Values.tracing.port }}
+  {{- if .Values.openTelemetry.enabled }}
+  - name: otel-port
+    port: {{ .Values.openTelemetry.port }}
     protocol: TCP
   {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -20,17 +20,12 @@ upgradeStrategy: Recreate
 # For example, to activate HA, bump the replicaCount and set those arguments (also, make sure that external labels are configured on the Prometheus side):
 # - --high-availabiliity=1
 # More info about HA: https://github.com/timescale/promscale/blob/master/docs/high-avaliability/prometheus-HA.md
-args: []
+extraArgs: []
 
-# To enable tracing in Promscale configure args as
-#args:
-#- -enable-feature=tracing
-#- -otlp-grpc-server-listen-address=:9202
-
-# Currently tracing support is in beta
+# Currently OpenTelemetry tracing support is in beta
 # so tracing features needs to be explicitly enabled.
-tracing:
-  # tracing is only enabled if below field is configured true
+openTelemetry:
+  # OpenTelemetry tracing is only enabled if below field is configured true
   enabled: false
   port: 9202
 


### PR DESCRIPTION
Solves #918

PR is based on top of #924 as changes from that PR as essential here.

Breaking changes:
- `args` section is moved to `extraArgs` to note that arguments may be added using other parameters
- `tracing` section moved to `openTelemetry`

Enhancements:
- enabling OT tracing can be done just with `openTelemetry.enable` parameter and do not require setting any other parameters
- tracing port name changed to reflect its relation to OpenTelemetry
