### PR TITLE
Adds support for PromQL based telemetry stats.

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -140,6 +140,7 @@ func createMetrics() *Metrics {
 		QueryDuration: prometheus.NewHistogram(
 			prometheus.HistogramOpts{
 				Namespace: util.PromNamespace,
+				Subsystem: "metrics",
 				Name:      "query_duration_seconds",
 				Help:      "Duration of query batch read calls to the PromQL engine.",
 				Buckets:   prometheus.DefBuckets,

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -112,7 +112,7 @@ func Run(cfg *Config) error {
 
 	var telemetryEngine telemetry.Engine
 
-	engine, err := telemetry.NewEngine(client.Connection, PromscaleID)
+	engine, err := telemetry.NewEngine(client.Connection, PromscaleID, client.Queryable())
 	if err != nil {
 		log.Error("msg", "aborting startup due to error in setting up telemetry-engine", "err", err.Error())
 		return fmt.Errorf("creating telemetry-engine: %w", err)

--- a/pkg/telemetry/promql.go
+++ b/pkg/telemetry/promql.go
@@ -1,0 +1,86 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package telemetry
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/timescale/promscale/pkg/promql"
+)
+
+type promqlTelemetry struct {
+	name        string
+	query       string
+	parsedQuery promql.Query
+}
+
+func (t *promqlTelemetry) execute(engine *promql.Engine, queryable promql.Queryable) (float64, error) {
+	if t.parsedQuery == nil {
+		qry, err := engine.NewInstantQuery(queryable, t.query, time.Now())
+		if err != nil {
+			return 0, fmt.Errorf("creating instant query: %w", err)
+		}
+		t.parsedQuery = qry
+	}
+
+	result := t.parsedQuery.Exec(context.Background())
+	if result.Err != nil {
+		return 0, fmt.Errorf("error executing promql query '%s': %w", t.query, result.Err)
+	}
+
+	value, err := getValue(result)
+	if err != nil {
+		return 0, fmt.Errorf("error extracting value from promql query '%s' response: %w", t.query, err)
+	}
+	return value, nil
+}
+
+func getValue(result *promql.Result) (float64, error) {
+	vec, err := result.Vector()
+	if err != nil {
+		return 0, fmt.Errorf("error reading vector response: %w", err)
+	}
+	numSamples := len([]promql.Sample(vec))
+	if numSamples > 1 {
+		return 0, fmt.Errorf("evaluated result must not contain more than one sample. Got num samples: %d", numSamples)
+	}
+
+	var value float64
+	if numSamples == 1 {
+		value = []promql.Sample(vec)[0].V
+	}
+
+	return value, nil
+}
+
+var promqlStats = []promqlTelemetry{
+	{
+		name:  "promql_query_execution_time_p50",
+		query: "histogram_quantile(0.5, sum by(le) (rate(promscale_metrics_query_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "promql_query_execution_time_p90",
+		query: "histogram_quantile(0.9, sum by(le) (rate(promscale_metrics_query_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "promql_query_execution_time_p95",
+		query: "histogram_quantile(0.95, sum by(le) (rate(promscale_metrics_query_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "promql_query_execution_time_p99",
+		query: "histogram_quantile(0.99, sum by(le) (rate(promscale_metrics_query_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "trace_query_execution_time_p50",
+		query: "histogram_quantile(0.5, sum by(le) (rate(promscale_trace_fetch_traces_api_execution_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "trace_query_execution_time_p90",
+		query: "histogram_quantile(0.9, sum by(le) (rate(promscale_trace_fetch_traces_api_execution_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "trace_query_execution_time_p95",
+		query: "histogram_quantile(0.95, sum by(le) (rate(promscale_trace_fetch_traces_api_execution_duration_seconds_bucket[1h])))",
+	}, {
+		name:  "trace_query_execution_time_p99",
+		query: "histogram_quantile(0.99, sum by(le) (rate(promscale_trace_fetch_traces_api_execution_duration_seconds_bucket[1h])))",
+	},
+}

--- a/pkg/tests/end_to_end_tests/migrate_test.go
+++ b/pkg/tests/end_to_end_tests/migrate_test.go
@@ -227,7 +227,7 @@ func TestMigrateTwice(t *testing.T) {
 		defer db.Close()
 
 		if *useTimescaleDB && extension.ExtensionIsInstalled {
-			_, err := telemetry.NewEngine(pgxconn.NewPgxConn(db), [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+			_, err := telemetry.NewEngine(pgxconn.NewPgxConn(db), [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, nil)
 			if err != nil {
 				t.Fatal("creating telemetry engine: %w", err)
 			}


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Telemetry collection also involves calculating quantiles that need the help
of PromQL expression. This commit implements the same. As of now, we
calculate p50, p90, p95, p99 of response durations of /query.* endpoints
and the /fetch_traces API (via GRPC).