### PR TITLE
Verify telemetry engine as `nil` if TimescaleDB is not installed.

### DIFF
--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -79,6 +79,9 @@ func NewEngine(conn pgxconn.PgxConn, uuid [16]byte, promqlQueryable promql.Query
 }
 
 func isTelemetryOff(conn pgxconn.PgxConn) (bool, error) {
+	if !util.IsTimescaleDBInstalled(conn) {
+		return true, nil
+	}
 	var state string
 	err := conn.QueryRow(context.Background(), "SHOW timescaledb.telemetry_level").Scan(&state)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Fixes: https://github.com/timescale/o11y-team-applications/issues/145

## Description

Same as the heading.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
