### PR TITLE
Improve logging of active servers on start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use the following categories for changes:
 ### Fixed
 - Register `promscale_ingest_channel_len_bucket` metric and make it a gauge [#1177]
 - Log warning when failing to write response to remote read requests [#1180]
+- Fix Promscale running even when some component may fail to start [#1217]
 
 ## [0.10.0] - 2022-02-17
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/jackc/pgtype v1.10.0
 	github.com/jackc/pgx/v4 v4.15.1-0.20220219175125-b6b24f9e8a5d
 	github.com/jaegertracing/jaeger v1.31.0
+	github.com/oklog/run v1.1.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.46.0
 	github.com/opentracing-contrib/go-stdlib v1.0.0
 	github.com/opentracing/opentracing-go v1.2.0


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

## Description

Fixes: #1182 
This PR improves the logging of Promscale on the start. 

The logs now will be
```shell
level=warn ts=2022-03-03T07:54:25.175Z caller=extension.go:59 msg="could not install promscale: the extension is not available. continuing without extension"
level=info ts=2022-03-03T07:54:25.186Z caller=client.go:146 msg="Prometheus HA is not enabled"
level=info ts=2022-03-03T07:54:25.192Z caller=client.go:116 msg="postgresql://postgres:%2A%2A%2A%2A@localhost:5432/timescale?application_name=promscale%400.11.0-dev.0&connect_timeout=60&sslmode=allow" numCopiers=8 pool_max_conns=80 pool_min_conns=8 statement_cache="512 statements"
level=warn ts=2022-03-03T07:54:25.215Z caller=telemetry.go:56 msg="Promscale collects anonymous usage telemetry data to help the Promscale team better understand and assist users. This can be disabled via the process described at https://docs.timescale.com/timescaledb/latest/how-to-guides/configuration/telemetry/#disabling-telemetry"
level=info ts=2022-03-03T08:03:54.300Z caller=runner.go:129 msg="Started Prometheus HTTP server" listening-port=:9201
level=info ts=2022-03-03T08:03:54.300Z caller=runner.go:207 msg="Started OpenTelemetry OTLP GRPC server" listening-port=:9202
```

Note: This PR adds `run.Group` (from `github.com/oklog/run`) that is used to manage the lifecycle of goroutines, which is a library used in Prometheus. This allows us to stop the execution even on partial error, which earlier was not being done.

TODO

- [x] Update the changelog


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
