### PR TITLE
.github: control tooling version used in CI via renovate

### DIFF
--- a/.github/env
+++ b/.github/env
@@ -1,2 +1,0 @@
-golang-version=1.16
-golangci-lint-version=v1.42.1

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,24 +6,44 @@
   ],
   "ignoreDeps": ["github.com/prometheus/prometheus"],
   "dependencyDashboardLabels": ["dependencies"],
+  "labels": ["dependencies"],
+  "regexManagers": [
+    {
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["golangci-lint-version:\\s(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "golangci/golangci-lint"
+    },
+    {
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["helm-version:\\s(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "helm/helm"
+    },
+    {
+      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
+      "matchStrings": ["golang-version:\\s(?<currentValue>.*?)\\n"],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang"
+    }
+  ],
   "packageRules": [
     {
-      "labels": ["helm", "dependencies"],
+      "addLabels": ["helm"],
       "groupName": "helm charts",
       "matchManagers": ["helmv3", "helm-values"]
     },
     {
-      "labels": ["go", "dependencies"],
+      "addLabels": ["go"],
       "groupName": "golang",
       "matchManagers": ["gomod"]
     },
     {
-      "labels": ["github_actions", "dependencies"],
+      "addLabels": ["github_actions"],
       "groupName": "github actions",
-      "matchManagers": ["github-actions"]
+      "matchPaths": [".github/**"]
     },
     {
-      "labels": ["dependencies"],
       "groupName": "docker-compose",
       "matchManagers": ["docker-compose"]
     }

--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: ['**']
 
+env:
+  golang-version: 1.16.0
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -20,9 +23,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - 
-        name: Import environment variables
-        run: cat ".github/env" >> $GITHUB_ENV
 
       -
         name: Set up Go

--- a/.github/workflows/go-scheduled.yml
+++ b/.github/workflows/go-scheduled.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "6 0 * * *"
 
+env:
+  golang-version: 1.16.0
+
 jobs:
 
   build:
@@ -18,9 +21,6 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0
@@ -49,10 +49,7 @@ jobs:
         lfs: true
 
     - name: Checkout LFS objects
-      run: git lfs checkout
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV      
+      run: git lfs checkout 
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0
@@ -95,9 +92,6 @@ jobs:
 
     - name: Checkout LFS objects
       run: git lfs checkout
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: ['**']
 
+env:
+  golang-version: 1.16.0
+  golangci-lint-version: v1.42.1
+
 jobs:
   build:
     name: Build and Lint
@@ -17,9 +21,6 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0
@@ -49,9 +50,6 @@ jobs:
 
     - name: Checkout test data files
       run: wget https://github.com/timescale/promscale-test-data/raw/main/traces-dataset.sz -O pkg/tests/testdata/traces-dataset.sz
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0
@@ -108,9 +106,6 @@ jobs:
 
     - name: Checkout test data files
       run: wget https://github.com/timescale/promscale-test-data/raw/main/traces-dataset.sz -O pkg/tests/testdata/traces-dataset.sz
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [master, main, force_test, release-*]
 
+env:
+  helm-version: v3.7.1
+
 jobs:
   generate:
     runs-on: ubuntu-latest
@@ -27,7 +30,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v2.0
         with:
-          version: v3.7.1
+          version: ${{ env.helm-version }}
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
@@ -38,8 +41,6 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.0
-        with:
-          version: v3.4.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -71,7 +72,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v2.0
         with:
-          version: v3.7.1
+          version: ${{ env.helm-version }}
 
       - name: Create package
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [master, main, force_test, release-*]
 
+env:
+  golang-version: 1.16.0
+
 jobs:
   run:
     runs-on: ubuntu-latest
@@ -24,9 +27,6 @@ jobs:
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0

--- a/.github/workflows/mixin.yml
+++ b/.github/workflows/mixin.yml
@@ -6,15 +6,16 @@ on:
   pull_request:
     paths:
     - 'docs/mixin/alerts/*.yml'
+
+env:
+  golang-version: 1.16.0
+
 jobs:
   check-mixin:
     runs-on: ubuntu-latest
     name: Check monitoring mixin
     steps:
     - uses: actions/checkout@v2
-
-    - name: Import environment variables
-      run: cat ".github/env" >> $GITHUB_ENV
 
     - name: Set up Go ${{ env.golang-version }}
       uses: actions/setup-go@v2.2.0


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

This is allowing renovate to handle tooling versions used in github actions. Configuration was tested in tobs repository after https://github.com/timescale/tobs/pull/268 and https://github.com/timescale/tobs/pull/274 were merged. 

https://github.com/timescale/tobs/pull/268 contains more of the reasoning behind this change.

This PR is finalizing a CI overhaul started in October by moving management of all dependencies to renovatebot.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
