### PR TITLE
Refactor out RemoteReadQuerier interface

### DIFF
--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -70,6 +70,10 @@ func (ms mockQuerier) Select(int64, int64, bool, *storage.SelectHints, *querier.
 	return &mockSeriesSet{err: ms.selectErr}, nil
 }
 
+func (m mockQuerier) RemoteReadQuerier() querier.RemoteReadQuerier {
+	return nil
+}
+
 func (m mockQuerier) ExemplarsQuerier(_ context.Context) querier.ExemplarQuerier {
 	return mockExemplarQuerier{}
 }

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -216,8 +216,10 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 		Results: make([]*prompb.QueryResult, len(req.Queries)),
 	}
 
+	qr := c.querier.RemoteReadQuerier()
+
 	for i, q := range req.Queries {
-		tts, err := c.querier.Query(q)
+		tts, err := qr.Query(q)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pgclient/client_test.go
+++ b/pkg/pgclient/client_test.go
@@ -36,7 +36,19 @@ func (q mockSamplesQuerier) Select(mint int64, maxt int64, sortSeries bool, hint
 	return nil, nil
 }
 
-func (q *mockQuerier) Query(*prompb.Query) ([]*prompb.TimeSeries, error) {
+func (q *mockQuerier) RemoteReadQuerier() querier.RemoteReadQuerier {
+	return mockRemoteReadQuerier{
+		tts: q.tts,
+		err: q.err,
+	}
+}
+
+type mockRemoteReadQuerier struct {
+	tts []*prompb.TimeSeries
+	err error
+}
+
+func (q mockRemoteReadQuerier) Query(_ *prompb.Query) ([]*prompb.TimeSeries, error) {
 	return q.tts, q.err
 }
 

--- a/pkg/pgmodel/querier/interface.go
+++ b/pkg/pgmodel/querier/interface.go
@@ -22,15 +22,22 @@ type SeriesSet interface {
 	Close()
 }
 
-// Querier queries the data using the provided query data and returns the
-// matching timeseries.
+// Querier provides access to the three query methods: remote read, samples,
+// and exemplars.
 type Querier interface {
-	// Query returns resulting timeseries for a query.
-	Query(*prompb.Query) ([]*prompb.TimeSeries, error)
+	// RemoteReadQuerier returns a remote storage querier
+	RemoteReadQuerier() RemoteReadQuerier
 	// SamplesQuerier returns a sample querier.
 	SamplesQuerier() SamplesQuerier
 	// ExemplarsQuerier returns an exemplar querier.
 	ExemplarsQuerier(ctx context.Context) ExemplarQuerier
+}
+
+// RemoteReadQuerier queries the data using the provided query data and returns
+// the matching timeseries.
+type RemoteReadQuerier interface {
+	// Query returns resulting timeseries for a query.
+	Query(*prompb.Query) ([]*prompb.TimeSeries, error)
 }
 
 // SamplesQuerier queries data using the provided query data and returns the

--- a/pkg/pgmodel/querier/querier_sql_test.go
+++ b/pkg/pgmodel/querier/querier_sql_test.go
@@ -722,7 +722,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 			}
 			querier := pgxQuerier{&queryTools{conn: mock, metricTableNames: mockMetrics, labelsReader: lreader.NewLabelsReader(mock, clockcache.WithMax(0))}}
 
-			result, err := querier.Query(c.query)
+			result, err := querier.RemoteReadQuerier().Query(c.query)
 
 			if err != nil {
 				switch {

--- a/pkg/pgmodel/querier/query_exemplar.go
+++ b/pkg/pgmodel/querier/query_exemplar.go
@@ -84,9 +84,8 @@ func (q *queryExemplars) Select(start, end time.Time, matchersList ...[]*labels.
 	return results, nil
 }
 
-// fetchSingleMetricSamples returns all the result rows for a single metric using the
-// query metadata and the tools. It uses the hints and node path to try to push
-// down query functions where possible.
+// fetchSingleMetricExemplars returns all exemplar rows for a single metric
+// using the query metadata and tools.
 func fetchSingleMetricExemplars(tools *queryTools, metadata *evalMetadata) ([]exemplarSeriesRow, error) {
 	sqlQuery := buildSingleMetricExemplarsQuery(metadata)
 
@@ -107,7 +106,7 @@ func fetchSingleMetricExemplars(tools *queryTools, metadata *evalMetadata) ([]ex
 	return exemplarSeriesRows, nil
 }
 
-// queryMultipleMetrics returns all the result rows for across multiple metrics
+// fetchMultipleMetricsExemplars returns all the result rows across multiple metrics
 // using the supplied query parameters.
 func fetchMultipleMetricsExemplars(tools *queryTools, metadata *evalMetadata) ([]exemplarSeriesRow, error) {
 	// First fetch series IDs per metric.

--- a/pkg/pgmodel/querier/query_remote_read.go
+++ b/pkg/pgmodel/querier/query_remote_read.go
@@ -1,0 +1,39 @@
+package querier
+
+import (
+	"fmt"
+
+	"github.com/timescale/promscale/pkg/prompb"
+)
+
+type queryRemoteRead struct {
+	*pgxQuerier
+}
+
+func newQueryRemoteRead(qr *pgxQuerier) *queryRemoteRead {
+	return &queryRemoteRead{qr}
+}
+
+// Query implements the RemoteReadQuerier interface. It is the entrypoint for
+// remote read queries.
+func (q *queryRemoteRead) Query(query *prompb.Query) ([]*prompb.TimeSeries, error) {
+	if query == nil {
+		return []*prompb.TimeSeries{}, nil
+	}
+
+	matchers, err := fromLabelMatchers(query.Matchers)
+	if err != nil {
+		return nil, err
+	}
+
+	qrySamples := newQuerySamples(q.pgxQuerier)
+	sampleRows, _, err := qrySamples.fetchSamplesRows(query.StartTimestampMs, query.EndTimestampMs, nil, nil, nil, matchers)
+	if err != nil {
+		return nil, err
+	}
+	results, err := buildTimeSeries(sampleRows, q.tools.labelsReader)
+	if err != nil {
+		return nil, fmt.Errorf("building time-series: %w", err)
+	}
+	return results, nil
+}

--- a/pkg/pgmodel/querier/query_sample.go
+++ b/pkg/pgmodel/querier/query_sample.go
@@ -21,7 +21,7 @@ func newQuerySamples(qr *pgxQuerier) *querySamples {
 	return &querySamples{qr}
 }
 
-// Select implements the Querier interface. It is the entry point for our
+// Select implements the SamplesQuerier interface. It is the entry point for our
 // own version of the Prometheus engine.
 func (q *querySamples) Select(mint, maxt int64, _ bool, hints *storage.SelectHints, qh *QueryHints, path []parser.Node, ms ...*labels.Matcher) (seriesSet SeriesSet, node parser.Node) {
 	sampleRows, topNode, err := q.fetchSamplesRows(mint, maxt, hints, qh, path, ms)
@@ -110,8 +110,8 @@ func fetchSingleMetricSamples(tools *queryTools, metadata *evalMetadata) ([]samp
 	return samplesRows, topNode, nil
 }
 
-// queryMultipleMetrics returns all the result rows for across multiple metrics
-// using the supplied query parameters.
+// fetchMultipleMetricsSamples returns all the result rows for across multiple
+// metrics using the supplied query parameters.
 func fetchMultipleMetricsSamples(tools *queryTools, metadata *evalMetadata) ([]sampleRow, error) {
 	// First fetch series IDs per metric.
 	metrics, schemas, series, err := GetMetricNameSeriesIds(tools.conn, metadata)

--- a/pkg/tests/end_to_end_tests/multi_tenancy_test.go
+++ b/pkg/tests/end_to_end_tests/multi_tenancy_test.go
@@ -72,7 +72,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err := qr.Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -123,7 +123,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -187,7 +187,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -263,7 +263,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 				},
 			},
 		}
-		result, err := qr.Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -287,7 +287,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 		// ----- query-test: querying an invalid tenant (tenant-c) -----
 		expectedResult = []prompb.TimeSeries{}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -338,7 +338,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -372,7 +372,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 
 		expectedResult = []prompb.TimeSeries{}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_RE,
@@ -464,7 +464,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 			},
 		}
 
-		result, err := qr.Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -510,7 +510,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 			},
 		}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -564,7 +564,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 			},
 		}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -581,7 +581,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 		verifyResults(t, expectedResult, result)
 
 		expectedResult = []prompb.TimeSeries{}
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -658,7 +658,7 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 			},
 		}
 
-		result, err := qr.Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -709,7 +709,7 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 			},
 		}
 
-		result, err = qr.Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,

--- a/pkg/tests/end_to_end_tests/nan_test.go
+++ b/pkg/tests/end_to_end_tests/nan_test.go
@@ -129,7 +129,7 @@ func TestSQLStaleNaN(t *testing.T) {
 			dbConn := pgxconn.NewPgxConn(db)
 			labelsReader := lreader.NewLabelsReader(dbConn, lCache)
 			r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
-			resp, err := r.Query(c.query)
+			resp, err := r.RemoteReadQuerier().Query(c.query)
 			if err != nil {
 				t.Fatalf("unexpected error while ingesting test dataset: %s", err)
 			}

--- a/pkg/tests/end_to_end_tests/null_chars_test.go
+++ b/pkg/tests/end_to_end_tests/null_chars_test.go
@@ -67,7 +67,7 @@ func TestOperationWithNullChars(t *testing.T) {
 		dbConn := pgxconn.NewPgxConn(db)
 		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
-		resp, err := r.Query(&prompb.Query{
+		resp, err := r.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,

--- a/pkg/tests/end_to_end_tests/query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/query_integration_test.go
@@ -114,7 +114,7 @@ func TestDroppedViewQuery(t *testing.T) {
 		dbConn := pgxconn.NewPgxConn(readOnly)
 		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
-		_, err := r.Query(&prompb.Query{
+		_, err := r.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -694,7 +694,7 @@ func TestSQLQuery(t *testing.T) {
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		for _, c := range testCases {
 			tester.Run(c.name, func(t *testing.T) {
-				resp, err := r.Query(c.query)
+				resp, err := r.RemoteReadQuerier().Query(c.query)
 
 				if err != nil && (c.expectErr == nil || err.Error() != c.expectErr.Error()) {
 					t.Fatalf("unexpected error returned:\ngot\n%s\nwanted\n%s", err, c.expectErr)
@@ -1068,7 +1068,7 @@ func TestPromQL(t *testing.T) {
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		for _, c := range testCases {
 			tester.Run(c.name, func(t *testing.T) {
-				connResp, connErr := r.Query(c.query)
+				connResp, connErr := r.RemoteReadQuerier().Query(c.query)
 				promResp, promErr := promClient.Read(&prompb.ReadRequest{
 					Queries: []*prompb.Query{c.query},
 				})


### PR DESCRIPTION
## Description

The Querier interface was a weird mixture of "method to query" and
"methods to get things with which to query". This change moves "method
to query" into its own interface.
