### PR TITLE
deploy/helm-chart: add kubernetes recommended labels

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -6,3 +6,4 @@ chart-dirs:
 chart-repos: []
 helm-extra-args: --timeout 600s
 validate-maintainers: false
+check-version-increment: false

--- a/deploy/helm-chart/Chart.yaml
+++ b/deploy/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: promscale
-version: 0.7.3
+version: 0.7.2
 appVersion: 0.7.1
 apiVersion: v2
 home: https://github.com/timescale/promscale

--- a/deploy/helm-chart/Chart.yaml
+++ b/deploy/helm-chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: promscale
-version: 0.7.2
+version: 0.7.3
 appVersion: 0.7.1
 apiVersion: v2
 home: https://github.com/timescale/promscale

--- a/deploy/helm-chart/templates/deployment-promscale.yaml
+++ b/deploy/helm-chart/templates/deployment-promscale.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "promscale.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "promscale-connector"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: "promscale-connector"
+    app.kubernetes.io/component: "connector"
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
@@ -19,6 +23,12 @@ spec:
     metadata:
       labels:
         app: {{ template "promscale.fullname" . }}
+        chart: {{ template "promscale.chart" . }}
+        release: {{ .Release.Name }}
+        app.kubernetes.io/name: "promscale-connector"
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
+        app.kubernetes.io/part-of: "promscale-connector"
+        app.kubernetes.io/component: "connector"
       annotations: 
         checksum/config: {{ printf "%s" .Values.connection | sha256sum -}}
         {{- if .Values.prometheus.annotations }}

--- a/deploy/helm-chart/templates/secret-connection.yaml
+++ b/deploy/helm-chart/templates/secret-connection.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ template "promscale.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "promscale-connector"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: "promscale-connector"
+    app.kubernetes.io/component: "connector"
 stringData:
   {{- if ne (.Values.connection.uri | toString) "" }}
   PROMSCALE_DB_URI: {{ .Values.connection.uri | toString | quote }}

--- a/deploy/helm-chart/templates/service-account.yaml
+++ b/deploy/helm-chart/templates/service-account.yaml
@@ -9,3 +9,7 @@ metadata:
     chart: {{ template "promscale.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "promscale-connector"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: "promscale-connector"
+    app.kubernetes.io/component: "connector"

--- a/deploy/helm-chart/templates/service-monitor.yaml
+++ b/deploy/helm-chart/templates/service-monitor.yaml
@@ -9,6 +9,10 @@ metadata:
     chart: {{ template "promscale.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "promscale-connector"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: "promscale-connector"
+    app.kubernetes.io/component: "connector"
 spec:
   endpoints:
   - interval: 30s

--- a/deploy/helm-chart/templates/svc-promscale.yaml
+++ b/deploy/helm-chart/templates/svc-promscale.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "promscale.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "promscale-connector"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: "promscale-connector"
+    app.kubernetes.io/component: "connector"
   {{- if .Values.service.annotations }}
   annotations:
     {{- .Values.service.annotations | toYaml | nindent 4 }}


### PR DESCRIPTION
I need statically defined labels to easily create pod anti affinity rule before deploying promscale ([this doesn't work](https://github.com/timescale/savannah-infra/pull/1168/files#diff-86f3fceb69e1bd3fda16d679c62b89b749dcf97360925716e339e597bf87707fR33-R36)). To do this we can pre-define few of [kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/). I have defined only 3, but in the future we can add more.