### PR TITLE
Pull latest promscale image

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -74,7 +74,7 @@ docker run --name timescaledb -e POSTGRES_PASSWORD=<password> -d -p 5432:5432 --
 Finally let’s run the Promscale Connector with tracing enabled (replace `<password>` with the password you selected in the previous step):
 
 ```bash
-docker run --name promscale -d -p 9201:9201 -p 9202:9202 --network promscale-timescaledb timescale/promscale:0.7.0-beta.latest -db-password=<password> -db-port=5432 -db-name=postgres -db-host=timescaledb -db-ssl-mode=allow -enable-feature=tracing -otlp-grpc-server-listen-address=:9202
+docker run --name promscale -d -p 9201:9201 -p 9202:9202 --network promscale-timescaledb timescale/promscale:latest -db-password=<password> -db-port=5432 -db-name=postgres -db-host=timescaledb -db-ssl-mode=allow -enable-feature=tracing -otlp-grpc-server-listen-address=:9202
 ```
 
 **Note**: `db-ssl-mode=allow` is just for explanatory purposes. In production environments, we advise you to use `db-ssl-mode=require` for security purposes.


### PR DESCRIPTION
A user in our community Slack reported that the instructions don't work because we added the -enable-feature flag but we kept the 0.7..0-beta.latest tag in the docker run command for the Promscale connector