### PR TITLE
Increase visibility into trace ingest

### DIFF
--- a/pkg/api/write_test.go
+++ b/pkg/api/write_test.go
@@ -124,10 +124,11 @@ func TestWrite(t *testing.T) {
 			},
 		},
 		{
-			name:         "write error",
-			isLeader:     true,
-			responseCode: http.StatusInternalServerError,
-			inserterErr:  fmt.Errorf("some error"),
+			name:             "write error",
+			isLeader:         true,
+			inserterResponse: 1,
+			responseCode:     http.StatusInternalServerError,
+			inserterErr:      fmt.Errorf("some error"),
 			requestBody: writeRequestToString(
 				&prompb.WriteRequest{
 					Timeseries: []prompb.TimeSeries{

--- a/pkg/pgmodel/ingestor/trace/batch.go
+++ b/pkg/pgmodel/ingestor/trace/batch.go
@@ -53,6 +53,7 @@ func (q sortableItems) Swap(i, j int) {
 
 //batcher queues up items to send to the DB but it sorts before sending
 //this avoids deadlocks in the DB. It also avoids sending the same items repeatedly.
+// batcher is not thread safe
 type batcher struct {
 	batch map[batchItem]interface{}
 	cache cache
@@ -65,9 +66,14 @@ func newBatcher(cache cache) batcher {
 	}
 }
 
-// Queue adds item to the batch to be sent.
+// Queue adds item to the batch to be sent or replaces an existing item
 func (b batcher) Queue(i batchItem) {
 	b.batch[i] = nil
+}
+
+// Number of items in the batch.
+func (b batcher) Len() int {
+	return len(b.batch)
 }
 
 // SendBatch sends the batch over the DB connections and gets the ID results.

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -156,7 +156,7 @@ var (
 			Namespace: util.PromNamespace,
 			Subsystem: "ingest",
 			Name:      "items_total",
-			Help:      "Total number of insertables (sample/metadata) ingested.",
+			Help:      "Total number of insertables (sample/metadata) received",
 		}, []string{"type", "kind"},
 	)
 	IngestorRequests = prometheus.NewCounterVec(
@@ -166,6 +166,16 @@ var (
 			Name:      "requests_total",
 			Help:      "Total number of requests to ingestor.",
 		}, []string{"type", "code"},
+	)
+	InsertBatchSize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: util.PromNamespace,
+			Subsystem: "ingest",
+			Name:      "insert_batch_size",
+			Help:      "Number of records inserted into database",
+			Buckets:   []float64{10, 50, 100, 200, 500, 1000, 2000, 4000, 6000, 8000, 10000, 20000},
+		},
+		[]string{"type", "kind"},
 	)
 )
 
@@ -188,5 +198,6 @@ func init() {
 		IngestorDuration,
 		IngestorItems,
 		IngestorRequests,
+		InsertBatchSize,
 	)
 }

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -179,6 +179,10 @@ func (b *MockBatch) Queue(query string, arguments ...interface{}) {
 	})
 }
 
+func (b *MockBatch) Len() int {
+	return len(b.items)
+}
+
 type MockBatchResult struct {
 	idx     int
 	queries []SqlQuery

--- a/pkg/pgxconn/pgx_conn.go
+++ b/pkg/pgxconn/pgx_conn.go
@@ -18,6 +18,7 @@ import (
 
 type PgxBatch interface {
 	Queue(query string, arguments ...interface{})
+	Len() int
 }
 
 type PgxConn interface {


### PR DESCRIPTION
Add few more metrics that will give us more insight into ingest.
Mainly we want to see how big our insert batches are and also the time it
takes to insert various trace related objects. This should help
us in finding weak spots.
