### PR TITLE
Add `db-writer-connection-concurrency` flag back

### DIFF
--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -61,6 +61,7 @@ var flagAliases = map[string][]string{
 	"db.statements-cache":               {"db-statements-cache"},
 	"db.uri":                            {"db-uri"},
 	"db.user":                           {"db-user"},
+	"db.num-writer-connections":         {"db-writer-connection-concurrency"},
 	"log.format":                        {"log-format"},
 	"log.level":                         {"log-level"},
 	"log.throughput-report-interval":    {"tput-report"},

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -188,6 +188,14 @@ func TestParseFlags(t *testing.T) {
 				return c
 			},
 		},
+		{
+			name: "test deprecated CLI flag",
+			args: []string{"-db-writer-connection-concurrency", "10"},
+			result: func(c Config) Config {
+				c.PgmodelCfg.WriteConnectionsPerProc = 10
+				return c
+			},
+		},
 	}
 
 	for _, c := range testCases {


### PR DESCRIPTION
This is a deprecated flag but we still need it for compatibility reasons.