### PR TITLE
renovate: Do not show version of dependency being update for gomod

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -35,8 +35,9 @@
     },
     {
       "addLabels": ["go"],
-      "groupName": "golang",
-      "matchManagers": ["gomod"]
+      "groupName": "golang dependencies",
+      "matchManagers": ["gomod"],
+      "commitMessageExtra": ""
     },
     {
       "addLabels": ["github_actions"],


### PR DESCRIPTION

## Description

The gomod manager never puts the name of the module being updated in the
title, so putting the version in the title is just confusing.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
