### PR TITLE
Expose build information through Prometheus metrics

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
   main: ./cmd/promscale/
   id: promscale
   ldflags:
-    - -s -w -X github.com/timescale/promscale/pkg/version.CommitHash={{.Commit}} -X github.com/timescale/promscale/pkg/telemetry.BuildPlatform=goreleaser
+    - -s -w -X github.com/timescale/promscale/pkg/version.CommitHash={{.Commit}} -X github.com/timescale/promscale/pkg/version.Branch={{.Branch}} -X github.com/timescale/promscale/pkg/telemetry.BuildPlatform=goreleaser
 - env:
   - CGO_ENABLED=0
   main: ./cmd/prom-migrator/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
+GIT_COMMIT ?= $(shell git rev-list -1 HEAD)
+GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
+
 .PHONY: build
 build: generate
-	go build -o dist/promscale ./cmd/promscale
+	go build -ldflags "-X 'github.com/timescale/promscale/pkg/version.Branch=${GIT_BRANCH}' -X 'github.com/timescale/promscale/pkg/version.CommitHash=${GIT_COMMIT}'" -o dist/promscale ./cmd/promscale
 
 .PHONY: test
 test: generate

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,9 +10,9 @@ COPY ./cmd cmd/
 ARG TARGETOS
 ARG TARGETARCH
 RUN go generate ./...
-RUN GIT_COMMIT=$(git rev-list -1 HEAD) \
+RUN GIT_COMMIT=$(git rev-list -1 HEAD) && GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
     && GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} CGO_ENABLED=0 go build -a \
-    --ldflags '-w' --ldflags "-X version.CommitHash=$GIT_COMMIT" \
+    -ldflags "-w -X 'github.com/timescale/promscale/pkg/version.CommitHash=$GIT_COMMIT' -X 'github.com/timescale/promscale/pkg/version.Branch=$GIT_BRANCH'" \
     -o /bin/promscale ./cmd/promscale
 
 # Final image

--- a/cmd/promscale/main.go
+++ b/cmd/promscale/main.go
@@ -23,13 +23,13 @@ func main() {
 	cfg := &runner.Config{}
 	cfg, err := runner.ParseFlags(cfg, args)
 	if err != nil {
-		fmt.Println("Version: ", version.Promscale, "Commit Hash: ", version.CommitHash)
+		fmt.Println(version.Info())
 		fmt.Println("Fatal error: cannot parse flags: ", err)
 		os.Exit(1)
 	}
 	err = log.Init(cfg.LogCfg)
 	if err != nil {
-		fmt.Println("Version: ", version.Promscale, "Commit Hash: ", version.CommitHash)
+		fmt.Println(version.Info())
 		fmt.Println("Fatal error: cannot start logger: ", err)
 		os.Exit(1)
 	}

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -61,7 +61,7 @@ func loggingStreamInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.
 }
 
 func Run(cfg *Config) error {
-	log.Info("msg", "Version:"+version.Promscale+"; Commit Hash: "+version.CommitHash)
+	log.Info("msg", version.Info())
 
 	redacted := *cfg
 	redacted.PgmodelCfg.Password = "****"


### PR DESCRIPTION
We expose version, commit and branch. This information is useful for
comparing benchmark numbers across various builds.