### PR TITLE
Remove StartTime and EndTime from QueryHints

### DIFF
--- a/pkg/pgmodel/querier/clauses.go
+++ b/pkg/pgmodel/querier/clauses.go
@@ -8,7 +8,9 @@ import (
 	pgmodel "github.com/timescale/promscale/pkg/pgmodel/model"
 )
 
-/* Given a clause with %d placeholder for parameter numbers, and the existing and new parameters, return a clause with the parameters set to the appropriate $index and the full set of parameter values */
+// Given a clause with %d placeholder for parameter numbers, and the existing
+// and new parameters, return a clause with the parameters set to the
+// appropriate $index and the full set of parameter values
 func setParameterNumbers(clause string, existingArgs []interface{}, newArgs ...interface{}) (string, []interface{}, error) {
 	argIndex := len(existingArgs) + 1
 	argCountInClause := strings.Count(clause, "%d")

--- a/pkg/pgmodel/querier/common.go
+++ b/pkg/pgmodel/querier/common.go
@@ -43,9 +43,8 @@ func fromLabelMatchers(matchers []*prompb.LabelMatcher) ([]*labels.Matcher, erro
 	return result, nil
 }
 
+// QueryHints contain additional metadata which promscale requires
 type QueryHints struct {
-	StartTime   time.Time
-	EndTime     time.Time
 	CurrentNode parser.Node
 	Lookback    time.Duration
 }

--- a/pkg/promql/engine.go
+++ b/pkg/promql/engine.go
@@ -835,8 +835,6 @@ func (ng *Engine) populateSeries(querier SamplesQuerier, evalStmt *parser.EvalSt
 			}
 
 			qh = &pgquerier.QueryHints{
-				StartTime:   evalStmt.Start,
-				EndTime:     evalStmt.End,
 				CurrentNode: n,
 				Lookback:    ng.lookbackDelta,
 			}


### PR DESCRIPTION
## Description

The StartTime and EndTime values stored in QueryHints were superfluous,
    and can be derived from other time ranges which are already available.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
