### PR TITLE
Add alerting rules for Promscale.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ We use the following categories for changes:
 
 ## [Unreleased]
 
+## Added
+- Alerting rules for Promscale. You can find them at [here](docs/promscale_alerting.md) [#1181]
+
 ### Fixed
 - Register `promscale_ingest_channel_len_bucket` metric and make it a gauge
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ remote storage endpoints. For more information about prom-migrator, visit
 * **[Multi-tenancy](docs/multi_tenancy.md)**
 * **[Writing Metric Data](docs/writing_to_promscale.md)**
 * **[Alerting](docs/alerting.md)**
+  * [Alerting for Promscale](docs/mixin/README.md)
 * **[Downsampling](docs/downsampling.md)**
 * **[Deleting Data](docs/metric_deletion_and_retention.md)**
 * **[Quick Tips](#-quick-tips)**

--- a/docs/mixin/README.md
+++ b/docs/mixin/README.md
@@ -1,0 +1,17 @@
+# Promscale Mixin
+
+This file contains instructions on how to use Promscale mixins.
+
+We recommend monitoring your Promscale deployments and include the mixins in this package
+as part of your alerting environment.
+
+## How to use
+Promscale alerts are defined [here](alerts/alerts.yaml). Copy the context into a file
+say `promscale_alerts.yaml`.
+
+## Configuring Prometheus
+In the Prometheus configuration file, add `promscale_alerts.yaml` under `rule_files` like
+```yaml
+rule_files:
+  - promscale_alerts.yaml
+```

--- a/docs/mixin/alerts/alerts.yaml
+++ b/docs/mixin/alerts/alerts.yaml
@@ -1,0 +1,192 @@
+groups:
+- name: promscale-general
+  rules:
+  - alert: PromscaleDown
+    expr: absent(up{job=~".*promscale.*"})
+    labels:
+      severity: critical
+    annotations:
+      summary: Promscale is down
+      description: No Promscale instance was found.
+- name: promscale-ingest
+  rules:
+  - alert: PromscaleIngestHighErrorRate
+    expr: |
+      (
+        sum by (job, instance, type) (
+          rate(promscale_ingest_requests_total{code=~"5.."}[5m])
+        )
+      /
+        sum by (job, instance, type) (
+          rate(promscale_ingest_requests_total[5m])
+        )
+      ) > 0.05
+    labels:
+      severity: warning
+    annotations:
+      summary: High error rate in Promscale ingestion
+      description: "Promscale ingestion is having a {{ $value | humanizePercentage }} error rate."
+  - alert: PromscaleIngestHighErrorRate
+    expr: |
+      (
+        sum by (job, instance, type) (
+          rate(promscale_ingest_requests_total{code=~"5.."}[5m])
+        )
+      /
+        sum by (job, instance, type) (
+          rate(promscale_ingest_requests_total[5m])
+        )
+      ) > 0.1
+    labels:
+      severity: critical
+    annotations:
+      summary: High error rate in Promscale ingestion
+      description: "Promscale ingestion is having a {{ $value | humanizePercentage }} error rate."
+  - alert: PromscaleIngestHighLatency
+    expr: |
+      (
+        histogram_quantile(
+          0.90,
+          sum by (job, instance, type, le) (
+            rate(promscale_ingest_duration_seconds_bucket[5m])
+          )
+        ) > 10
+      and
+        sum by (job, instance, type) (
+            rate(promscale_ingest_duration_seconds_bucket[5m])
+        )
+      ) > 0
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: Slow Promscale ingestion
+      description: "90% of ingestion batch took {{ $value }} seconds to ingest."
+  - alert: PromscaleIngestHighLatency
+    expr: |
+      (
+        histogram_quantile(
+          0.90,
+          sum by (job, instance, type, le) (
+            rate(promscale_ingest_duration_seconds_bucket[5m])
+          )
+        ) > 30
+      and
+        sum by (job, instance, type) (
+            rate(promscale_ingest_duration_seconds_bucket[5m])
+        )
+      ) > 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Slow Promscale ingestion
+      description: "90% of ingestion batch took {{ $value }} seconds to ingest."
+- name: promscale-query
+  rules:
+  - alert: PromscaleQueryHighErrorRate
+    expr: |
+      (
+        sum by (job, instance, type) (
+          rate(promscale_query_requests_total{code=~"5.."}[5m])
+        )
+      /
+        sum by (job, instance, type) (
+          rate(promscale_query_requests_total[5m])
+        )
+      ) > 0.05
+    labels:
+      severity: warning
+    annotations:
+      summary: High error rate in querying Promscale
+      description: "Evaluating queries via Promscale has {{ $value | humanizePercentage }} error rate."
+  - alert: PromscaleQueryHighErrorRate
+    expr: |
+      (
+        sum by (job, instance, type) (
+          rate(promscale_query_requests_total{code=~"5.."}[5m])
+        )
+      /
+        sum by (job, instance, type) (
+          rate(promscale_query_requests_total[5m])
+        )
+      ) > 0.1
+    labels:
+      severity: critical
+    annotations:
+      summary: High error rate in querying Promscale
+      description: "Evaluating queries via Promscale had {{ $value | humanizePercentage }} error rate."
+  - alert: PromscaleQueryHighLatency
+    expr: |
+      (
+        histogram_quantile(
+          0.90,
+          sum by (job, instance, type, le) (
+            rate(promscale_query_duration_seconds_bucket[5m])
+          )
+        ) > 5
+      and
+        sum by (job, instance, type) (
+          rate(promscale_query_duration_seconds_bucket[5m])
+        ) > 0
+      )
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: Slow Promscale querying
+      description: "90% of the queries took {{ $value }} seconds to evaluate."
+  - alert: PromscaleQueryHighLatency
+    expr: |
+      (
+        histogram_quantile(
+          0.90,
+          sum by (job, instance, type, le) (
+            rate(promscale_query_duration_seconds_bucket[5m])
+          )
+        ) > 10
+      and
+        sum by (job, instance, type) (
+          rate(promscale_query_duration_seconds_bucket[5m])
+        ) > 0
+      )
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: Slow Promscale querying
+      description: "90% of the queries took {{ $value }} seconds to evaluate."
+- name: promscale-cache
+  rules:
+  - alert: PromscaleCacheHighNumberOfEvictions
+    expr: |
+      (
+        sum by (job, instance, name, type) (
+          rate(promscale_cache_evictions_total[5m])
+        )
+      /
+        sum by (job, instance, name, type) (
+          promscale_cache_capacity_elements
+        )
+      ) > 0.2
+    labels:
+      severity: warning
+    annotations:
+      summary: High cache eviction in Promscale
+      description: "Promscale {{ $labels.name }} is evicting at {{ $value }} entries a second."
+  - alert: PromscaleCacheTooSmall
+    expr: |
+      (
+        sum by (job, instance, type, name) (
+          rate(promscale_cache_query_hits_total[5m])
+        )
+      /
+        sum by (job, instance, type, name) (
+          rate(promscale_cache_queries_total[5m])
+        )
+      ) < 0.9
+    labels:
+      severity: warning
+    annotations:
+      summary: High cache eviction in Promscale
+      description: "Promscale {{ $labels.name }} has a hit ratio of {{ $value }}."


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

## Description
This PR adds alerting rules for Promscale based on the metrics that are already exposed.

Note: The `for` field is written assuming `30s` scrape interval for most systems.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
