### PR TITLE
Ensure that span start <= end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ We use the following categories for changes:
 ### Added
 - Add Prometheus metrics support for Tracing [#1102]
 
+### Fixed
+- Fix spans with end < start. Start and end are swapped in this case. [#1096]
+
 ## [0.9.0] - 2022-02-02
 
 ### Added

--- a/pkg/tests/end_to_end_tests/dataset_traces_test.go
+++ b/pkg/tests/end_to_end_tests/dataset_traces_test.go
@@ -136,8 +136,9 @@ func fillSpanOne(span pdata.Span) {
 	span.SetTraceID(pdata.NewTraceID(traceID1))
 	span.SetSpanID(pdata.NewSpanID(generateRandSpanID()))
 	span.SetName("operationA")
-	span.SetStartTimestamp(testSpanStartTimestamp)
-	span.SetEndTimestamp(testSpanEndTimestamp)
+	// test the logic that detects and fixes end < start
+	span.SetStartTimestamp(testSpanEndTimestamp)
+	span.SetEndTimestamp(testSpanStartTimestamp)
 	span.SetDroppedAttributesCount(1)
 	span.SetTraceState("span-trace-state1")
 	initSpanAttributes(span.Attributes())


### PR DESCRIPTION
## Description

I have seen instances in which promscale attempts to insert spans that have an end time < start time. There is a database check constraint that catches this error, but it results in dropped spans. This patch catches the issue in Go and swaps the start and end times so that the spans will be inserted successfully.

[Issue](https://github.com/timescale/promscale/issues/1092)

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
