### PR TITLE
Prevent row deadlock

### DIFF
--- a/pkg/pgmodel/model/batch.go
+++ b/pkg/pgmodel/model/batch.go
@@ -7,6 +7,8 @@ package model
 import (
 	"fmt"
 	"time"
+
+	"github.com/timescale/promscale/pkg/log"
 )
 
 // Data wraps incoming data with its in-timestamp. It is used to warn if the rate
@@ -67,4 +69,24 @@ func (t *Batch) Visitor() *batchVisitor {
 
 func (t *Batch) Absorb(other Batch) {
 	t.AppendSlice(other.data)
+}
+
+func (t *Batch) Len() int {
+	return t.CountSeries()
+}
+
+func (t *Batch) Swap(i, j int) {
+	t.data[i], t.data[j] = t.data[j], t.data[i]
+}
+
+func (t *Batch) Less(i, j int) bool {
+	s1, _, err := t.data[i].Series().GetSeriesID()
+	if err != nil {
+		log.Warn("seriesID", "not set but being sorted on")
+	}
+	s2, _, err := t.data[j].Series().GetSeriesID()
+	if err != nil {
+		log.Warn("seriesID", "not set but being sorted on")
+	}
+	return s1 < s2
 }


### PR DESCRIPTION
If Prometheus retries sending samples  Promscale can attempt to insert duplicate data.
This can result in a row deadlock. Deadlock is detectable by PG when running on a singlenode.
However in a multinode setup that does not work due to distributed nature.
We make sure to always sort series before inserting to avoid the deadlock.
We don't sort samples in the series because they should already be sorted by Prometheus.

Closes https://github.com/timescale/promscale/issues/975