### PR TITLE
Prevent swallowed build errors in e2e tests

### DIFF
--- a/.github/workflows/docker-compose-tests.yml
+++ b/.github/workflows/docker-compose-tests.yml
@@ -1,5 +1,9 @@
 name: Docker Compose tests
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
   push:
     branches: [master, main, force_test, release-*]
@@ -26,8 +30,6 @@ jobs:
 
     - name: Test docker-compose setup referenced in docs
       run: ./docker-compose/test.sh
-      shell: bash
 
     - name: Test high-availability docker-compose setup
       run: ./docker-compose/high-availability/test.sh
-      shell: bash

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -1,5 +1,9 @@
 name: goreleaser
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
   push:
     branches: [master, main, force_test, release-*, staging, trying]

--- a/.github/workflows/go-report-card.yml
+++ b/.github/workflows/go-report-card.yml
@@ -1,5 +1,9 @@
 name: Go Report Card
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
   push:
     branches: [master, main]

--- a/.github/workflows/go-scheduled.yml
+++ b/.github/workflows/go-scheduled.yml
@@ -1,5 +1,9 @@
 name: Daily scheduled extended Go tests
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
   push:
     branches: [force_test, release-*]

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,9 @@
 name: Go
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
   push:
     branches: [master, main, force_test, release-*, staging, trying]

--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,4 +1,7 @@
 name: Run Gosec
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
 on:
   push:
     branches: [master, main, force_test, release-*]

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,9 @@
 name: Integration
 
+defaults:
+  run:
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 on:
   push:
     branches: [master, main, force_test, release-*, staging, trying]

--- a/pkg/tests/end_to_end_tests/telemetry_test.go
+++ b/pkg/tests/end_to_end_tests/telemetry_test.go
@@ -61,6 +61,9 @@ func TestPromscaleTobsMetadata(t *testing.T) {
 }
 
 func TestTelemetryInfoTableWrite(t *testing.T) {
+	if !*useTimescaleDB {
+		t.Skip("telemetry requires TimescaleDB")
+	}
 	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
 		db := testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_writer")
 		defer db.Close()
@@ -128,6 +131,9 @@ func TestOnlyOneHousekeeper(t *testing.T) {
 }
 
 func TestHousekeeper(t *testing.T) {
+	if !*useTimescaleDB || *useTimescaleOSS || !*useExtension {
+		t.Skip("telemetry requires TimescaleDB and the Promscale extension")
+	}
 	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
 		db := testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_writer")
 		defer db.Close()
@@ -162,6 +168,9 @@ func TestHousekeeper(t *testing.T) {
 }
 
 func TestCleanStalePromscales(t *testing.T) {
+	if !*useTimescaleDB {
+		t.Skip("telemetry requires TimescaleDB")
+	}
 	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
 		db := testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_writer")
 		defer db.Close()
@@ -252,7 +261,7 @@ func TestTelemetryEngineWhenTelemetryIsSetToOff(t *testing.T) {
 }
 
 func TestTelemetrySQLStats(t *testing.T) {
-	if !*useExtension {
+	if !*useExtension || !*useTimescale2 {
 		t.Skip("test will give wrong result without promscale_extension. Hence, skipping")
 	}
 	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
@@ -296,6 +305,9 @@ func TestTelemetrySQLStats(t *testing.T) {
 }
 
 func TestPromQLBasedTelemetry(t *testing.T) {
+	if !*useExtension {
+		t.Skip("test will give wrong result without promscale_extension. Hence, skipping")
+	}
 	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
 		conn, err := dbOwner.Acquire(context.Background())
 		if err != nil {

--- a/pkg/tests/end_to_end_tests/trace_delete_test.go
+++ b/pkg/tests/end_to_end_tests/trace_delete_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestDeleteSpans(t *testing.T) {
+	if *useMultinode {
+		t.Skip("Span deletion fails on multinode")
+	}
 	var ctx = context.Background()
 	databaseName := fmt.Sprintf("%s_delete_all_traces", *testDatabase)
 	withDB(t, databaseName, func(db *pgxpool.Pool, tb testing.TB) {


### PR DESCRIPTION
GitHub's documentation on `run` [1] and `shell` [2] implies that
commands invoked via bash will be run with `pipefail`. Unfortunately
this is not the case. Specifying `bash` as the `shell` does activate
`pipefail`, and prevent errors in test execution from being swallowed.

[1]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsrun
[2]: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstepsshell