### PR TITLE
Reduce dependabot frequency to update Go deps weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -135,7 +135,7 @@ jobs:
         MULTI: ${{ matrix.test-setups.multi }}
         TSDBOSS: ${{ matrix.test-setups.tsdboss }}
         SHORTNAME: ${{ matrix.test-setups.shortname }}
-      run: go test -race ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-timescaledb-oss=$TSDBOSS -use-multinode=$MULTI -postgres-version-major=$PG | tee $SHORTNAME-test-run.log  2>&1
+      run: go test -race -timeout=30m ./pkg/tests/end_to_end_tests/ -use-extension=$EXT -use-timescaledb=$TSDB -use-timescale2=$TSDB2 -use-timescaledb-oss=$TSDBOSS -use-multinode=$MULTI -postgres-version-major=$PG | tee $SHORTNAME-test-run.log  2>&1
 
     - name: 'Upload Log Artifact'
       if: ${{ always() }}


### PR DESCRIPTION
## Description

Some of the dependencies release new versions very quickly leading to
a lot of PRs generated by dependabot. Reducing the frequency to weekly
makes it more manageable to maintain the dependencies.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
