### PR TITLE
fix(helm): use fixed target port on svc-promscale

### DIFF
--- a/deploy/helm-chart/Chart.yaml
+++ b/deploy/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: promscale
-version: 0.7.1
+version: 0.7.2
 appVersion: 0.7.1
 apiVersion: v2
 home: https://github.com/timescale/promscale

--- a/deploy/helm-chart/templates/svc-promscale.yaml
+++ b/deploy/helm-chart/templates/svc-promscale.yaml
@@ -19,9 +19,11 @@ spec:
   ports:
   - name: metrics-port
     port: {{ .Values.prometheus.port }}
+    targetPort: metrics-port
     protocol: TCP
   {{- if .Values.openTelemetry.enabled }}
   - name: otel-port
     port: {{ .Values.openTelemetry.port }}
+    targetPort: otel-port
     protocol: TCP
   {{- end }}


### PR DESCRIPTION
Hello,

While playing around with the Helm chart, I saw an issue when using a custom `prometheus.port` or `openTelemetry.port` value. Currently, the service will automatically use the custom configuration as the `targetPort`, which will fail as those ports are not customizable.

The fix proposes to hardcode the  `targetPort` bindings to the Deployment's named ports.

Let me know if you have any remarks about it. :)