### PR TITLE
deploy/helm-chart: allow templating connection values

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -60,6 +60,7 @@ jobs:
   publish-chart:
     runs-on: ubuntu-latest
     needs: [generate, lint-test]
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -84,7 +85,6 @@ jobs:
             helm s3 push chart_release/* tscharts --acl public-read --dry-run 
 
       - name: push package
-        if: startsWith(github.ref, 'refs/tags/')
         env:
           AWS_REGION: 'us-east-1'
           AWS_ACCESS_KEY_ID: ${{ secrets.ORG_AWS_HELM_CHART_BUCKET_ACCESS_KEY_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ We use the following categories for changes:
 ## [Unreleased]
 
 ### Added
+- Allow templating host and uri connection strings in helm chart [#1055]
 - Add ability to configure the default chunk interval on startup [#991]
 - Add `ps_trace.delete_all_traces()` function to delete all trace data [#1012]
 - Add `ps_trace.set_span_retention_period(INTERVAL)` function to set span retention period [#1015]

--- a/deploy/helm-chart/templates/secret-connection.yaml
+++ b/deploy/helm-chart/templates/secret-connection.yaml
@@ -15,7 +15,7 @@ metadata:
     app.kubernetes.io/component: "connector"
 stringData:
   {{- if ne (.Values.connection.uri | toString) "" }}
-  PROMSCALE_DB_URI: {{ .Values.connection.uri | toString | quote }}
+  PROMSCALE_DB_URI: {{ tpl .Values.connection.uri . | toString | quote }}
   {{- else }}
   PROMSCALE_DB_PORT: {{ .Values.connection.port | toString | quote }}
   PROMSCALE_DB_USER: {{ .Values.connection.user | toString | quote }}

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -45,12 +45,12 @@ connection:
   # user used to connect to TimescaleDB
   user: postgres
   password: ""
-  host: "timescaledb.default.svc.cluster.local"
+  host: "timescaledb.{{ .Release.Namespace }}.svc.cluster.local"
   port: 5432
   sslMode: require
   # database name in which to store the metrics
   # must be created before start
-  dbName: timescale
+  dbName: tsdb
 
 # Enable ServiceMonitor used by prometheus-operator to configure prometheus for metrics scraping
 serviceMonitor:


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

This allows simplifying configuration for cases when DB is in the same namespace as promscale-connector. To illustrate:
```shell
$ helm template --namespace ns . | grep PROMSCALE_DB_HOST
  PROMSCALE_DB_HOST: "timescaledb.ns.svc.cluster.local"
```

I also changed the default db name to `tsdb` as this is also the default name when using timescaledb on cloud.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
