### PR TITLE
Make Renovate bot ignore pinned Prometheus version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "config:base",
     "schedule:daily"
   ],
+  "ignoreDeps": ["github.com/prometheus/prometheus"],
   "dependencyDashboardLabels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
## Description

Prometheus library versions need to be pinned by us in order to work
properly with Promscale.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
