### PR TITLE
Enable tracing flags by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ We use the following categories for changes:
 - Alerting rules for Promscale. You can find them [here](docs/promscale_alerting.md) [#1181, #1185]
 - Add database status and request metrics [#1185]
 
+### Changed
+- Enable tracing by default [#1213]
+
 ### Fixed
 - Register `promscale_ingest_channel_len_bucket` metric and make it a gauge [#1177]
 - Log warning when failing to write response to remote read requests [#1180]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,9 +46,9 @@ The following subsections cover all CLI flags which promscale supports. You can 
 |------|:-----:|:-------:|:-----------|
 | cache.memory-target | unsigned-integer or percentage | 80% | Target for max amount of memory to use. Specified in bytes or as a percentage of system memory (e.g. 80%). |
 | config | string | config.yml | YAML configuration file path for Promscale. |
-| enable-feature | string | "" | Enable one or more experimental promscale features (as a comma-separated list). Current experimental features are `tracing`, `promql-at-modifier`, and `promql-negative-offset`. For more information, please consult the following resources: [tracing](tracing.md), [promql-at-modifier](https://prometheus.io/docs/prometheus/latest/feature_flags/#modifier-in-promql), [promql-negative-offset](https://prometheus.io/docs/prometheus/latest/feature_flags/#negative-offset-in-promql). |
+| enable-feature | string | "" | Enable one or more experimental promscale features (as a comma-separated list). Current experimental features are `promql-at-modifier`, and `promql-negative-offset`. For more information, please consult the following resources: [promql-at-modifier](https://prometheus.io/docs/prometheus/latest/feature_flags/#modifier-in-promql), [promql-negative-offset](https://prometheus.io/docs/prometheus/latest/feature_flags/#negative-offset-in-promql). |
 | thanos.store-api.server-address | string | "" (disabled) | Address to listen on for Thanos Store API endpoints. |
-| tracing.otlp.server-address string | string | "" (disabled) | Address to listen on for OTLP GRPC server. |
+| tracing.otlp.server-address string | string | ":9202" | Address to listen on for OpenTelemetry OTLP GRPC server. |
 
 ### Auth flags
 

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -130,7 +130,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.StringVar(&cfg.Auth.BearerToken, "web.auth.bearer-token", "", "Bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token-file and basic auth methods.")
 	fs.StringVar(&cfg.Auth.BearerTokenFile, "web.auth.bearer-token-file", "", "Path of the file containing the bearer token (JWT) used for web endpoint authentication. Disabled by default. Mutually exclusive with bearer-token and basic auth methods.")
 
-	fs.Var(&cfg.PromscaleEnabledFeatureList, "enable-feature", "Enable beta/experimental features as a comma-separated list. Currently the following values can be passed: tracing, promql-at-modifier, promql-negative-offset")
+	fs.Var(&cfg.PromscaleEnabledFeatureList, "enable-feature", "Enable beta/experimental features as a comma-separated list. Currently the following values can be passed: promql-at-modifier, promql-negative-offset")
 
 	fs.DurationVar(&cfg.MaxQueryTimeout, "metrics.promql.query-timeout", 2*time.Minute, "Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in "+
 		"'/api/v1/query.*' endpoints.")
@@ -149,8 +149,10 @@ func Validate(cfg *Config) error {
 	cfg.EnabledFeatureMap = make(map[string]struct{})
 	for _, f := range cfg.PromscaleEnabledFeatureList {
 		switch f {
-		case "tracing", "promql-at-modifier", "promql-negative-offset":
+		case "promql-at-modifier", "promql-negative-offset":
 			cfg.EnabledFeatureMap[f] = struct{}{}
+		case "tracing":
+			log.Error("msg", "tracing feature is now on by default, no need to use it with --enable-feature flag")
 		default:
 			return fmt.Errorf("invalid feature: %s", f)
 		}

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -122,7 +122,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.ConfigFile, "config", "config.yml", "YAML configuration file path for Promscale.")
 	fs.StringVar(&cfg.ListenAddr, "web.listen-address", ":9201", "Address to listen on for web endpoints.")
 	fs.StringVar(&cfg.ThanosStoreAPIListenAddr, "thanos.store-api.server-address", "", "Address to listen on for Thanos Store API endpoints.")
-	fs.StringVar(&cfg.OTLPGRPCListenAddr, "tracing.otlp.server-address", "", "Address to listen on for OTLP GRPC server.")
+	fs.StringVar(&cfg.OTLPGRPCListenAddr, "tracing.otlp.server-address", ":9202", "Address to listen on for OpenTelemetry OTLP GRPC server.")
 	fs.StringVar(&corsOriginFlag, "web.cors-origin", ".*", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`)
 	fs.DurationVar(&cfg.ThroughputInterval, "telemetry.log.throughput-report-interval", time.Second, "Duration interval at which throughput should be reported. Setting duration to `0` will disable reporting throughput, otherwise, an interval with unit must be provided, e.g. `10s` or `3m`.")
 	fs.StringVar(&migrateOption, "migrate", "true", fmt.Sprintf("Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. %s", deprecatedFlagSuffix))
@@ -181,16 +181,6 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 
 	if err := validate(cfg); err != nil {
 		return nil, fmt.Errorf("validate config: %w", err)
-	}
-
-	_, tracingEnabled := (cfg.APICfg.EnabledFeatureMap)["tracing"]
-	OLTPGRPCListenerConfigured := len(cfg.OTLPGRPCListenAddr) > 0
-
-	if !tracingEnabled && OLTPGRPCListenerConfigured {
-		return nil, fmt.Errorf("feature 'tracing' must be enabled (with `-enable-feature tracing`) to configure 'tracing.otlp.server-address'")
-	}
-	if tracingEnabled && !OLTPGRPCListenerConfigured {
-		return nil, fmt.Errorf("'tracing.otlp.server-address' must be configured if 'tracing' enabled")
 	}
 
 	cfg.StopAfterMigrate = false

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -69,7 +69,6 @@ func TestParseFlags(t *testing.T) {
 				c.APICfg.PromscaleEnabledFeatureList = []string{"promql-at-modifier", "tracing"}
 				c.APICfg.EnabledFeatureMap = map[string]struct{}{
 					"promql-at-modifier": {},
-					"tracing":            {},
 				}
 				return c
 			},
@@ -159,23 +158,8 @@ func TestParseFlags(t *testing.T) {
 			shouldError: true,
 		},
 		{
-			name:        "setting tracing parameter without tracing enabled should fail",
-			args:        []string{"-otlp-grpc-server-listen-address", "bar"},
-			shouldError: true,
-		},
-		{
 			name:        "enable feature should fail on unknown feature",
 			args:        []string{"-enable-feature", "unknown"},
-			shouldError: true,
-		},
-		{
-			name:        "enable tracing should fail without OTLP",
-			args:        []string{"-enable-feature", "tracing"},
-			shouldError: true,
-		},
-		{
-			name:        "OTLP should fail without enable tracing",
-			args:        []string{"-otlp-grpc-server-listen-address", "someaddress"},
 			shouldError: true,
 		},
 		{
@@ -184,7 +168,6 @@ func TestParseFlags(t *testing.T) {
 			result: func(c Config) Config {
 				c.OTLPGRPCListenAddr = "someaddress"
 				c.APICfg.EnabledFeatureMap = map[string]struct{}{
-					"tracing":                {},
 					"promql-at-modifier":     {},
 					"promql-negative-offset": {},
 				}

--- a/scripts/end_to_end_tests.sh
+++ b/scripts/end_to_end_tests.sh
@@ -209,8 +209,8 @@ compare_connector_and_prom "series?match%5B%5D=ts_prom_sent_samples_total"
 # Labels endpoint cannot be compared to Prometheus becuase it will always differ due to direct backfilling of the real dataset.
 # We have to compare it to the correct expected output. Note that `namespace` and `node` labels are from JSON import payload,
 # while `custom_label` label is from text format write request.
-EXPECTED_OUTPUT1='{"status":"success","data":["__name__","code","custom_label","handler","instance","job","kind","le","method","mode","name","namespace","node","path","quantile","status","subsystem","type","version"]}'
-EXPECTED_OUTPUT2='{"status":"success","data":["__name__","code","custom_label","handler","instance","job","kind","le","method","mode","name","namespace","node","path","quantile","status","subsystem","type"]}'
+EXPECTED_OUTPUT1='{"status":"success","data":["__name__","code","custom_label","grpc_code","grpc_method","grpc_service","grpc_type","handler","instance","job","kind","le","method","mode","name","namespace","node","path","quantile","status","subsystem","type","version"]}'
+EXPECTED_OUTPUT2='{"status":"success","data":["__name__","code","custom_label","grpc_code","grpc_method","grpc_service","grpc_type","handler","instance","job","kind","le","method","mode","name","namespace","node","path","quantile","status","subsystem","type"]}'
 LABELS_OUTPUT=$(curl -s "http://${CONNECTOR_URL}/api/v1/labels")
 
 if [ "${LABELS_OUTPUT}" != "${EXPECTED_OUTPUT1}" ] && [ "${LABELS_OUTPUT}" != "${EXPECTED_OUTPUT2}" ]; then


### PR DESCRIPTION
## Description

We are moving tracing support out of optional to on by default. This means
removing the --enable-feature option for tracing and logging a warning
if somebody is still using it unnecessarily. OTLP GRPC server will
always be started by default on port 9202.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
