### PR TITLE
Add templating for db secret name and host in helm-chart

### DIFF
--- a/deploy/helm-chart/templates/deployment-promscale.yaml
+++ b/deploy/helm-chart/templates/deployment-promscale.yaml
@@ -52,7 +52,7 @@ spec:
           envFrom:
           - secretRef:
               {{- $secretName := ternary (include "promscale.fullname" .) .Values.connectionSecretName (eq .Values.connectionSecretName "") }}
-              name: {{ $secretName }}
+              name: {{ tpl $secretName . }}
           {{- if .Values.resources }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/deploy/helm-chart/templates/secret-connection.yaml
+++ b/deploy/helm-chart/templates/secret-connection.yaml
@@ -20,7 +20,7 @@ stringData:
   PROMSCALE_DB_PORT: {{ .Values.connection.port | toString | quote }}
   PROMSCALE_DB_USER: {{ .Values.connection.user | toString | quote }}
   PROMSCALE_DB_PASSWORD: {{ .Values.connection.password | toString | quote }}
-  PROMSCALE_DB_HOST: {{ .Values.connection.host | toString | quote }}
+  PROMSCALE_DB_HOST: {{ tpl .Values.connection.host . | toString | quote }}
   PROMSCALE_DB_NAME: {{ .Values.connection.dbName | toString | quote }}
   PROMSCALE_DB_SSL_MODE: {{ .Values.connection.sslMode | toString | quote }}
   {{- end }}


### PR DESCRIPTION
## Description

Currently, with recent helm-chart changes, we aren't supporting templating options for `connectionSecretName` and `connection.host`. In tobs we build these values using `.Release.Name` and `.Release.Namespace`. So to support this tempting option in tobs adding templating support. 

For example:

The default connectionSecretName is `{{ .Release.Name }}-credentials`
The default hostname is `{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local`

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
