### PR TITLE
Add Make Target for Downloading Trace Dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .DS_Store
 .git
 venv
+/pkg/tests/testdata/traces-dataset.sz

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,17 @@ build:
 test:
 	go test -v -race ./... -timeout 40m
 
-e2e-test:
+# traces-dataset.sz is used by ./pkg/tests/end_to_end_tests/ingest_trace_test.go
+pkg/tests/testdata/traces-dataset.sz:
+	wget https://github.com/timescale/promscale-test-data/raw/main/traces-dataset.sz -O ./pkg/tests/testdata/traces-dataset.sz
+
+e2e-test: pkg/tests/testdata/traces-dataset.sz
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false -use-timescaledb=false
 	go test -v ./pkg/tests/end_to_end_tests/ -use-timescale2
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false -use-timescale2
 	go test -v ./pkg/tests/end_to_end_tests/ -use-multinode
-
 
 go-fmt:
 	go fmt ./...


### PR DESCRIPTION
The `./pkg/tests/end_to_end_tests/ingest_trace_test.go` tests require
a dataset file. This file is fairly large, and is stored out-of-band
in a second GitHub repo. This commit adds a make target to make it
easy for folks to download this file into the correct place in the
code tree.