### PR TITLE
Fix passing of async flag

### DIFF
--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -137,6 +137,7 @@ func NewClientWithPool(cfg *Config, numCopiers int, connPool *pgxpool.Pool, mt t
 	c := ingestor.Cfg{
 		NumCopiers:             numCopiers,
 		IgnoreCompressedChunks: cfg.IgnoreCompressedChunks,
+		AsyncAcks:              cfg.AsyncAcks,
 	}
 
 	var (

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -34,7 +34,6 @@ type Config struct {
 	DbConnectionTimeout     time.Duration
 	IgnoreCompressedChunks  bool
 	AsyncAcks               bool
-	ReportInterval          int
 	WriteConnectionsPerProc int
 	MaxConnections          int
 	UsesHA                  bool
@@ -82,6 +81,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 		"Example DB URI `postgres://postgres:password@localhost:5432/timescale?sslmode=require`")
 	fs.BoolVar(&cfg.EnableStatementsCache, "db.statements-cache", defaultDbStatementsCache, "Whether database connection pool should use cached prepared statements. "+
 		"Disable if using PgBouncer")
+	fs.BoolVar(&cfg.AsyncAcks, "metrics.async-acks", false, "Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss.")
 	return cfg
 }
 

--- a/pkg/pgclient/config_test.go
+++ b/pkg/pgclient/config_test.go
@@ -24,7 +24,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 		SslMode                 string
 		DbConnectionTimeout     time.Duration
 		AsyncAcks               bool
-		ReportInterval          int
 		LabelsCacheSize         uint64
 		MetricsCacheSize        uint64
 		SeriesCacheSize         uint64
@@ -52,7 +51,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     time.Minute * 2,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -75,7 +73,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Database:                "timescale",
 				SslMode:                 "require",
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -98,7 +95,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				Database:                "timescale",
 				SslMode:                 "require",
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -123,7 +119,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     time.Hour,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -148,7 +143,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -173,7 +167,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -198,7 +191,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -223,7 +215,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -248,7 +239,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,
@@ -273,7 +263,6 @@ func TestConfig_GetConnectionStr(t *testing.T) {
 				SslMode:                 "require",
 				DbConnectionTimeout:     defaultConnectionTime,
 				AsyncAcks:               false,
-				ReportInterval:          0,
 				LabelsCacheSize:         0,
 				MetricsCacheSize:        0,
 				SeriesCacheSize:         0,

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -20,7 +20,6 @@ import (
 
 type Cfg struct {
 	AsyncAcks              bool
-	ReportInterval         int
 	NumCopiers             int
 	DisableEpochSync       bool
 	IgnoreCompressedChunks bool

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -35,7 +35,6 @@ type Config struct {
 	TLSCertFile                 string
 	TLSKeyFile                  string
 	ThroughputInterval          time.Duration
-	AsyncAcks                   bool
 	Migrate                     bool
 	StopAfterMigrate            bool
 	UseVersionLease             bool
@@ -125,7 +124,6 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.BoolVar(&cfg.UseVersionLease, "startup.use-schema-version-lease", true, "Use schema version lease to prevent race conditions during migration.")
 	fs.BoolVar(&cfg.InstallExtensions, "startup.install-extensions", true, "Install TimescaleDB, Promscale extension.")
 	fs.BoolVar(&cfg.UpgradeExtensions, "startup.upgrade-extensions", true, "Upgrades TimescaleDB, Promscale extensions.")
-	fs.BoolVar(&cfg.AsyncAcks, "metrics.async-acks", false, "Acknowledge asynchronous inserts. If this is true, the inserter will not wait after insertion of metric data in the database. This increases throughput at the cost of a small chance of data loss.")
 	fs.BoolVar(&cfg.UpgradePrereleaseExtensions, "startup.upgrade-prerelease-extensions", false, "Upgrades to pre-release TimescaleDB, Promscale extensions.")
 	fs.StringVar(&cfg.TLSCertFile, "auth.tls-cert-file", "", "TLS Certificate file used for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 	fs.StringVar(&cfg.TLSKeyFile, "auth.tls-key-file", "", "TLS Key file for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")


### PR DESCRIPTION
There were two problems with async flag. First it was present
in two Config structs and parsed in the struct that is not being
used. Second was that async flag was not passed when creating
sub-config structure. This resulted in async flag not being
applied.

Also removing some unused config.

Hopefully in future we will increase test coverage for flags and configs so we catch this easily. 
It seems we would need a decent amount of refactoring to support these tests so I'll leave it for another PR.