### PR TITLE
Log warning when remote read request is cancelled midway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ We use the following categories for changes:
 ## [Unreleased]
 
 ### Fixed
-- Register `promscale_ingest_channel_len_bucket` metric and make it a gauge
+- Register `promscale_ingest_channel_len_bucket` metric and make it a gauge [#1177]
+- Log warning when failing to write response to remote read requests [#1180]
 
 ## [0.10.0] - 2022-02-17
 

--- a/pkg/api/read.go
+++ b/pkg/api/read.go
@@ -87,8 +87,11 @@ func Read(config *Config, reader querier.Reader, metrics *Metrics, updateMetrics
 
 		compressed = snappy.Encode(nil, data)
 		if _, err := w.Write(compressed); err != nil {
-			statusCode = "500"
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			// Most likely the request was cancelled from client side.
+			// We use a non-standard code so we can distinguish from actual
+			// internal server errors.
+			statusCode = "499"
+			log.Warn("msg", "Error writing HTTP response", "err", err)
 			return
 		}
 		statusCode = "2xx"


### PR DESCRIPTION


## Description
  Previously, we were trying to update the header but that cannot be
  done in this instance since we are already starting to write the
  request body. Only valid way of handling these situations is to
  log the error and finish the request.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
