### PR TITLE
Fix ingested_samples_total telemetry

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -23,11 +23,11 @@ type Metrics struct {
 	RemoteReadReceivedQueries prometheus.Counter
 }
 
-func updateIngestMetrics(code string, duration, numSamples, numMetadata float64) {
+func updateIngestMetrics(code string, duration, receivedSamples, receivedMetadata float64) {
 	pgMetrics.IngestorRequests.With(prometheus.Labels{"type": "metric", "code": code}).Inc()
 	pgMetrics.IngestorDuration.With(prometheus.Labels{"type": "metric", "code": code}).Observe(duration)
-	pgMetrics.IngestorItems.With(prometheus.Labels{"type": "metric", "kind": "sample"}).Add(numSamples)
-	pgMetrics.IngestorItems.With(prometheus.Labels{"type": "metric", "kind": "metadata"}).Add(numMetadata)
+	pgMetrics.IngestorItemsReceived.With(prometheus.Labels{"type": "metric", "kind": "sample"}).Add(receivedSamples)
+	pgMetrics.IngestorItemsReceived.With(prometheus.Labels{"type": "metric", "kind": "metadata"}).Add(receivedMetadata)
 }
 
 func updateQueryMetrics(handler, code string, duration float64) {

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -123,7 +123,7 @@ func RegisterMetricsForTelemetry(t telemetry.Engine) error {
 	var err error
 	if err = t.RegisterMetric(
 		"promscale_ingested_samples_total",
-		pgMetrics.IngestorItems.With(prometheus.Labels{"type": "metric", "kind": "sample"})); err != nil {
+		pgMetrics.IngestorItems.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "sample"})); err != nil {
 		return fmt.Errorf("register 'promscale_ingested_samples_total' metric for telemetry: %w", err)
 	}
 	if err = t.RegisterMetric(

--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -446,8 +446,8 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest
 			registerDuplicates(numRowsExpected - insertedRows)
 		}
 	}
-	metrics.IngestorInsertablesIngested.With(prometheus.Labels{"type": "metric", "kind": "sample"}).Add(float64(totalSamples))
-	metrics.IngestorInsertablesIngested.With(prometheus.Labels{"type": "metric", "kind": "exemplar"}).Add(float64(totalExemplars))
+	metrics.IngestorItems.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "sample"}).Add(float64(totalSamples))
+	metrics.IngestorItems.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "exemplar"}).Add(float64(totalExemplars))
 
 	var val []byte
 	row := results.QueryRow()
@@ -481,6 +481,7 @@ func insertMetadata(conn pgxconn.PgxConn, reqs []pgmodel.Metadata) (insertedRows
 	if err := row.Scan(&insertedRows); err != nil {
 		return 0, fmt.Errorf("send metadata batch: %w", err)
 	}
+	metrics.IngestorItems.With(prometheus.Labels{"type": "metric", "kind": "metadata", "subsystem": ""}).Add(float64(insertedRows))
 	metrics.IngestorInsertDuration.With(prometheus.Labels{"type": "metric", "subsystem": "", "kind": "exemplar"}).Observe(time.Since(start).Seconds())
 	return insertedRows, nil
 }

--- a/pkg/pgmodel/ingestor/trace/writer.go
+++ b/pkg/pgmodel/ingestor/trace/writer.go
@@ -62,7 +62,7 @@ type traceWriterImpl struct {
 }
 
 func NewWriter(conn pgxconn.PgxConn, t telemetry.Engine) *traceWriterImpl {
-	if err := t.RegisterMetric("promscale_ingested_spans_total", metrics.IngestorItems.With(prometheus.Labels{"type": "trace", "kind": "span"})); err != nil {
+	if err := t.RegisterMetric("promscale_ingested_spans_total", metrics.IngestorItems.With(prometheus.Labels{"type": "trace", "kind": "span", "subsystem": ""})); err != nil {
 		log.Debug("msg", "err registering telemetry metric promscale_ingested_spans_total", "err", err.Error())
 	}
 	return &traceWriterImpl{
@@ -142,7 +142,7 @@ func (t *traceWriterImpl) InsertTraces(ctx context.Context, traces pdata.Traces)
 	startIngest := time.Now() // Time taken for complete ingestion => Processing + DB insert.
 	code := "500"
 	metrics.IngestorActiveWriteRequests.With(traceSpanLabel).Inc()
-	metrics.IngestorItems.With(traceSpanLabel).Add(float64(traces.SpanCount()))
+	metrics.IngestorItemsReceived.With(traceSpanLabel).Add(float64(traces.SpanCount()))
 	defer func() {
 		metrics.IngestorRequests.With(prometheus.Labels{"type": "trace", "code": code}).Inc()
 		metrics.IngestorDuration.With(prometheus.Labels{"type": "trace", "code": ""}).Observe(time.Since(startIngest).Seconds())
@@ -352,6 +352,7 @@ func (t *traceWriterImpl) InsertTraces(ctx context.Context, traces pdata.Traces)
 	if err := t.sendBatch(ctx, spanBatch); err != nil {
 		return fmt.Errorf("error sending trace span batch: %w", err)
 	}
+	metrics.IngestorItems.With(prometheus.Labels{"type": "trace", "kind": "span", "subsystem": ""}).Add(float64(traces.SpanCount()))
 	metrics.IngestorInsertDuration.With(prometheus.Labels{"type": "trace", "subsystem": "", "kind": "span"}).Observe(time.Since(start).Seconds())
 
 	code = "2xx"

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -90,14 +90,6 @@ var (
 			Buckets:   util.HistogramBucketsSaturating(1, 2, FlushSize),
 		}, []string{"type", "subsystem"},
 	)
-	IngestorInsertablesIngested = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: util.PromNamespace,
-			Subsystem: "ingest",
-			Name:      "inserted_total",
-			Help:      "Total insertables (samples/exemplars/spans) inserted into the database.",
-		}, []string{"type", "kind"},
-	)
 	IngestorInsertsPerBatch = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: util.PromNamespace,
@@ -156,7 +148,15 @@ var (
 			Namespace: util.PromNamespace,
 			Subsystem: "ingest",
 			Name:      "items_total",
-			Help:      "Total number of insertables (sample/metadata) received",
+			Help:      "Total number of items (sample/metadata/span) ingested",
+		}, []string{"type", "kind", "subsystem"},
+	)
+	IngestorItemsReceived = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: util.PromNamespace,
+			Subsystem: "ingest",
+			Name:      "items_received_total",
+			Help:      "Total items (samples/exemplars/spans) received.",
 		}, []string{"type", "kind"},
 	)
 	IngestorRequests = prometheus.NewCounterVec(
@@ -189,7 +189,6 @@ func init() {
 		IngestorChannelCap,
 		IngestorChannelLen,
 		IngestorFlushSeries,
-		IngestorInsertablesIngested,
 		IngestorInsertsPerBatch,
 		IngestorRowsPerBatch,
 		IngestorRowsPerInsert,
@@ -197,6 +196,7 @@ func init() {
 		IngestorActiveWriteRequests,
 		IngestorDuration,
 		IngestorItems,
+		IngestorItemsReceived,
 		IngestorRequests,
 		InsertBatchSize,
 	)

--- a/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
+++ b/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
@@ -130,7 +130,7 @@ func prepareWriterWithHa(db *pgxpool.Pool, t testing.TB) (*util.ManualTicker, ht
 		t.Fatalf("could not create ingestor: %v", err)
 	}
 	api.InitMetrics()
-	return ticker, api.Write(ing, dataParser, nil, func(code string, numSamples, numMetadata, duration float64) {}), ing, err
+	return ticker, api.Write(ing, dataParser, nil, func(code string, duration, receivedSamples, receivedMetadata float64) {}), ing, err
 }
 
 func TestHALeaderChangeDueToInactivity(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

## Description

This PR fixes ingested_samples telemetry by using another metric name for items (aka insertables) received.

TODO:

- [x] Fix api/write_test.go
- [x] Run ingestion, querying for samples and traces to verify metrics are correctly implemented
- [x] Verify telemetry collection

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
