### PR TITLE
Use timescale extension schema variable in migration

### DIFF
--- a/pkg/pgmodel/common/extension/extension.go
+++ b/pkg/pgmodel/common/extension/extension.go
@@ -43,7 +43,7 @@ func InstallUpgradeTimescaleDBExtensions(connstr string, extOptions ExtensionMig
 	}
 	defer func() { _ = db.Close(context.Background()) }()
 
-	err = MigrateExtension(db, "timescaledb", "public", version.TimescaleVersionRange, version.TimescaleVersionRangeFullString, extOptions)
+	err = MigrateExtension(db, "timescaledb", schema.Timescale, version.TimescaleVersionRange, version.TimescaleVersionRangeFullString, extOptions)
 	if err != nil {
 		return fmt.Errorf("could not install timescaledb: %w", err)
 	}


### PR DESCRIPTION
Back in 3af97e9f we introduced a variable for the Timescale extension's
schema, but it was not used in the extension migration.