### PR TITLE
Add ability to configure chunk interval on startup

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -81,6 +81,7 @@ You can also find information on flags with `promscale_<version> -help`.
 
 | Flag | Type | Default | Description |
 |------|:-----:|:-------:|:-----------|
+| startup.dataset.config | string | "" (disabled) | Dataset configuration in YAML format for Promscale. It is used for setting various dataset configuration like default metric chunk interval. For more information, please consult the following resources: [dataset](dataset.md)  |
 | startup.install-extensions | boolean | true | Install TimescaleDB & Promscale extensions. |
 | startup.only | boolean | false | Only run startup configuration with Promscale (i.e. migrate) and exit. Can be used to run promscale as an init container for HA setups. |
 | startup.skip-migrate | boolean | false | Skip migrating Promscale SQL schema to latest version on startup. |

--- a/docs/dataset.md
+++ b/docs/dataset.md
@@ -1,0 +1,29 @@
+# Dataset configuration format
+
+This document describes the format of the configuration structure used to setup the Promscale dataset options. Setup is done by using the `-startup.dataset.config` flag which should contain this configuration structure in YAML format
+
+Example usage:
+```
+promscale -startup.dataset.config=$'metrics:\n  default_chunk_interval: 6h'
+```
+
+Expected format is YAML and currently only option that can be set is default chunk interval.
+
+Example configuration in config.yaml:
+
+```
+startup.dataset.config: |
+  metrics:
+    default_chunk_interval: 6h
+```
+
+Above configuration will set the default chunk interval to 6 hours.
+
+Note: Any configuration omitted from the configuration structure will be set to its default value.
+
+
+## Default values
+
+| Setting | Type | Default | Description |
+|:--------|:----:|:-------:|:------------|
+| default_chunk_interval | duration | 8h | Chunk interval used to create hypertable chunks that store the metric data |

--- a/pkg/dataset/config.go
+++ b/pkg/dataset/config.go
@@ -1,0 +1,40 @@
+package dataset
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/timescale/promscale/pkg/log"
+	"github.com/timescale/promscale/pkg/pgmodel/common/schema"
+	"gopkg.in/yaml.v2"
+)
+
+const defaultChunkInterval = 8 * time.Hour
+
+var setDefaultChunkIntervalSQL = fmt.Sprintf("SELECT %s.set_default_chunk_interval($1)", schema.Prom)
+
+type Config struct {
+	Metrics Metrics `yaml:"metrics"`
+}
+
+type Metrics struct {
+	ChunkInterval time.Duration `yaml:"default_chunk_interval"`
+}
+
+func NewConfig(contents string) (cfg Config, err error) {
+	err = yaml.Unmarshal([]byte(contents), &cfg)
+	return cfg, err
+}
+
+func (c *Config) Apply(conn *pgx.Conn) error {
+	if c.Metrics.ChunkInterval <= 0 {
+		c.Metrics.ChunkInterval = defaultChunkInterval
+	}
+
+	log.Info("msg", fmt.Sprintf("Setting dataset default chunk interval to %s", c.Metrics.ChunkInterval))
+
+	_, err := conn.Exec(context.Background(), setDefaultChunkIntervalSQL, c.Metrics.ChunkInterval)
+	return err
+}

--- a/pkg/dataset/config_test.go
+++ b/pkg/dataset/config_test.go
@@ -1,0 +1,42 @@
+package dataset
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfig(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		cfg   Config
+		err   string
+	}{
+		{
+			name:  "invalid config yaml",
+			input: "invalid",
+			err:   "yaml: unmarshal errors:\n  line 1: cannot unmarshal !!str `invalid` into dataset.Config",
+		},
+		{
+			name:  "happy path",
+			input: "metrics:\n  default_chunk_interval: 3h",
+			cfg:   Config{Metrics: Metrics{ChunkInterval: 3 * time.Hour}},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.name, func(t *testing.T) {
+
+			cfg, err := NewConfig(c.input)
+
+			if c.err != "" {
+				require.EqualError(t, err, c.err)
+				return
+			}
+
+			require.Equal(t, cfg, c.cfg)
+		})
+	}
+}

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -31,6 +31,7 @@ type Config struct {
 	LimitsCfg                   limits.Config
 	TenancyCfg                  tenancy.Config
 	ConfigFile                  string
+	DatasetConfig               string
 	TLSCertFile                 string
 	TLSKeyFile                  string
 	ThroughputInterval          time.Duration
@@ -117,6 +118,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&corsOriginFlag, "web.cors-origin", ".*", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`)
 	fs.DurationVar(&cfg.ThroughputInterval, "log.throughput-report-interval", time.Second, "Duration interval at which throughput should be reported. Setting duration to `0` will disable reporting throughput, otherwise, an interval with unit must be provided, e.g. `10s` or `3m`.")
 	fs.StringVar(&migrateOption, "migrate", "true", "Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. (DEPRECATED) Will be removed in version 0.9.0")
+	fs.StringVar(&cfg.DatasetConfig, "startup.dataset.config", "", "Dataset configuration in YAML format for Promscale. It is used for setting various dataset configuration like default metric chunk interval")
 	fs.BoolVar(&cfg.StartupOnly, "startup.only", false, "Only run startup configuration with Promscale (i.e. migrate) and exit. Can be used to run promscale as an init container for HA setups.")
 	fs.BoolVar(&skipMigrate, "startup.skip-migrate", false, "Skip migrating Promscale SQL schema to latest version on startup.")
 

--- a/pkg/tests/end_to_end_tests/config_dataset_test.go
+++ b/pkg/tests/end_to_end_tests/config_dataset_test.go
@@ -1,0 +1,47 @@
+package end_to_end_tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/timescale/promscale/pkg/dataset"
+)
+
+func TestDatasetConfigApply(t *testing.T) {
+
+	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
+		conn, err := dbOwner.Acquire(context.Background())
+		require.NoError(t, err)
+		defer conn.Release()
+
+		pgxConn := conn.Conn()
+		require.Equal(t, getDefaultChunkInterval(t, pgxConn), 8*time.Hour)
+
+		cfg := dataset.Config{Metrics: dataset.Metrics{ChunkInterval: 4 * time.Hour}}
+
+		err = cfg.Apply(pgxConn)
+		require.NoError(t, err)
+
+		require.Equal(t, getDefaultChunkInterval(t, pgxConn), 4*time.Hour)
+
+		// Set to default if chunk interval is not specified.
+		cfg.Metrics.ChunkInterval = 0
+
+		err = cfg.Apply(pgxConn)
+		require.NoError(t, err)
+
+		require.Equal(t, getDefaultChunkInterval(t, pgxConn), 8*time.Hour)
+	})
+}
+
+func getDefaultChunkInterval(t testing.TB, conn *pgx.Conn) (chunkInterval time.Duration) {
+	err := conn.QueryRow(context.Background(), "SELECT _prom_catalog.get_default_chunk_interval()").Scan(&chunkInterval)
+	if err != nil {
+		t.Fatal("error getting default chunk interval", err)
+	}
+	return chunkInterval
+}


### PR DESCRIPTION
Configuring chunk interval at startup enables users to fine tune their
metrics dataset using only Promscale.

Fixes #974 