### PR TITLE
Remove cron instructions

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -50,13 +50,6 @@ For updating Promscale in this method, you need to stop the Promscale that is cu
 `docker-compose stop` and then pull the image with the tag you want to upgrade to with `docker pull timescale/promscale:<version-tag>`.
 This will pull the respective image to your local docker registry. You can then run the updated image with `docker-compose up`.
 
-## 🕞 Setting up cron jobs
-
-Docker installations also need to make sure the `execute_maintenance()`
-procedure on a regular basis (e.g. via cron). We recommend executing it every
-30 minutes. This is necessary to execute maintenance tasks such as enforcing
-data retention policies according to the configured policy.
-
 **Example:**
 
 ```bash

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -50,16 +50,6 @@ For updating Promscale in this method, you need to stop the Promscale that is cu
 `docker-compose stop` and then pull the image with the tag you want to upgrade to with `docker pull timescale/promscale:<version-tag>`.
 This will pull the respective image to your local docker registry. You can then run the updated image with `docker-compose up`.
 
-**Example:**
-
-```bash
-docker exec \
-   --user postgres \
-   timescaledb \
-      psql \
-        -c "CALL execute_maintenance();"
-```
-
 ## 🔥 Configuring Prometheus to use this remote storage connector
 
 You must tell prometheus to use this remote storage connector by adding


### PR DESCRIPTION
Setting up cron to run execute maintenance is no longer needed with TimescaleDB 2. Promscale autmatically schedules jobs within the database to run execute_maintenance.

Solves #910