### PR TITLE
move goreleaser config to common location

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --snapshot --skip-publish --rm-dist -f build/.goreleaser.yml
+          args: release --snapshot --skip-publish --rm-dist -f .goreleaser.yml
       -
         name: GoReleaser Release
         uses: goreleaser/goreleaser-action@v2
@@ -55,7 +55,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist -f build/.goreleaser.yml
+          args: release --rm-dist -f .goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,2 +1,0 @@
-release:
-  draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -186,5 +186,6 @@ docker_manifests:
   skip_push: auto
 
 release:
+  draft: true
   extra_files:
     - glob: ./dist/rpm/*


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

Cannonical location for goreleaser config file is in root of the repository. In https://github.com/timescale/promscale/pull/1133 we merged a config in this location but it was not picked up during release as we already had another, "hidden" config in `build/` directory. To limit future confusion this PR is moving configuration to the TLD.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
