### PR TITLE
Add a simple tracing setup to the docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ We use the following categories for changes:
 - Add `ps_trace.get_trace_retention_period()` database function to get current trace retention period [#1015]
 - Add ability to set additional environment variables in helm chart [#1041]
 - Add OpenTelemetry tracing instrumentation to metric ingest codepath
+- Add example tracing setup to docker-compose [#1024]
 
 ### Changed
 - Rename CLI flags to improve user interface [#964]

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     image: timescale/promscale:latest
     ports:
       - 9201:9201/tcp
+      - 9202:9202/tcp
     restart: on-failure
     depends_on:
       - db
@@ -28,6 +29,29 @@ services:
       PROMSCALE_DB_CONNECT_RETRIES: 10
       PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
+      PROMSCALE_ENABLE_FEATURE: tracing
+      PROMSCALE_OTLP_GRPC_SERVER_LISTEN_ADDRESS: ":9202"
+      PROMSCALE_TELEMETRY_TRACE_JAEGER_ENDPOINT: "http://otel-collector:14268/api/traces"
+      PROMSCALE_TELEMETRY_TRACE_SAMPLING_RATIO: "0.1"
+
+  otel-collector:
+    platform: linux/amd64
+    image: "otel/opentelemetry-collector:0.41.0"
+    command: [ "--config=/etc/otel-collector-config.yml" ]
+    volumes:
+      - ./otel-collector-config.yml:/etc/otel-collector-config.yml
+    ports:
+      - "14268:14268" # jaeger http
+
+  jaeger:
+    image: jaegertracing/jaeger-query:1.30.0
+    environment:
+      SPAN_STORAGE_TYPE: grpc-plugin
+    command: [
+      "--grpc-storage.server=promscale:9202",
+    ]
+    ports:
+      - "16686:16686"
 
   node_exporter:
     image: quay.io/prometheus/node-exporter

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
+    depends_on:
+     - promscale
     ports:
       - 9090:9090/tcp
     volumes:
@@ -24,7 +26,6 @@ services:
     restart: on-failure
     depends_on:
       - db
-      - prometheus
     environment:
       PROMSCALE_DB_CONNECT_RETRIES: 10
       PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text

--- a/docker-compose/otel-collector-config.yml
+++ b/docker-compose/otel-collector-config.yml
@@ -1,0 +1,27 @@
+receivers:
+  jaeger:
+    protocols:
+      thrift_http:
+        endpoint: "0.0.0.0:14268"
+
+exporters:
+  logging:
+  otlp:
+    endpoint: promscale:9202
+    tls:
+      insecure: true
+
+processors:
+  batch:
+
+service:
+  telemetry:
+    logs:
+      level: "debug"
+
+  pipelines:
+    traces:
+      receivers: [jaeger]
+      exporters: [otlp, logging]
+      processors: [batch]
+


### PR DESCRIPTION
## Description

This change adds a tracing configuration to our docker-compose, leveraging Promscale's trace output.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
