### PR TITLE
Add the helm release CICD job

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -56,3 +56,38 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml
+
+  publish-chart:
+    runs-on: ubuntu-latest
+    needs: [generate, lint-test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
+      - name: Create package
+        env:
+          AWS_REGION: 'us-east-1'
+          AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_SECRET_ACCESS_KEY }}
+        run: |
+            mkdir -p chart_release
+            helm package deploy/helm-chart -d chart_release/
+            helm plugin install https://github.com/hypnoglow/helm-s3.git          
+            helm repo add tscharts s3://charts.timescale.com
+            helm s3 push chart_release/* tscharts --acl public-read --dry-run 
+
+      - name: push package
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          AWS_REGION: 'us-east-1'
+          AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_SECRET_ACCESS_KEY }}
+        run: |
+          helm s3 push chart_release/* tscharts --acl public-read


### PR DESCRIPTION
This job compiles and publishes the helm release. It works
by downloading the latest index, and then packaging the new
chart and adding it to the new index, and uploading it back
to the S3 bucket.

There is a possible race condition that if two such jobs
execute at the same time only one of the jobs will have it's
chart added to the repo. This is not very likely though.

The other alternative is to have a git repo for all the charts
and upload from there. This avoids the possibility of a race
condition but is a more complex solution.