### PR TITLE
Remove deprecated flags for new release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ We use the following categories for changes:
 - Log warning when failing to write response to remote read requests [#1180]
 - Fix Promscale running even when some component may fail to start [#1217]
 
+### Removed
+- Remove deprecated flags. More info can be found [here](docs/configuration.md#old-flag-removal-in-version-0.11.0) [#1229]
+
 ## [0.10.0] - 2022-02-17
 
 ### Added

--- a/cmd/promscale/main.go
+++ b/cmd/promscale/main.go
@@ -23,15 +23,13 @@ func main() {
 	cfg := &runner.Config{}
 	cfg, err := runner.ParseFlags(cfg, args)
 	if err != nil {
-		fmt.Println(version.Info())
-		fmt.Println("Fatal error: cannot parse flags: ", err)
-		os.Exit(1)
+		log.Info("msg", version.Info())
+		log.Fatal("msg", "cannot parse flags", "err", err)
 	}
 	err = log.Init(cfg.LogCfg)
 	if err != nil {
 		fmt.Println(version.Info())
-		fmt.Println("Fatal error: cannot start logger: ", err)
-		os.Exit(1)
+		log.Fatal("msg", "cannot start logger", "err", err)
 	}
 	err = runner.Run(cfg)
 	if err != nil {

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -28,11 +28,9 @@ services:
     depends_on:
       - db
     environment:
-      PROMSCALE_DB_CONNECT_RETRIES: 10
       PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
-      PROMSCALE_ENABLE_FEATURE: tracing
-      PROMSCALE_OTLP_GRPC_SERVER_LISTEN_ADDRESS: ":9202"
+      PROMSCALE_TRACING_OTLP_SERVER_ADDRESS: ":9202"
       PROMSCALE_TELEMETRY_TRACE_JAEGER_ENDPOINT: "http://otel-collector:14268/api/traces"
       PROMSCALE_TELEMETRY_TRACE_SAMPLING_RATIO: "0.1"
 

--- a/docker-compose/test.sh
+++ b/docker-compose/test.sh
@@ -10,7 +10,7 @@ echo "running tests"
 #build latest image
 docker build -t timescale/promscale:latest ../ --file ../build/Dockerfile
 
-docker-compose -p test_docker-compose up -d
+docker compose -p test_docker-compose up -d
 
 cleanup() {
     if (( $? != 0 )); then
@@ -41,7 +41,7 @@ done
 ## sleep for 30s so we can find ingestion logs in promscale
 sleep 30
 
-writeLog=$(docker logs test_docker-compose_promscale_1  2>&1| grep samples/sec | tail -n 1 || true)
+writeLog=$(docker logs test_docker-compose-promscale-1  2>&1| grep samples/sec | tail -n 1 || true)
    if [ -n "$writeLog" ]; then
     echo "promscale is ingesting data"
 else

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,3 +134,65 @@ The following subsections cover all CLI flags which promscale supports. You can 
 | web.enable-admin-api | boolean | false | Allow operations via API that are for advanced users. Currently, these operations are limited to deletion of series. |
 | web.listen-address | string | `:9201` | Address to listen on for web endpoints. |
 | web.telemetry-path | string | `/metrics` | Web endpoint for exposing Promscale's Prometheus metrics. |
+
+
+## Old flag removal in version 0.11.0
+
+With version 0.11.0, we are removing old versions of flag names and enviromental variables. If you run Promscale with those old names, you should get a warning with a suggestion to update the name to the corresponding flag name or environmental variable.
+
+This is the list of CLI flags that are removed in favor of the new flag names:
+
+-app
+-async-acks
+-auth-password
+-auth-password-file
+-auth-username
+-bearer-token
+-bearer-token-file
+-db-connection-timeout
+-db-connections-max
+-db-host
+-db-name
+-db-password
+-db-port
+-db-ssl-mode
+-db-statements-cache
+-db-uri
+-db-user
+-db-writer-connection-concurrency
+-exemplar-cache-size
+-high-availability
+-ignore-samples-written-to-compressed-chunks
+-install-extensions
+-labels-cache-size
+-log-format
+-log-level
+-memory-target
+-metrics-cache-size
+-migrate
+-multi-tenancy
+-multi-tenancy-allow-non-tenants
+-multi-tenancy-valid-tenants
+-otlp-grpc-server-listen-address
+-promql-default-subquery-step-interval
+-promql-lookback-delta
+-promql-max-points-per-ts
+-promql-max-samples
+-promql-query-timeout
+-read-only
+-series-cache-initial-size
+-series-cache-max-bytes
+-thanos-store-api-listen-address
+-tls-cert-file
+-tls-key-file
+-tput-report
+-upgrade-extensions
+-upgrade-prerelease-extensions
+-use-schema-version-lease
+-web-cors-origin
+-web-enable-admin-api
+-web-listen-address
+-web-telemetry-path
+
+
+One special case here is the `migrate` flag which has no direct translation to the new name. Instead, we suggest using `-startup.skip-migrate` or `-startup.only` flags depending on the value used with the old flag.

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -46,60 +46,66 @@ type Config struct {
 	StartupOnly                 bool
 }
 
+const (
+	envVarPrefix    = "PROMSCALE"
+	aliasDescFormat = "alias: %s"
+)
+
 var (
-	aliasDescTemplate    = "Alias for -%s flag. "
-	deprecatedFlagSuffix = "(DEPRECATED) Will be removed in version 0.11.0"
-	flagAliases          = map[string][]string{
-		"auth.tls-cert-file":                {"tls-cert-file"},
-		"auth.tls-key-file":                 {"tls-key-file"},
-		"cache.memory-target":               {"memory-target"},
-		"db.app":                            {"app"},
-		"db.connection-timeout":             {"db-connection-timeout"},
-		"db.connections-max":                {"db-connections-max"},
-		"db.host":                           {"db-host"},
-		"db.name":                           {"db-name"},
-		"db.num-writer-connections":         {"db-writer-connection-concurrency"},
-		"db.password":                       {"db-password"},
-		"db.port":                           {"db-port"},
-		"db.read-only":                      {"read-only"},
-		"db.ssl-mode":                       {"db-ssl-mode"},
-		"db.statements-cache":               {"db-statements-cache"},
-		"db.uri":                            {"db-uri"},
-		"db.user":                           {"db-user"},
-		"metrics.async-acks":                {"async-acks"},
-		"metrics.cache.exemplar.size":       {"exemplar-cache-size"},
-		"metrics.cache.labels.size":         {"labels-cache-size"},
-		"metrics.cache.metrics.size":        {"metrics-cache-size"},
-		"metrics.cache.series.initial-size": {"series-cache-initial-size"},
-		"metrics.cache.series.max-bytes":    {"series-cache-max-bytes"},
-		"metrics.high-availability":         {"high-availability"},
-		"metrics.ignore-samples-written-to-compressed-chunks": {"ignore-samples-written-to-compressed-chunks"},
-		"metrics.multi-tenancy":                               {"multi-tenancy"},
-		"metrics.multi-tenancy.allow-non-tenants":             {"multi-tenancy-allow-non-tenants"},
-		"metrics.multi-tenancy.valid-tenants":                 {"multi-tenancy-valid-tenants"},
-		"metrics.promql.default-subquery-step-interval":       {"promql-default-subquery-step-interval"},
-		"metrics.promql.lookback-delta":                       {"promql-lookback-delta"},
-		"metrics.promql.max-points-per-ts":                    {"promql-max-points-per-ts"},
-		"metrics.promql.max-samples":                          {"promql-max-samples"},
-		"metrics.promql.query-timeout":                        {"promql-query-timeout"},
-		"startup.install-extensions":                          {"install-extensions"},
-		"startup.upgrade-extensions":                          {"upgrade-extensions"},
-		"startup.upgrade-prerelease-extensions":               {"upgrade-prerelease-extensions"},
-		"startup.use-schema-version-lease":                    {"use-schema-version-lease"},
-		"telemetry.log.format":                                {"log-format"},
-		"telemetry.log.level":                                 {"log-level"},
-		"telemetry.log.throughput-report-interval":            {"tput-report"},
-		"thanos.store-api.server-address":                     {"thanos-store-api-listen-address"},
-		"tracing.otlp.server-address":                         {"otlp-grpc-server-listen-address"},
-		"web.auth.bearer-token":                               {"bearer-token"},
-		"web.auth.bearer-token-file":                          {"bearer-token-file"},
-		"web.auth.password":                                   {"auth-password"},
-		"web.auth.password-file":                              {"auth-password-file"},
-		"web.auth.username":                                   {"auth-username"},
-		"web.cors-origin":                                     {"web-cors-origin"},
-		"web.enable-admin-api":                                {"web-enable-admin-api"},
-		"web.listen-address":                                  {"web-listen-address"},
-		"web.telemetry-path":                                  {"web-telemetry-path"},
+	removedEnvVarError    = fmt.Errorf("using removed environmental variables, please update your configuration to new variable names to proceed")
+	removedFlagsError     = fmt.Errorf("using removed flags, please update to new flag names to proceed")
+	removedConfigVarError = fmt.Errorf("using removed configuration file variables, please update to new variable names to proceed")
+	flagAliases           = map[string]string{
+		"auth.tls-cert-file":                "tls-cert-file",
+		"auth.tls-key-file":                 "tls-key-file",
+		"cache.memory-target":               "memory-target",
+		"db.app":                            "app",
+		"db.connection-timeout":             "db-connection-timeout",
+		"db.connections-max":                "db-connections-max",
+		"db.host":                           "db-host",
+		"db.name":                           "db-name",
+		"db.num-writer-connections":         "db-writer-connection-concurrency",
+		"db.password":                       "db-password",
+		"db.port":                           "db-port",
+		"db.read-only":                      "read-only",
+		"db.ssl-mode":                       "db-ssl-mode",
+		"db.statements-cache":               "db-statements-cache",
+		"db.uri":                            "db-uri",
+		"db.user":                           "db-user",
+		"metrics.async-acks":                "async-acks",
+		"metrics.cache.exemplar.size":       "exemplar-cache-size",
+		"metrics.cache.labels.size":         "labels-cache-size",
+		"metrics.cache.metrics.size":        "metrics-cache-size",
+		"metrics.cache.series.initial-size": "series-cache-initial-size",
+		"metrics.cache.series.max-bytes":    "series-cache-max-bytes",
+		"metrics.high-availability":         "high-availability",
+		"metrics.ignore-samples-written-to-compressed-chunks": "ignore-samples-written-to-compressed-chunks",
+		"metrics.multi-tenancy":                               "multi-tenancy",
+		"metrics.multi-tenancy.allow-non-tenants":             "multi-tenancy-allow-non-tenants",
+		"metrics.multi-tenancy.valid-tenants":                 "multi-tenancy-valid-tenants",
+		"metrics.promql.default-subquery-step-interval":       "promql-default-subquery-step-interval",
+		"metrics.promql.lookback-delta":                       "promql-lookback-delta",
+		"metrics.promql.max-points-per-ts":                    "promql-max-points-per-ts",
+		"metrics.promql.max-samples":                          "promql-max-samples",
+		"metrics.promql.query-timeout":                        "promql-query-timeout",
+		"startup.install-extensions":                          "install-extensions",
+		"startup.upgrade-extensions":                          "upgrade-extensions",
+		"startup.upgrade-prerelease-extensions":               "upgrade-prerelease-extensions",
+		"startup.use-schema-version-lease":                    "use-schema-version-lease",
+		"telemetry.log.format":                                "log-format",
+		"telemetry.log.level":                                 "log-level",
+		"telemetry.log.throughput-report-interval":            "tput-report",
+		"thanos.store-api.server-address":                     "thanos-store-api-listen-address",
+		"tracing.otlp.server-address":                         "otlp-grpc-server-listen-address",
+		"web.auth.bearer-token":                               "bearer-token",
+		"web.auth.bearer-token-file":                          "bearer-token-file",
+		"web.auth.password":                                   "auth-password",
+		"web.auth.password-file":                              "auth-password-file",
+		"web.auth.username":                                   "auth-username",
+		"web.cors-origin":                                     "web-cors-origin",
+		"web.enable-admin-api":                                "web-enable-admin-api",
+		"web.listen-address":                                  "web-listen-address",
+		"web.telemetry-path":                                  "web-telemetry-path",
 	}
 )
 
@@ -108,7 +114,6 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 		fs = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
 		corsOriginFlag string
-		migrateOption  string
 		skipMigrate    bool
 	)
 
@@ -125,7 +130,6 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.OTLPGRPCListenAddr, "tracing.otlp.server-address", ":9202", "Address to listen on for OpenTelemetry OTLP GRPC server.")
 	fs.StringVar(&corsOriginFlag, "web.cors-origin", ".*", `Regex for CORS origin. It is fully anchored. Example: 'https?://(domain1|domain2)\.com'`)
 	fs.DurationVar(&cfg.ThroughputInterval, "telemetry.log.throughput-report-interval", time.Second, "Duration interval at which throughput should be reported. Setting duration to `0` will disable reporting throughput, otherwise, an interval with unit must be provided, e.g. `10s` or `3m`.")
-	fs.StringVar(&migrateOption, "migrate", "true", fmt.Sprintf("Update the Prometheus SQL schema to the latest version. Valid options are: [true, false, only]. %s", deprecatedFlagSuffix))
 	fs.StringVar(&cfg.DatasetConfig, "startup.dataset.config", "", "Dataset configuration in YAML format for Promscale. It is used for setting various dataset configuration like default metric chunk interval")
 	fs.BoolVar(&cfg.StartupOnly, "startup.only", false, "Only run startup configuration with Promscale (i.e. migrate) and exit. Can be used to run promscale as an init container for HA setups.")
 	fs.BoolVar(&skipMigrate, "startup.skip-migrate", false, "Skip migrating Promscale SQL schema to latest version on startup.")
@@ -137,9 +141,11 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	fs.StringVar(&cfg.TLSCertFile, "auth.tls-cert-file", "", "TLS Certificate file used for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 	fs.StringVar(&cfg.TLSKeyFile, "auth.tls-key-file", "", "TLS Key file for server authentication, leave blank to disable TLS. NOTE: this option is used for all servers that Promscale runs (web and GRPC).")
 
-	addAliases(fs, flagAliases, deprecatedFlagSuffix)
+	if err := checkForRemovedEnvVarUsage(); err != nil {
+		return nil, err
+	}
 
-	if err := util.ParseEnv("PROMSCALE", fs); err != nil {
+	if err := util.ParseEnv(envVarPrefix, fs); err != nil {
 		return nil, fmt.Errorf("error parsing env variables: %w", err)
 	}
 
@@ -148,24 +154,13 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 		ff.WithConfigFileParser(ffyaml.Parser),
 		ff.WithAllowMissingConfigFile(true),
 	); err != nil {
-		return nil, fmt.Errorf("configuration error: %w", err)
-	}
-
-	// Warn about deprecated flags.
-	if flagsForUpdate := deprecatedFlagsUsed(fs); len(flagsForUpdate) > 0 {
-		log.Warn("msg", "Using deprecated flags that will be dropped in a future version. Please update to new flag names.")
-		for oldFlag, newFlag := range flagsForUpdate {
-			log.Warn("msg", fmt.Sprintf("Update deprecated flag %s to new flag %s", oldFlag, newFlag))
+		// We might be dealing with old flags whose usage needs to be logged.
+		// TODO: remove handling of old flags in a future version
+		if oldFlagErr := checkForRemovedConfigFlags(fs, args); oldFlagErr != nil {
+			return nil, oldFlagErr
 		}
-	}
-	// Migrate flag is a special case that needs to be logged separately.
-	switch migrateOption {
-	case "false":
-		log.Warn("msg", "Using deprecated flag `migrate` set to `false` which will be dropped in a future version. "+
-			"Please update you configuration by using `startup.skip-migrate` flag.")
-	case "only":
-		log.Warn("msg", "Using deprecated flag `migrate` set to `only` which will be dropped in a future version. "+
-			"Please update you configuration by using `startup.only` flag.")
+
+		return nil, fmt.Errorf("configuration error when parsing flags: %w", err)
 	}
 
 	// Checking if TLS files are not both set or both empty.
@@ -184,19 +179,14 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	}
 
 	cfg.StopAfterMigrate = false
-	if strings.EqualFold(migrateOption, "true") {
-		cfg.Migrate = true
-	} else if strings.EqualFold(migrateOption, "false") {
-		cfg.Migrate = false
-	} else if strings.EqualFold(migrateOption, "only") {
-		cfg.Migrate = true
-		cfg.StopAfterMigrate = true
-	} else {
-		return nil, fmt.Errorf("Invalid option for migrate: %v. Valid options are [true, false, only]", migrateOption)
-	}
+	cfg.Migrate = true
 
 	if skipMigrate {
 		cfg.Migrate = false
+	}
+
+	if cfg.StartupOnly {
+		cfg.StopAfterMigrate = true
 	}
 
 	if cfg.APICfg.ReadOnly {
@@ -240,51 +230,159 @@ func validate(cfg *Config) error {
 	return nil
 }
 
-func addAliases(fs *flag.FlagSet, aliases map[string][]string, descSuffix string) {
-	aliasDescFormat := aliasDescTemplate + descSuffix
-	set := false
-	fs.VisitAll(func(f *flag.Flag) {
-		if flagAliases, ok := aliases[f.Name]; ok {
-			set = false
-			for _, alias := range flagAliases {
-				set = true
-				fs.Var(f.Value, alias, fmt.Sprintf(aliasDescFormat, f.Name))
-			}
-
-			if !set {
-				panic(fmt.Sprintf("trying to set an flag alias for a flag that is missing: %s", f.Name))
-			}
-		}
-	})
+func addAliases(fs *flag.FlagSet, aliases map[string]string) {
+	for newFlag, flagAlias := range aliases {
+		fs.String(flagAlias, "", fmt.Sprintf(aliasDescFormat, newFlag))
+	}
 }
 
-func deprecatedFlagsUsed(fs *flag.FlagSet) map[string]string {
-	var (
-		result      = make(map[string]string)
-		newFlagName string
-		count       int
-	)
-
-	fs.Visit(func(f *flag.Flag) {
-		if strings.Contains(f.Usage, deprecatedFlagSuffix) {
-			i, err := fmt.Sscanf(f.Usage, aliasDescTemplate, &newFlagName)
-
-			switch {
-			case f.Name == "migrate":
-				// Migrate flag is a special case since it's not just a rename
-				// of an old flag. We handle it separately when logging
-				// use of deprecated flags.
-				return
-			case err != nil:
-				fallthrough
-			case i != 1:
-				panic("deprecated flag usage not set in the correct format")
-			}
-
-			result[f.Name] = newFlagName
-			count++
+func checkForRemovedConfigFlags(fs *flag.FlagSet, args []string) error {
+	// Check arguments for old flags.
+	if oldFlags := removedFlagsUsed(args); len(oldFlags) > 0 {
+		for oldFlag, newFlag := range oldFlags {
+			handleOldFlags(oldFlag, newFlag)
 		}
+		return removedFlagsError
+	}
+
+	// Check config file for old names.
+	aliasFS := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	// Need to set config and migrate flags which are special cases.
+	// Config is for detecting config file and migrate for detecting that special configuration setting.
+	aliasFS.String("config", "config.yml", "")
+	aliasFS.String("migrate", "true", "")
+	addAliases(aliasFS, flagAliases)
+
+	if err := ff.Parse(aliasFS, args,
+		ff.WithConfigFileFlag("config"),
+		ff.WithConfigFileParser(ffyaml.Parser),
+		ff.WithIgnoreUndefined(true),
+		ff.WithAllowMissingConfigFile(true),
+	); err != nil {
+		// If are having trouble parsing the old flags, just ignore since there isn't much we can do.
+		// Logging this error would just create confusion for the user.
+		return nil
+	}
+
+	var (
+		foundOldFlags bool
+		newFlagName   string
+	)
+	aliasFS.Visit(func(f *flag.Flag) {
+		i, err := fmt.Sscanf(f.Usage, aliasDescFormat, &newFlagName)
+		switch {
+		case f.Name == "migrate":
+			// Migrate flag is a special case since it's not just a rename
+			// of an old flag. We handle it with regards to the flag value.
+			newFlagName = f.Value.String()
+		case err != nil || i != 1:
+			// If are having trouble parsing the old flags, just ignore since there isn't much we can do.
+			// Logging this error would just create confusion for the user.
+			println(err)
+			return
+		}
+		foundOldFlags = true
+		handleOldFlags(f.Name, newFlagName)
 	})
 
+	if foundOldFlags {
+		return removedConfigVarError
+	}
+	return nil
+}
+
+func handleOldFlags(oldFlag, newFlag string) {
+	if oldFlag != "migrate" {
+		log.Warn("msg", fmt.Sprintf("Update removed flag `%s` to new flag `%s`", oldFlag, newFlag))
+	}
+
+	// Handling the special migrate flag
+	switch newFlag {
+	case "false":
+		log.Warn("msg", "Using removed flag `migrate` set to `false`. "+
+			"Please update you configuration by using `startup.skip-migrate` flag.")
+	case "only":
+		log.Warn("msg", "Using removed flag `migrate` set to `only`. "+
+			"Please update you configuration by using `startup.only` flag.")
+	default:
+		log.Warn("msg", "Using removed flag `migrate` with an invalid value. "+
+			"Please update you configuration by using one of the startup flags.")
+	}
+}
+
+func checkForRemovedEnvVarUsage() (err error) {
+	for newName, oldName := range flagAliases {
+		newName, oldName = util.GetEnvVarName(envVarPrefix, newName), util.GetEnvVarName(envVarPrefix, oldName)
+
+		// We don't care if flags are using the same env variable.
+		if newName == oldName {
+			continue
+		}
+
+		if val := os.Getenv(oldName); val != "" {
+			err = removedEnvVarError
+			log.Warn("msg", fmt.Sprintf("using unsupported environment variable [%s] for configuration flag which has been removed. Please update to new name [%s].", oldName, newName))
+		}
+	}
+
+	oldMigrate := util.GetEnvVarName(envVarPrefix, "migrate")
+	// Handling the special migrate flag
+	if val := os.Getenv(oldMigrate); val != "" {
+		err = removedEnvVarError
+		switch val {
+		case "false":
+			log.Warn("msg", fmt.Sprintf("Using removed environment variable `%s` set to `false`. "+
+				"Please update you configuration by using `%s` environment variable.",
+				oldMigrate,
+				util.GetEnvVarName(envVarPrefix, "startup.skip-migrate")),
+			)
+		case "only":
+			log.Warn("msg", fmt.Sprintf("Using removed flag `%s` set to `only`. "+
+				"Please update you configuration by using `%s` environment variable.",
+				oldMigrate,
+				util.GetEnvVarName(envVarPrefix, "startup.only")),
+			)
+		default:
+			log.Warn("msg", fmt.Sprintf("Using removed flag `%s` with an invalid value. "+
+				"Please update you configuration by using one of the startup environment variables or flags.",
+				oldMigrate),
+			)
+		}
+	}
+
+	return err
+}
+
+func removedFlagsUsed(args []string) map[string]string {
+	result := make(map[string]string)
+
+argloop:
+	for i, arg := range args {
+		if arg[0] != '-' {
+			continue
+		}
+
+		splits := strings.SplitN(arg, "=", 2)
+		arg = strings.TrimLeft(splits[0], "-")
+
+		for newName, oldName := range flagAliases {
+			if arg == oldName {
+				result[oldName] = newName
+				continue argloop
+			}
+		}
+
+		// Migrate is a special case that needs to be handled according to its value.
+		if arg == "migrate" {
+			value := ""
+			switch {
+			case len(splits) > 1: // Value is after '=' delimiter.
+				value = splits[1]
+			case len(args) > i+1: // Value is the next argument.
+				value = args[i+1]
+			}
+			result["migrate"] = value
+		}
+	}
 	return result
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -40,9 +40,7 @@ func ParseEnv(p string, fs *flag.FlagSet) error {
 		}
 		// Create an env var name
 		// based on the supplied prefix.
-		envVar := fmt.Sprintf("%s_%s", p, strings.ToUpper(f.Name))
-		envVar = strings.Replace(envVar, "-", "_", -1)
-		envVar = strings.Replace(envVar, ".", "_", -1)
+		envVar := GetEnvVarName(p, f.Name)
 
 		// Update the Flag.Value if the
 		// env var is non "".
@@ -66,6 +64,14 @@ func ParseEnv(p string, fs *flag.FlagSet) error {
 	})
 
 	return err
+}
+
+// GetEnvVarName returns the name of the environment variable used
+// for setting the configuration flag based on a prefix and flag name.
+func GetEnvVarName(prefix, fName string) (envVar string) {
+	envVar = fmt.Sprintf("%s_%s", prefix, strings.ToUpper(fName))
+	envVar = strings.ReplaceAll(envVar, "-", "_")
+	return strings.ReplaceAll(envVar, ".", "_")
 }
 
 func IsTimescaleDBInstalled(conn pgxconn.PgxConn) bool {

--- a/scripts/end_to_end_tests.sh
+++ b/scripts/end_to_end_tests.sh
@@ -80,13 +80,13 @@ wait_for() {
 echo "Waiting for database to be up..."
 wait_for "$DB_URL"
 
-PROMSCALE_LOG_LEVEL=debug \
+PROMSCALE_TELEMETRY_LOG_LEVEL=debug \
 PROMSCALE_DB_CONNECT_RETRIES=10 \
 PROMSCALE_DB_PASSWORD=postgres \
 PROMSCALE_DB_NAME=postgres \
 PROMSCALE_DB_SSL_MODE=disable \
 PROMSCALE_WEB_TELEMETRY_PATH=/metrics \
-./promscale -migrate=only
+./promscale -startup.only
 
 docker exec e2e-tsdb psql -U postgres -d postgres \
   -c "CREATE ROLE writer PASSWORD 'test' LOGIN" \
@@ -94,14 +94,14 @@ docker exec e2e-tsdb psql -U postgres -d postgres \
   -c "CREATE ROLE reader PASSWORD 'test' LOGIN" \
   -c "GRANT prom_reader TO reader"
 
-PROMSCALE_LOG_LEVEL=debug \
-PROMSCALE_DB_CONNECT_RETRIES=10 \
+
+PROMSCALE_TELEMETRY_LOG_LEVEL=debug \
 PROMSCALE_DB_PASSWORD=test \
 PROMSCALE_DB_USER=writer \
 PROMSCALE_DB_NAME=postgres \
 PROMSCALE_DB_SSL_MODE=disable \
 PROMSCALE_WEB_TELEMETRY_PATH=/metrics \
-./promscale -install-extensions=false -migrate=false -upgrade-extensions=false &
+./promscale -startup.install-extensions=false -startup.skip-migrate -startup.upgrade-extensions=false &
 
 CONN_PID=$!
 
@@ -137,14 +137,13 @@ curl -v \
 
 kill $CONN_PID
 
-PROMSCALE_LOG_LEVEL=debug \
-PROMSCALE_DB_CONNECT_RETRIES=10 \
+PROMSCALE_TELEMETRY_LOG_LEVEL=debug \
 PROMSCALE_DB_PASSWORD=test \
 PROMSCALE_DB_USER=writer \
 PROMSCALE_DB_NAME=postgres \
 PROMSCALE_DB_SSL_MODE=disable \
 PROMSCALE_WEB_TELEMETRY_PATH=/metrics \
-./promscale -install-extensions=false -migrate=false -upgrade-extensions=false &
+./promscale -startup.install-extensions=false -startup.skip-migrate -startup.upgrade-extensions=false &
 
 CONN_PID=$!
 
@@ -161,14 +160,13 @@ curl -f \
 
 kill $CONN_PID
 
-PROMSCALE_LOG_LEVEL=debug \
-PROMSCALE_DB_CONNECT_RETRIES=10 \
+PROMSCALE_TELEMETRY_LOG_LEVEL=debug \
 PROMSCALE_DB_PASSWORD=test \
 PROMSCALE_DB_USER=reader \
 PROMSCALE_DB_NAME=postgres \
 PROMSCALE_DB_SSL_MODE=disable \
 PROMSCALE_WEB_TELEMETRY_PATH=/metrics \
-./promscale -install-extensions=false -migrate=false -upgrade-extensions=false -read-only &
+./promscale -startup.install-extensions=false -startup.skip-migrate -startup.upgrade-extensions=false -db.read-only &
 
 CONN_PID=$!
 


### PR DESCRIPTION
## Description

We have deprecated flags that need to be removed for next release. This
change removes the flags but still attempts to detect usage of old flag
names and old environmental variable names and logs their usage with
recommendations to rename them to new names. Execution will stop if
any of the old names are used.

Fixes #1109 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
