### PR TITLE
Make prom-migrator unit test independent of current time

### DIFF
--- a/cmd/prom-migrator/main.go
+++ b/cmd/prom-migrator/main.go
@@ -37,6 +37,12 @@ const (
 	defaultLaIncrement     = time.Minute
 )
 
+// timeNowUnix returns the current Unix timestamp.
+// time.Now().Unix() call is wrapped so it can be mocked during testing.
+var timeNowUnix = func() int64 {
+	return time.Now().Unix()
+}
+
 type config struct {
 	name    string
 	start   string
@@ -333,7 +339,7 @@ func stripSingleQuotes(s string) string {
 func parseRFC3339(s string) (int64, error) {
 	if s == "" {
 		// When 'end' is not set.
-		return time.Now().Unix(), nil
+		return timeNowUnix(), nil
 	}
 	t, err := time.Parse(time.RFC3339, stripSingleQuotes(s))
 	if err != nil {
@@ -356,7 +362,7 @@ func convertTimeStrFlagsToTs(conf *config) error {
 	}
 	conf.mintSec = int64(v)
 	if conf.end == "" {
-		conf.end = fmt.Sprintf("%d", time.Now().Unix())
+		conf.end = fmt.Sprintf("%d", timeNowUnix())
 	}
 	v, err = strconv.Atoi(conf.end)
 	if err != nil {

--- a/cmd/prom-migrator/main_test.go
+++ b/cmd/prom-migrator/main_test.go
@@ -25,6 +25,11 @@ func getReaderLabelsMatcher(matcherType labels.MatchType, labelValue string) []*
 }
 
 func TestParseFlags(t *testing.T) {
+	currentTime := time.Now().Unix()
+	timeNowUnix = func() int64 {
+		return currentTime
+	}
+
 	cases := []struct {
 		name            string
 		input           []string
@@ -481,10 +486,10 @@ func TestParseFlags(t *testing.T) {
 			expectedConf: &config{
 				name:                 "prom-migrator",
 				start:                defaultStartTime,
-				end:                  fmt.Sprintf("%d", time.Now().Unix()),
+				end:                  fmt.Sprintf("%d", timeNowUnix()),
 				humanReadableTime:    true,
-				maxt:                 time.Now().Unix() * 1000,
-				maxtSec:              time.Now().Unix(),
+				maxt:                 timeNowUnix() * 1000,
+				maxtSec:              timeNowUnix(),
 				readerMetricsMatcher: `{__name__=~".+"}`,
 				readerLabelsMatcher:  getReaderLabelsMatcher(labels.MatchRegexp, ".+"),
 				readerClientConfig: utils.ClientConfig{
@@ -519,11 +524,11 @@ func TestParseFlags(t *testing.T) {
 			expectedConf: &config{
 				name:                 "prom-migrator",
 				start:                "1",
-				end:                  fmt.Sprintf("%d", time.Now().Unix()),
+				end:                  fmt.Sprintf("%d", timeNowUnix()),
 				mint:                 1000,
 				mintSec:              1,
-				maxt:                 time.Now().Unix() * 1000,
-				maxtSec:              time.Now().Unix(),
+				maxt:                 timeNowUnix() * 1000,
+				maxtSec:              timeNowUnix(),
 				readerMetricsMatcher: `{__name__=~".+"}`,
 				readerLabelsMatcher:  getReaderLabelsMatcher(labels.MatchRegexp, ".+"),
 				readerClientConfig: utils.ClientConfig{
@@ -558,12 +563,12 @@ func TestParseFlags(t *testing.T) {
 			expectedConf: &config{
 				name:                 "prom-migrator",
 				start:                "'1970-01-01T00:00:01+00:00'",
-				end:                  fmt.Sprintf("%d", time.Now().Unix()),
+				end:                  fmt.Sprintf("%d", timeNowUnix()),
 				humanReadableTime:    true,
 				mint:                 1000,
 				mintSec:              1,
-				maxt:                 time.Now().Unix() * 1000,
-				maxtSec:              time.Now().Unix(),
+				maxt:                 timeNowUnix() * 1000,
+				maxtSec:              timeNowUnix(),
 				readerMetricsMatcher: `{__name__=~".+"}`,
 				readerLabelsMatcher:  getReaderLabelsMatcher(labels.MatchRegexp, ".+"),
 				readerClientConfig: utils.ClientConfig{
@@ -598,12 +603,12 @@ func TestParseFlags(t *testing.T) {
 			expectedConf: &config{
 				name:                 "prom-migrator",
 				start:                "'1970-01-01T00:00:01+00:00'",
-				end:                  fmt.Sprintf("%d", time.Now().Unix()),
+				end:                  fmt.Sprintf("%d", timeNowUnix()),
 				humanReadableTime:    true,
 				mint:                 1000,
 				mintSec:              1,
-				maxt:                 time.Now().Unix() * 1000,
-				maxtSec:              time.Now().Unix(),
+				maxt:                 timeNowUnix() * 1000,
+				maxtSec:              timeNowUnix(),
 				readerMetricsMatcher: `{__name__=~".+"}`,
 				readerLabelsMatcher:  getReaderLabelsMatcher(labels.MatchRegexp, ".+"),
 				readerClientConfig: utils.ClientConfig{
@@ -638,12 +643,12 @@ func TestParseFlags(t *testing.T) {
 			expectedConf: &config{
 				name:                 "prom-migrator",
 				start:                "'1970-01-01T00:00:01+00:00'",
-				end:                  fmt.Sprintf("%d", time.Now().Unix()),
+				end:                  fmt.Sprintf("%d", timeNowUnix()),
 				humanReadableTime:    true,
 				mint:                 1000,
 				mintSec:              1,
-				maxt:                 time.Now().Unix() * 1000,
-				maxtSec:              time.Now().Unix(),
+				maxt:                 timeNowUnix() * 1000,
+				maxtSec:              timeNowUnix(),
 				readerMetricsMatcher: `{__name__=~".+"}`,
 				readerLabelsMatcher:  getReaderLabelsMatcher(labels.MatchRegexp, ".+"),
 				readerClientConfig: utils.ClientConfig{


### PR DESCRIPTION
Testing that depends on current time is usually flaky. This change wraps
`time.Now().Unix()` calls into an independent function which can be
manipulated to always return the same value thus making test more reliable.