### PR TITLE
Speed up Docker builds with caching

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,22 +1,21 @@
 # Build stage
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15.4-alpine AS builder
-COPY ./.git promscale/.git
-COPY ./pkg promscale/pkg
-COPY ./cmd promscale/cmd
-COPY ./go.mod promscale/go.mod
-COPY ./go.sum promscale/go.sum
+RUN apk update && apk add --no-cache git
+WORKDIR /promscale
+COPY ./go.mod ./go.sum ./
+RUN go mod download
+COPY ./.git .git/
+COPY ./pkg pkg/
+COPY ./cmd cmd/
 ARG TARGETOS
 ARG TARGETARCH
-RUN apk update && apk add --no-cache git \
-    && cd promscale \
-    && go mod download \
-    && GIT_COMMIT=$(git rev-list -1 HEAD) \
+RUN GIT_COMMIT=$(git rev-list -1 HEAD) \
     && GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} CGO_ENABLED=0 go build -a \
     --ldflags '-w' --ldflags "-X version.CommitHash=$GIT_COMMIT" \
-    -o /go/promscale ./cmd/promscale
+    -o /bin/promscale ./cmd/promscale
 
 # Final image
 FROM busybox
 LABEL maintainer="Timescale https://www.timescale.com"
-COPY --from=builder /go/promscale /
+COPY --from=builder /bin/promscale /
 ENTRYPOINT ["/promscale"]


### PR DESCRIPTION
Reorganized the order of certain Dockerfile commands so we can speed up
image builds. This enables Docker to re-use cached layers if files haven't changed.
This mainly addresses slowness of `go mod download`.
Another optimization we can do is reusing build caches but that requires bigger changes so I'll leave that for another PR.

With new Dockefile my local build time improved from 200s -> 70s ;)