### PR TITLE
Remove deprecated `migrate` from CLI.md

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,6 @@ You can also find information on flags with `promscale_<version> -help`.
 | cache.memory-target | unsigned-integer or percentage | 80% | Target for max amount of memory to use. Specified in bytes or as a percentage of system memory (e.g. 80%). |
 | config | string | config.yml | YAML configuration file path for Promscale. |
 | enable-feature | string | "" | Enable one or more experimental promscale features (as a comma-separated list). Current experimental features are `tracing`, `promql-at-modifier`, and `promql-negative-offset`. For more information, please consult the following resources: [tracing](tracing.md), [promql-at-modifier](https://prometheus.io/docs/prometheus/latest/feature_flags/#modifier-in-promql), [promql-negative-offset](https://prometheus.io/docs/prometheus/latest/feature_flags/#negative-offset-in-promql). |
-| migrate | string | true | Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. |
 | thanos.store-api.server-address | string | "" (disabled) | Address to listen on for Thanos Store API endpoints. |
 | tracing.otlp.server-address string | string | "" (disabled) | Address to listen on for OTLP GRPC server. |
 


### PR DESCRIPTION
## Description

The `migrate` option is deprecated.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
