### PR TITLE
Add database host and port to instructions

### DIFF
--- a/docs/binary.md
+++ b/docs/binary.md
@@ -19,7 +19,7 @@ chmod +x promscale
 
 To deploy Promscale, run the following command:
 ```
-./promscale --db-name <DBNAME> --db-password <DB-Password> --db-ssl-mode allow
+./promscale --db-host <DB_HOSTNAME> --db-port <DB_PORT> --db-name <DBNAME> --db-password <DB-Password> --db-ssl-mode allow
 ```
 Note that the flags `db-name` and `db-password` refer to the name and password of your TimescaleDB database.
 


### PR DESCRIPTION
## Description

The instructions don't tell people how to specify a host and port if TSDB is not running locally on the default port. I've just added the two parameters to the promscale command.
