### PR TITLE
Add Promscale as scrape target in docker-compose config

### DIFF
--- a/docker-compose/prometheus.yml
+++ b/docker-compose/prometheus.yml
@@ -8,6 +8,11 @@ scrape_configs:
   - job_name: node-exporter
     static_configs:
       - targets: ['node_exporter:9100']
+  - job_name: promscale
+    metrics_path: '/metrics-text'
+    static_configs:
+      - targets: ['promscale:9201']
+
 remote_write:
   - url: "http://promscale:9201/write"
 remote_read:


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

This adds Promscale as a scrape target to the prometheus config we provide with our docker-compose. It should give visibility to the fact that Promscale can be scraped by prometheus.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [-] CHANGELOG entry for user-facing changes
- [-] Updated the relevant documentation
