### PR TITLE
Update HA doc and add old HA CLI alias

### DIFF
--- a/docs/high-availability/prometheus-HA.md
+++ b/docs/high-availability/prometheus-HA.md
@@ -55,7 +55,7 @@ global:
 ```
 
 After Prometheus instances are configured to send the correct labels,
-Promscale simply needs to be started with the `-high-availability` CLI flag.
+Promscale simply needs to be started with the `-metrics.high-availability` CLI flag.
 Internally, Promscale will elect a single replica per cluster to be the
 current leader. Only data sent from that replica will be ingested. If that
 leader-replica stops sending data, then a new replica will be elected as the

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -67,6 +67,7 @@ var flagAliases = map[string][]string{
 	"metrics.cache.metrics.size":        {"metrics-cache-size"},
 	"metrics.cache.series.initial-size": {"series-cache-initial-size"},
 	"metrics.cache.series.max-bytes":    {"series-cache-max-bytes"},
+	"metrics.high-availability":         {"high-availability"},
 	"metrics.ignore-samples-written-to-compressed-chunks": {"ignore-samples-written-to-compressed-chunks"},
 	"metrics.multi-tenancy":                               {"multi-tenancy"},
 	"metrics.multi-tenancy.allow-non-tenants":             {"multi-tenancy-allow-non-tenants"},


### PR DESCRIPTION
## Description

Old CLI flag for high availability was referenced in one of the docs and that old flag did not have the necessary alias.
This change fixes that.

Fixes #1073 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
