### PR TITLE
Fix broken pushdown queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use the following categories for changes:
 ### Fixed
 - Fix spans with end < start. Start and end are swapped in this case. [#1096]
 - Disable push downs which use `offset`, as they are broken [#1129]
+- Fix aggregate pushdown evaluation [#1098]
 
 ## [0.9.0] - 2022-02-02
 

--- a/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_query_endpoint_test.go
@@ -2510,6 +2510,14 @@ func TestPromQLQueryEndpoint(t *testing.T) {
 			name:  "delta function over range selector with offset",
 			query: `delta(metric_2[1m] offset 3m)`,
 		},
+		{
+			name:  "pushdown with range smaller than instant vector lookback",
+			query: `rate(metric_2[1m]) / metric_2`,
+		},
+		{
+			name:  "pushdown with range smaller than instant vector lookback and offset",
+			query: `rate(metric_2[1m]) / metric_2 offset 2m`,
+		},
 	}
 	start := time.Unix(startTime/1000, 0)
 	end := time.Unix(endTime/1000, 0)


### PR DESCRIPTION
## Description

Under certain circumstances, pushdown queries using promscale-extension
aggregates fail.

The failure comes from the fact that the start and end parameters passed
to the aggregate don't correctly align with the actual data which is
aggregated over by the query.

A call to the prom_rate aggregate looks something like the following:

```sql
SELECT
    prom_rate(start, end, step_size, range, sample_time, sample_value)
FROM a_metric
WHERE a_metric.t >= data_start
  AND a_metric.t <= data_end
```

If the time span [data_start, data_end] delivers results which are
outside of the time span [start, end], the aggregate function errors.

In general, this bug appeared when an aggregate pushdown function (such
as PromQL rate) is used together with a vector selector, such that the
lookback of the vector selector is larger than that of the aggregate
pushdown.

The fix is to build the SQL query using the correct values for
data_start and data_end.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
