### PR TITLE
Fix broken `promscale_packager` telemetry field for docker envs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ We use the following categories for changes:
 ### Added
 - Add support to instrument Promscale's Otel GRPC server with Prometheus metrics [#1061]
 
+### Fixed
+- Fix broken `promscale_packager` telemetry field for docker envs [#1077]
+
 ## [0.8.0] - 2022-01-18
 
 ### Added

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,6 +17,7 @@ RUN GIT_COMMIT=$(git rev-list -1 HEAD) \
 
 # Final image
 FROM busybox
+ENV PROMSCALE_PKG=docker
 LABEL maintainer="Timescale https://www.timescale.com"
 COPY --from=builder /bin/promscale /
 ENTRYPOINT ["/promscale"]

--- a/pkg/telemetry/metadata.go
+++ b/pkg/telemetry/metadata.go
@@ -61,12 +61,10 @@ func turnOffPackageLogging() {
 
 func getPkgEnv() string {
 	pkg := os.Getenv("PROMSCALE_PKG")
-	switch pkg {
-	case "deb", "rpm", "apk":
-		return pkg
-	default:
-		return "unknown"
+	if pkg == "" {
+		pkg = "unknown"
 	}
+	return pkg
 }
 
 func toString(prop []byte) string {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This commits fixes the `promscale_packager` telemetry field that was
earlier showing `unknown` for all docker deployments. Now, it will show
`promscale_packager: docker` in the `_timescaledb_catalog.metadata`
table.

Metadata table output

```shell
 promscale_packager                                          | docker                               | t
 promscale_os_node_name                                      | 2bce24e46fcc                         | t
```

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
