### PR TITLE
Log deprecated flag usage

### DIFF
--- a/cmd/promscale/main.go
+++ b/cmd/promscale/main.go
@@ -15,6 +15,7 @@ import (
 )
 
 func main() {
+	log.InitDefault()
 	args := os.Args[1:]
 	if shouldProceed := runner.ParseArgs(args); !shouldProceed {
 		os.Exit(0)

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -121,8 +121,8 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 
 	fs.BoolVar(&cfg.ReadOnly, "db.read-only", false, "Read-only mode for the connector. Operations related to writing or updating the database are disallowed. It is used when pointing the connector to a TimescaleDB read replica.")
 	fs.BoolVar(&cfg.HighAvailability, "metrics.high-availability", false, "Enable external_labels based HA.")
-	fs.BoolVar(&cfg.AdminAPIEnabled, "web-enable-admin-api", false, "Allow operations via API that are for advanced users. Currently, these operations are limited to deletion of series.")
-	fs.StringVar(&cfg.TelemetryPath, "web-telemetry-path", "/metrics", "Web endpoint for exposing Promscale's Prometheus metrics.")
+	fs.BoolVar(&cfg.AdminAPIEnabled, "web.enable-admin-api", false, "Allow operations via API that are for advanced users. Currently, these operations are limited to deletion of series.")
+	fs.StringVar(&cfg.TelemetryPath, "web.telemetry-path", "/metrics", "Web endpoint for exposing Promscale's Prometheus metrics.")
 
 	fs.StringVar(&cfg.Auth.BasicAuthUsername, "web.auth.username", "", "Authentication username used for web endpoint authentication. Disabled by default.")
 	fs.StringVar(&cfg.Auth.BasicAuthPassword, "web.auth.password", "", "Authentication password used for web endpoint authentication. This flag should be set together with auth-username. It is mutually exclusive with auth-password-file and bearer-token flags.")

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -43,6 +43,17 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	return cfg
 }
 
+// InitDefault is used to start the logger with sane defaults before we can configure it.
+// It's useful in instances where we want to log stuff before the configuration
+// has been successfully parsed. Calling Init function later on overrides this.
+func InitDefault() {
+	l := level.NewFilter(
+		log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
+		level.AllowInfo(),
+	)
+	logger = log.With(l, "ts", timestampFormat, "caller", log.Caller(4))
+}
+
 // Init starts logging given the configuration. By default, it uses logfmt format
 // and minimum logging level.
 func Init(cfg Config) error {

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -46,58 +46,62 @@ type Config struct {
 	StartupOnly                 bool
 }
 
-var flagAliases = map[string][]string{
-	"auth.tls-cert-file":                {"tls-cert-file"},
-	"auth.tls-key-file":                 {"tls-key-file"},
-	"cache.memory-target":               {"memory-target"},
-	"db.app":                            {"app"},
-	"db.connection-timeout":             {"db-connection-timeout"},
-	"db.connections-max":                {"db-connections-max"},
-	"db.host":                           {"db-host"},
-	"db.name":                           {"db-name"},
-	"db.num-writer-connections":         {"db-writer-connection-concurrency"},
-	"db.password":                       {"db-password"},
-	"db.port":                           {"db-port"},
-	"db.read-only":                      {"read-only"},
-	"db.ssl-mode":                       {"db-ssl-mode"},
-	"db.statements-cache":               {"db-statements-cache"},
-	"db.uri":                            {"db-uri"},
-	"db.user":                           {"db-user"},
-	"metrics.async-acks":                {"async-acks"},
-	"metrics.cache.exemplar.size":       {"exemplar-cache-size"},
-	"metrics.cache.labels.size":         {"labels-cache-size"},
-	"metrics.cache.metrics.size":        {"metrics-cache-size"},
-	"metrics.cache.series.initial-size": {"series-cache-initial-size"},
-	"metrics.cache.series.max-bytes":    {"series-cache-max-bytes"},
-	"metrics.high-availability":         {"high-availability"},
-	"metrics.ignore-samples-written-to-compressed-chunks": {"ignore-samples-written-to-compressed-chunks"},
-	"metrics.multi-tenancy":                               {"multi-tenancy"},
-	"metrics.multi-tenancy.allow-non-tenants":             {"multi-tenancy-allow-non-tenants"},
-	"metrics.multi-tenancy.valid-tenants":                 {"multi-tenancy-valid-tenants"},
-	"metrics.promql.default-subquery-step-interval":       {"promql-default-subquery-step-interval"},
-	"metrics.promql.lookback-delta":                       {"promql-lookback-delta"},
-	"metrics.promql.max-points-per-ts":                    {"promql-max-points-per-ts"},
-	"metrics.promql.max-samples":                          {"promql-max-samples"},
-	"metrics.promql.query-timeout":                        {"promql-query-timeout"},
-	"startup.install-extensions":                          {"install-extensions"},
-	"startup.upgrade-extensions":                          {"upgrade-extensions"},
-	"startup.upgrade-prerelease-extensions":               {"upgrade-prerelease-extensions"},
-	"startup.use-schema-version-lease":                    {"use-schema-version-lease"},
-	"telemetry.log.format":                                {"log-format"},
-	"telemetry.log.level":                                 {"log-level"},
-	"telemetry.log.throughput-report-interval":            {"tput-report"},
-	"thanos.store-api.server-address":                     {"thanos-store-api-listen-address"},
-	"tracing.otlp.server-address":                         {"otlp-grpc-server-listen-address"},
-	"web.auth.bearer-token":                               {"bearer-token"},
-	"web.auth.bearer-token-file":                          {"bearer-token-file"},
-	"web.auth.password":                                   {"auth-password"},
-	"web.auth.password-file":                              {"auth-password-file"},
-	"web.auth.username":                                   {"auth-username"},
-	"web.cors-origin":                                     {"web-cors-origin"},
-	"web.enable-admin-api":                                {"web-enable-admin-api"},
-	"web.listen-address":                                  {"web-listen-address"},
-	"web.telemetry-path":                                  {"web-telemetry-path"},
-}
+var (
+	aliasDescTemplate    = "Alias for -%s flag. "
+	deprecatedFlagSuffix = "(DEPRECATED) Will be removed in version 0.11.0"
+	flagAliases          = map[string][]string{
+		"auth.tls-cert-file":                {"tls-cert-file"},
+		"auth.tls-key-file":                 {"tls-key-file"},
+		"cache.memory-target":               {"memory-target"},
+		"db.app":                            {"app"},
+		"db.connection-timeout":             {"db-connection-timeout"},
+		"db.connections-max":                {"db-connections-max"},
+		"db.host":                           {"db-host"},
+		"db.name":                           {"db-name"},
+		"db.num-writer-connections":         {"db-writer-connection-concurrency"},
+		"db.password":                       {"db-password"},
+		"db.port":                           {"db-port"},
+		"db.read-only":                      {"read-only"},
+		"db.ssl-mode":                       {"db-ssl-mode"},
+		"db.statements-cache":               {"db-statements-cache"},
+		"db.uri":                            {"db-uri"},
+		"db.user":                           {"db-user"},
+		"metrics.async-acks":                {"async-acks"},
+		"metrics.cache.exemplar.size":       {"exemplar-cache-size"},
+		"metrics.cache.labels.size":         {"labels-cache-size"},
+		"metrics.cache.metrics.size":        {"metrics-cache-size"},
+		"metrics.cache.series.initial-size": {"series-cache-initial-size"},
+		"metrics.cache.series.max-bytes":    {"series-cache-max-bytes"},
+		"metrics.high-availability":         {"high-availability"},
+		"metrics.ignore-samples-written-to-compressed-chunks": {"ignore-samples-written-to-compressed-chunks"},
+		"metrics.multi-tenancy":                               {"multi-tenancy"},
+		"metrics.multi-tenancy.allow-non-tenants":             {"multi-tenancy-allow-non-tenants"},
+		"metrics.multi-tenancy.valid-tenants":                 {"multi-tenancy-valid-tenants"},
+		"metrics.promql.default-subquery-step-interval":       {"promql-default-subquery-step-interval"},
+		"metrics.promql.lookback-delta":                       {"promql-lookback-delta"},
+		"metrics.promql.max-points-per-ts":                    {"promql-max-points-per-ts"},
+		"metrics.promql.max-samples":                          {"promql-max-samples"},
+		"metrics.promql.query-timeout":                        {"promql-query-timeout"},
+		"startup.install-extensions":                          {"install-extensions"},
+		"startup.upgrade-extensions":                          {"upgrade-extensions"},
+		"startup.upgrade-prerelease-extensions":               {"upgrade-prerelease-extensions"},
+		"startup.use-schema-version-lease":                    {"use-schema-version-lease"},
+		"telemetry.log.format":                                {"log-format"},
+		"telemetry.log.level":                                 {"log-level"},
+		"telemetry.log.throughput-report-interval":            {"tput-report"},
+		"thanos.store-api.server-address":                     {"thanos-store-api-listen-address"},
+		"tracing.otlp.server-address":                         {"otlp-grpc-server-listen-address"},
+		"web.auth.bearer-token":                               {"bearer-token"},
+		"web.auth.bearer-token-file":                          {"bearer-token-file"},
+		"web.auth.password":                                   {"auth-password"},
+		"web.auth.password-file":                              {"auth-password-file"},
+		"web.auth.username":                                   {"auth-username"},
+		"web.cors-origin":                                     {"web-cors-origin"},
+		"web.enable-admin-api":                                {"web-enable-admin-api"},
+		"web.listen-address":                                  {"web-listen-address"},
+		"web.telemetry-path":                                  {"web-telemetry-path"},
+	}
+)
 
 func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	var (
@@ -121,7 +125,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.OTLPGRPCListenAddr, "tracing.otlp.server-address", "", "Address to listen on for OTLP GRPC server.")
 	fs.StringVar(&corsOriginFlag, "web.cors-origin", ".*", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`)
 	fs.DurationVar(&cfg.ThroughputInterval, "telemetry.log.throughput-report-interval", time.Second, "Duration interval at which throughput should be reported. Setting duration to `0` will disable reporting throughput, otherwise, an interval with unit must be provided, e.g. `10s` or `3m`.")
-	fs.StringVar(&migrateOption, "migrate", "true", "Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. (DEPRECATED) Will be removed in version 0.11.0")
+	fs.StringVar(&migrateOption, "migrate", "true", fmt.Sprintf("Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. %s", deprecatedFlagSuffix))
 	fs.StringVar(&cfg.DatasetConfig, "startup.dataset.config", "", "Dataset configuration in YAML format for Promscale. It is used for setting various dataset configuration like default metric chunk interval")
 	fs.BoolVar(&cfg.StartupOnly, "startup.only", false, "Only run startup configuration with Promscale (i.e. migrate) and exit. Can be used to run promscale as an init container for HA setups.")
 	fs.BoolVar(&skipMigrate, "startup.skip-migrate", false, "Skip migrating Promscale SQL schema to latest version on startup.")
@@ -133,7 +137,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.TLSCertFile, "auth.tls-cert-file", "", "TLS Certificate file used for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 	fs.StringVar(&cfg.TLSKeyFile, "auth.tls-key-file", "", "TLS Key file for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 
-	util.AddAliases(fs, flagAliases, "(DEPRECATED) Will be removed in version 0.11.0")
+	addAliases(fs, flagAliases, deprecatedFlagSuffix)
 
 	if err := util.ParseEnv("PROMSCALE", fs); err != nil {
 		return nil, fmt.Errorf("error parsing env variables: %w", err)
@@ -145,6 +149,23 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 		ff.WithAllowMissingConfigFile(true),
 	); err != nil {
 		return nil, fmt.Errorf("configuration error: %w", err)
+	}
+
+	// Warn about deprecated flags.
+	if flagsForUpdate := deprecatedFlagsUsed(fs); len(flagsForUpdate) > 0 {
+		log.Warn("msg", "Using deprecated flags that will be dropped in a future version. Please update to new flag names.")
+		for oldFlag, newFlag := range flagsForUpdate {
+			log.Warn("msg", fmt.Sprintf("Update deprecated flag %s to new flag %s", oldFlag, newFlag))
+		}
+	}
+	// Migrate flag is a special case that needs to be logged separately.
+	switch migrateOption {
+	case "false":
+		log.Warn("msg", "Using deprecated flag `migrate` set to `false` which will be dropped in a future version. "+
+			"Please update you configuration by using `startup.skip-migrate` flag.")
+	case "only":
+		log.Warn("msg", "Using deprecated flag `migrate` set to `only` which will be dropped in a future version. "+
+			"Please update you configuration by using `startup.only` flag.")
 	}
 
 	// Checking if TLS files are not both set or both empty.
@@ -224,4 +245,53 @@ func validate(cfg *Config) error {
 		return fmt.Errorf("error validating multi-tenancy configuration: %w", err)
 	}
 	return nil
+}
+
+func addAliases(fs *flag.FlagSet, aliases map[string][]string, descSuffix string) {
+	aliasDescFormat := aliasDescTemplate + descSuffix
+	set := false
+	fs.VisitAll(func(f *flag.Flag) {
+		if flagAliases, ok := aliases[f.Name]; ok {
+			set = false
+			for _, alias := range flagAliases {
+				set = true
+				fs.Var(f.Value, alias, fmt.Sprintf(aliasDescFormat, f.Name))
+			}
+
+			if !set {
+				panic(fmt.Sprintf("trying to set an flag alias for a flag that is missing: %s", f.Name))
+			}
+		}
+	})
+}
+
+func deprecatedFlagsUsed(fs *flag.FlagSet) map[string]string {
+	var (
+		result      = make(map[string]string)
+		newFlagName string
+		count       int
+	)
+
+	fs.Visit(func(f *flag.Flag) {
+		if strings.Contains(f.Usage, deprecatedFlagSuffix) {
+			i, err := fmt.Sscanf(f.Usage, aliasDescTemplate, &newFlagName)
+
+			switch {
+			case f.Name == "migrate":
+				// Migrate flag is a special case since it's not just a rename
+				// of an old flag. We handle it separately when logging
+				// use of deprecated flags.
+				return
+			case err != nil:
+				fallthrough
+			case i != 1:
+				panic("deprecated flag usage not set in the correct format")
+			}
+
+			result[f.Name] = newFlagName
+			count++
+		}
+	})
+
+	return result
 }

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -121,7 +121,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.OTLPGRPCListenAddr, "tracing.otlp.server-address", "", "Address to listen on for OTLP GRPC server.")
 	fs.StringVar(&corsOriginFlag, "web.cors-origin", ".*", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`)
 	fs.DurationVar(&cfg.ThroughputInterval, "telemetry.log.throughput-report-interval", time.Second, "Duration interval at which throughput should be reported. Setting duration to `0` will disable reporting throughput, otherwise, an interval with unit must be provided, e.g. `10s` or `3m`.")
-	fs.StringVar(&migrateOption, "migrate", "true", "Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. (DEPRECATED) Will be removed in version 0.9.0")
+	fs.StringVar(&migrateOption, "migrate", "true", "Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. (DEPRECATED) Will be removed in version 0.11.0")
 	fs.StringVar(&cfg.DatasetConfig, "startup.dataset.config", "", "Dataset configuration in YAML format for Promscale. It is used for setting various dataset configuration like default metric chunk interval")
 	fs.BoolVar(&cfg.StartupOnly, "startup.only", false, "Only run startup configuration with Promscale (i.e. migrate) and exit. Can be used to run promscale as an init container for HA setups.")
 	fs.BoolVar(&skipMigrate, "startup.skip-migrate", false, "Skip migrating Promscale SQL schema to latest version on startup.")
@@ -133,7 +133,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.TLSCertFile, "auth.tls-cert-file", "", "TLS Certificate file used for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 	fs.StringVar(&cfg.TLSKeyFile, "auth.tls-key-file", "", "TLS Key file for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 
-	util.AddAliases(fs, flagAliases, "(DEPRECATED) Will be removed in version 0.9.0")
+	util.AddAliases(fs, flagAliases, "(DEPRECATED) Will be removed in version 0.11.0")
 
 	if err := util.ParseEnv("PROMSCALE", fs); err != nil {
 		return nil, fmt.Errorf("error parsing env variables: %w", err)

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -5,10 +5,14 @@
 package runner
 
 import (
+	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseFlags(t *testing.T) {
@@ -339,4 +343,44 @@ func TestParseFlagsConfigPrecedence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddAlias(t *testing.T) {
+	aliases := map[string][]string{
+		"first_flag":  {"first_flag_alias", "first_flag_another_alias"},
+		"second_flag": {"second_flag_alias"},
+	}
+
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Bool("first_flag", true, "First flag desc")
+	fs.String("second_flag", "empty", "Second flag desc")
+
+	descSuffix := "Test description."
+
+	addAliases(fs, aliases, descSuffix)
+
+	ff := fs.Lookup("first_flag")
+	sf := fs.Lookup("second_flag")
+
+	require.NotNil(t, ff)
+	require.NotNil(t, sf)
+
+	alias := fs.Lookup("first_flag_alias")
+	require.NotNil(t, alias)
+	require.Equal(t, ff.Value, alias.Value)
+	require.Equal(t, ff.DefValue, alias.DefValue)
+	require.Equal(t, alias.Usage, fmt.Sprintf(aliasDescTemplate+descSuffix, ff.Name))
+
+	alias = fs.Lookup("first_flag_another_alias")
+	require.NotNil(t, alias)
+	require.Equal(t, ff.Value, alias.Value)
+	require.Equal(t, ff.DefValue, alias.DefValue)
+	require.Equal(t, alias.Usage, fmt.Sprintf(aliasDescTemplate+descSuffix, ff.Name))
+
+	alias = fs.Lookup("second_flag_alias")
+	require.NotNil(t, alias)
+	require.Equal(t, sf.Value, alias.Value)
+	require.Equal(t, sf.DefValue, alias.DefValue)
+	require.Equal(t, alias.Usage, fmt.Sprintf(aliasDescTemplate+descSuffix, sf.Name))
+
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,10 +69,17 @@ func ParseEnv(p string, fs *flag.FlagSet) error {
 
 func AddAliases(fs *flag.FlagSet, aliases map[string][]string, descSuffix string) {
 	aliasDescFormat := aliasDescTemplate + descSuffix
+	set := false
 	fs.VisitAll(func(f *flag.Flag) {
 		if flagAliases, ok := aliases[f.Name]; ok {
+			set = false
 			for _, alias := range flagAliases {
+				set = true
 				fs.Var(f.Value, alias, fmt.Sprintf(aliasDescFormat, f.Name))
+			}
+
+			if !set {
+				panic(fmt.Sprintf("trying to set an flag alias for a flag that is missing: %s", f.Name))
 			}
 		}
 	})

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -11,10 +11,7 @@ import (
 	"strings"
 )
 
-const (
-	PromNamespace     = "promscale"
-	aliasDescTemplate = "Alias for -%s flag. "
-)
+const PromNamespace = "promscale"
 
 // ParseEnv takes a prefix string p and *flag.FlagSet. Each flag
 // in the FlagSet is exposed as an upper case environment variable
@@ -65,22 +62,4 @@ func ParseEnv(p string, fs *flag.FlagSet) error {
 	})
 
 	return err
-}
-
-func AddAliases(fs *flag.FlagSet, aliases map[string][]string, descSuffix string) {
-	aliasDescFormat := aliasDescTemplate + descSuffix
-	set := false
-	fs.VisitAll(func(f *flag.Flag) {
-		if flagAliases, ok := aliases[f.Name]; ok {
-			set = false
-			for _, alias := range flagAliases {
-				set = true
-				fs.Var(f.Value, alias, fmt.Sprintf(aliasDescFormat, f.Name))
-			}
-
-			if !set {
-				panic(fmt.Sprintf("trying to set an flag alias for a flag that is missing: %s", f.Name))
-			}
-		}
-	})
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -129,46 +129,6 @@ func TestParseEnv(t *testing.T) {
 
 }
 
-func TestAddAlias(t *testing.T) {
-	aliases := map[string][]string{
-		"first_flag":  {"first_flag_alias", "first_flag_another_alias"},
-		"second_flag": {"second_flag_alias"},
-	}
-
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.Bool("first_flag", true, "First flag desc")
-	fs.String("second_flag", "empty", "Second flag desc")
-
-	descSuffix := "Test description."
-
-	AddAliases(fs, aliases, descSuffix)
-
-	ff := fs.Lookup("first_flag")
-	sf := fs.Lookup("second_flag")
-
-	require.NotNil(t, ff)
-	require.NotNil(t, sf)
-
-	alias := fs.Lookup("first_flag_alias")
-	require.NotNil(t, alias)
-	require.Equal(t, ff.Value, alias.Value)
-	require.Equal(t, ff.DefValue, alias.DefValue)
-	require.Equal(t, alias.Usage, fmt.Sprintf(aliasDescTemplate+descSuffix, ff.Name))
-
-	alias = fs.Lookup("first_flag_another_alias")
-	require.NotNil(t, alias)
-	require.Equal(t, ff.Value, alias.Value)
-	require.Equal(t, ff.DefValue, alias.DefValue)
-	require.Equal(t, alias.Usage, fmt.Sprintf(aliasDescTemplate+descSuffix, ff.Name))
-
-	alias = fs.Lookup("second_flag_alias")
-	require.NotNil(t, alias)
-	require.Equal(t, sf.Value, alias.Value)
-	require.Equal(t, sf.DefValue, alias.DefValue)
-	require.Equal(t, alias.Usage, fmt.Sprintf(aliasDescTemplate+descSuffix, sf.Name))
-
-}
-
 func TestExtractMetricValue(t *testing.T) {
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{Namespace: "test", Name: "extraction"})
 


### PR DESCRIPTION
## Description

This PR contains a couple of changes that are connected to the renaming process of old flags. Main feature is the addition of logging usage of deprecated flags with recommendations on how to migrate them.

I'm unsure if any of this should be added to the changelog, perhaps only the change to remove the deprecated flags in 0.11.0 version. I would like some input on that before adding it.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
