### PR TITLE
Run `go generate` in Makefile and Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 .PHONY: build
-build:
+build: generate
 	go build -o dist/promscale ./cmd/promscale
 
-test:
+.PHONY: test
+test: generate
 	go test -v -race ./... -timeout 40m
 
 # traces-dataset.sz is used by ./pkg/tests/end_to_end_tests/ingest_trace_test.go
 pkg/tests/testdata/traces-dataset.sz:
 	wget https://github.com/timescale/promscale-test-data/raw/main/traces-dataset.sz -O ./pkg/tests/testdata/traces-dataset.sz
 
-e2e-test: pkg/tests/testdata/traces-dataset.sz
+.PHONY: e2e-test
+e2e-test: pkg/tests/testdata/traces-dataset.sz generate
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false -use-timescaledb=false
@@ -17,13 +19,17 @@ e2e-test: pkg/tests/testdata/traces-dataset.sz
 	go test -v ./pkg/tests/end_to_end_tests/ -use-extension=false -use-timescale2
 	go test -v ./pkg/tests/end_to_end_tests/ -use-multinode
 
+.PHONY: go-fmt
 go-fmt:
 	go fmt ./...
 
+.PHONY: go-lint
 go-lint:
 	golangci-lint run
 
+.PHONY: generate
 generate:
 	go generate ./...
 
+.PHONY: all
 all: build test e2e-test go-fmt go-lint

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,6 +9,7 @@ COPY ./pkg pkg/
 COPY ./cmd cmd/
 ARG TARGETOS
 ARG TARGETARCH
+RUN go generate ./...
 RUN GIT_COMMIT=$(git rev-list -1 HEAD) \
     && GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} CGO_ENABLED=0 go build -a \
     --ldflags '-w' --ldflags "-X version.CommitHash=$GIT_COMMIT" \


### PR DESCRIPTION
Since we statically implement content of SQL files into Go code we need to run `go generate` to make
sure we use the latest SQL code.