### PR TITLE
Ingest traces using COPY FROM

### DIFF
--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgproto3/v2"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/stretchr/testify/require"
 	"github.com/timescale/promscale/pkg/pgmodel/common/errors"
@@ -52,6 +53,10 @@ func NewErrorSqlRecorder(queries []SqlQuery, err error, t *testing.T) *SqlRecord
 }
 
 func (r *SqlRecorder) Close() {
+}
+
+func (r *SqlRecorder) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+	return nil, nil
 }
 
 func (r *SqlRecorder) Exec(ctx context.Context, sql string, arguments ...interface{}) (pgconn.CommandTag, error) {

--- a/pkg/pgxconn/pgx_conn.go
+++ b/pkg/pgxconn/pgx_conn.go
@@ -68,6 +68,7 @@ type PgxConn interface {
 	CopyFromRows(rows [][]interface{}) pgx.CopyFromSource
 	NewBatch() PgxBatch
 	SendBatch(ctx context.Context, b PgxBatch) (pgx.BatchResults, error)
+	Acquire(ctx context.Context) (*pgxpool.Conn, error)
 }
 
 type PgxRows interface {
@@ -198,6 +199,10 @@ func (p *connImpl) NewBatch() PgxBatch {
 func (p *connImpl) SendBatch(ctx context.Context, b PgxBatch) (pgx.BatchResults, error) {
 	requestTotal.With(promMethodLabel("send_batch")).Inc()
 	return newBatchResultsWithDuration(p.Conn.SendBatch(ctx, b.(*pgx.Batch)), time.Now()), nil
+}
+
+func (p *connImpl) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
+	return p.Conn.Acquire(ctx)
 }
 
 // filters out indentation characters from the


### PR DESCRIPTION
Using Postgres COPY FROM resulted in 2X improvements for trace ingest performance.
Here we use COPY FROM for inserting spans, links and events into respective hypertables.
COPY FROM uses binary protocol so it's expected to perform well.
