### PR TITLE
Refactors telemetry metric registration

### DIFF
--- a/pkg/jaeger/api.go
+++ b/pkg/jaeger/api.go
@@ -1,25 +1,18 @@
 package jaeger
 
 import (
-	"fmt"
-
 	"github.com/gorilla/mux"
 	jaegerQueryApp "github.com/jaegertracing/jaeger/cmd/query/app"
 	jaegerQueryService "github.com/jaegertracing/jaeger/cmd/query/app/querysvc"
 
 	"github.com/timescale/promscale/pkg/jaeger/query"
 	"github.com/timescale/promscale/pkg/pgxconn"
-	"github.com/timescale/promscale/pkg/telemetry"
 )
 
-func ExtendQueryAPIs(r *mux.Router, conn pgxconn.PgxConn, t telemetry.Engine) error {
-	reader, err := query.New(conn, t)
-	if err != nil {
-		return fmt.Errorf("error initializing tracing query: %w", err)
-	}
+func ExtendQueryAPIs(r *mux.Router, conn pgxconn.PgxConn) {
+	reader := query.New(conn)
 	handler := jaegerQueryApp.NewAPIHandler(
 		jaegerQueryService.NewQueryService(reader, reader, jaegerQueryService.QueryServiceOptions{}),
 	)
 	handler.RegisterRoutes(r)
-	return nil
 }

--- a/pkg/jaeger/query/metrics.go
+++ b/pkg/jaeger/query/metrics.go
@@ -31,7 +31,7 @@ var (
 	})
 )
 
-func registerMetricsForTelemetry(t telemetry.Engine) error {
+func RegisterTelemetryMetrics(t telemetry.Engine) error {
 	var err error
 	if err = t.RegisterMetric("promscale_trace_query_requests_executed_total", traceRequestsExec); err != nil {
 		return fmt.Errorf("register 'promscale_trace_query_requests_executed_total' metric for telemetry: %w", err)

--- a/pkg/jaeger/query/query.go
+++ b/pkg/jaeger/query/query.go
@@ -6,7 +6,6 @@ package query
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -18,18 +17,14 @@ import (
 	"github.com/timescale/promscale/pkg/log"
 	"github.com/timescale/promscale/pkg/pgmodel/metrics"
 	"github.com/timescale/promscale/pkg/pgxconn"
-	"github.com/timescale/promscale/pkg/telemetry"
 )
 
 type Query struct {
 	conn pgxconn.PgxConn
 }
 
-func New(conn pgxconn.PgxConn, t telemetry.Engine) (*Query, error) {
-	if err := registerMetricsForTelemetry(t); err != nil {
-		return nil, fmt.Errorf("register metrics for telemetry: %w", err)
-	}
-	return &Query{conn}, nil
+func New(conn pgxconn.PgxConn) *Query {
+	return &Query{conn}
 }
 
 func (p *Query) SpanReader() spanstore.Reader {

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/pgxconn"
 	"github.com/timescale/promscale/pkg/prompb"
-	"github.com/timescale/promscale/pkg/telemetry"
 	"github.com/timescale/promscale/pkg/tracer"
 )
 
@@ -39,7 +38,7 @@ type DBIngestor struct {
 
 // NewPgxIngestor returns a new Ingestor that uses connection pool and a metrics cache
 // for caching metric table names.
-func NewPgxIngestor(conn pgxconn.PgxConn, cache cache.MetricCache, sCache cache.SeriesCache, eCache cache.PositionCache, cfg *Cfg, t telemetry.Engine) (*DBIngestor, error) {
+func NewPgxIngestor(conn pgxconn.PgxConn, cache cache.MetricCache, sCache cache.SeriesCache, eCache cache.PositionCache, cfg *Cfg) (*DBIngestor, error) {
 	dispatcher, err := newPgxDispatcher(conn, cache, sCache, eCache, cfg)
 	if err != nil {
 		return nil, err
@@ -47,7 +46,7 @@ func NewPgxIngestor(conn pgxconn.PgxConn, cache cache.MetricCache, sCache cache.
 	return &DBIngestor{
 		sCache:     sCache,
 		dispatcher: dispatcher,
-		tWriter:    trace.NewWriter(conn, t),
+		tWriter:    trace.NewWriter(conn),
 	}, nil
 }
 
@@ -61,7 +60,7 @@ func NewPgxIngestorForTests(conn pgxconn.PgxConn, cfg *Cfg) (*DBIngestor, error)
 	c := cache.NewMetricCache(cacheConfig)
 	s := cache.NewSeriesCache(cacheConfig, nil)
 	e := cache.NewExemplarLabelsPosCache(cacheConfig)
-	return NewPgxIngestor(conn, c, s, e, cfg, telemetry.NewNoopEngine())
+	return NewPgxIngestor(conn, c, s, e, cfg)
 }
 
 const (

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -44,18 +44,18 @@ type engineImpl struct {
 	metrics sync.Map
 }
 
-func NewEngine(conn pgxconn.PgxConn, uuid [16]byte, promqlQueryable promql.Queryable) (*engineImpl, error) {
+func NewEngine(conn pgxconn.PgxConn, uuid [16]byte, promqlQueryable promql.Queryable) (Engine, error) {
 	isTelemetryOff, err := isTelemetryOff(conn)
 	if err != nil {
 		log.Debug("msg", "unable to get TimescaleDB telemetry configuration. Maybe TimescaleDB is not installed", "err", err.Error())
+		return NewNoopEngine(), nil
 	}
 	if isTelemetryOff {
-		return nil, nil
-	} else {
-		// Warn the users about telemetry collection only if telemetry collection is enabled.
-		log.Warn("msg", "Promscale collects anonymous usage telemetry data to help the Promscale team better understand and assist users. "+
-			"This can be disabled via the process described at https://docs.timescale.com/timescaledb/latest/how-to-guides/configuration/telemetry/#disabling-telemetry")
+		return NewNoopEngine(), nil
 	}
+	// Warn the users about telemetry collection only if telemetry collection is enabled.
+	log.Warn("msg", "Promscale collects anonymous usage telemetry data to help the Promscale team better understand and assist users. "+
+		"This can be disabled via the process described at https://docs.timescale.com/timescaledb/latest/how-to-guides/configuration/telemetry/#disabling-telemetry")
 
 	t := &engineImpl{
 		conn: conn,
@@ -73,7 +73,7 @@ func NewEngine(conn pgxconn.PgxConn, uuid [16]byte, promqlQueryable promql.Query
 	}
 
 	if err := t.writeMetadata(); err != nil {
-		return nil, fmt.Errorf("writing metadata: %w", err)
+		return NewNoopEngine(), fmt.Errorf("writing metadata: %w", err)
 	}
 	return t, nil
 }
@@ -386,9 +386,9 @@ func convertIntToString(i int64) string {
 	return strconv.FormatInt(i, 10)
 }
 
-type noop struct{}
+type Noop struct{}
 
-func NewNoopEngine() Engine                                    { return noop{} }
-func (noop) Start()                                            {}
-func (noop) Stop()                                             {}
-func (noop) RegisterMetric(string, ...prometheus.Metric) error { return nil }
+func NewNoopEngine() Engine                                    { return Noop{} }
+func (Noop) Start()                                            {}
+func (Noop) Stop()                                             {}
+func (Noop) RegisterMetric(string, ...prometheus.Metric) error { return nil }

--- a/pkg/tests/end_to_end_tests/drop_test.go
+++ b/pkg/tests/end_to_end_tests/drop_test.go
@@ -21,7 +21,6 @@ import (
 	pgmodel "github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/pgxconn"
 	"github.com/timescale/promscale/pkg/prompb"
-	"github.com/timescale/promscale/pkg/telemetry"
 )
 
 func TestSQLRetentionPeriod(t *testing.T) {
@@ -471,7 +470,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 		}
 
 		c := cache.NewMetricCache(cache.DefaultConfig)
-		ingestor, err := ingstr.NewPgxIngestor(pgxconn.NewPgxConn(db), c, scache, nil, &ingstr.Cfg{DisableEpochSync: true}, telemetry.NewNoopEngine())
+		ingestor, err := ingstr.NewPgxIngestor(pgxconn.NewPgxConn(db), c, scache, nil, &ingstr.Cfg{DisableEpochSync: true})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
+++ b/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/pgxconn"
 	"github.com/timescale/promscale/pkg/prompb"
-	"github.com/timescale/promscale/pkg/telemetry"
 )
 
 type haTestInput struct {
@@ -125,7 +124,7 @@ func prepareWriterWithHa(db *pgxpool.Pool, t testing.TB) (*util.ManualTicker, ht
 	dataParser.AddPreprocessor(ha.NewFilter(haService))
 	mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 
-	ing, err := ingestor.NewPgxIngestor(pgxconn.NewPgxConn(db), mCache, sCache, nil, &ingestor.Cfg{}, telemetry.NewNoopEngine())
+	ing, err := ingestor.NewPgxIngestor(pgxconn.NewPgxConn(db), mCache, sCache, nil, &ingestor.Cfg{})
 	if err != nil {
 		t.Fatalf("could not create ingestor: %v", err)
 	}

--- a/pkg/tests/end_to_end_tests/ingest_trace_test.go
+++ b/pkg/tests/end_to_end_tests/ingest_trace_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/timescale/promscale/pkg/jaeger/query"
 	ingstr "github.com/timescale/promscale/pkg/pgmodel/ingestor"
 	"github.com/timescale/promscale/pkg/pgxconn"
-	"github.com/timescale/promscale/pkg/telemetry"
 )
 
 func TestIngestTraces(t *testing.T) {
@@ -64,8 +63,7 @@ func TestQueryTraces(t *testing.T) {
 		err = ingestor.IngestTraces(context.Background(), traces)
 		require.NoError(t, err)
 
-		q, err := query.New(pgxconn.NewQueryLoggingPgxConn(db), telemetry.NewNoopEngine())
-		require.NoError(t, err)
+		q := query.New(pgxconn.NewQueryLoggingPgxConn(db))
 
 		getOperationsTest(t, q)
 		findTraceTest(t, q)

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/timescale/promscale/pkg/api"
 	"github.com/timescale/promscale/pkg/pgclient"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
-	"github.com/timescale/promscale/pkg/telemetry"
 	"github.com/timescale/promscale/pkg/tenancy"
 )
 
@@ -312,7 +311,7 @@ func buildRouterWithAPIConfig(pool *pgxpool.Pool, cfg *api.Config) (*mux.Router,
 		return nil, pgClient, fmt.Errorf("cannot run test, cannot instantiate pgClient")
 	}
 
-	router, err := api.GenerateRouter(cfg, pgClient, nil, telemetry.NewNoopEngine())
+	router, err := api.GenerateRouter(cfg, pgClient, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("generate router: %w", err)
 	}

--- a/pkg/tests/end_to_end_tests/trace_query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/trace_query_integration_test.go
@@ -23,7 +23,6 @@ import (
 	promscaleJaeger "github.com/timescale/promscale/pkg/jaeger"
 	ingstr "github.com/timescale/promscale/pkg/pgmodel/ingestor"
 	"github.com/timescale/promscale/pkg/pgxconn"
-	"github.com/timescale/promscale/pkg/telemetry"
 )
 
 type traceQuery struct {
@@ -67,8 +66,7 @@ func TestCompareTraceQueryResponse(t *testing.T) {
 		router, _, err := buildRouter(db)
 		require.NoError(t, err)
 
-		err = promscaleJaeger.ExtendQueryAPIs(router, pgxconn.NewPgxConn(db), telemetry.NewNoopEngine())
-		require.NoError(t, err)
+		promscaleJaeger.ExtendQueryAPIs(router, pgxconn.NewPgxConn(db))
 
 		go func() {
 			listener, err := net.Listen("tcp", ":9201")


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This commit refactors the metric registration process in telemetry. Now,
the telemetry engine no longer requires to be passed down to each module
that wants to send telemetry, rather just expose a func which accepts a
telemetry engine.

The call of this exposed function happens in runner.go where all modules
that want to send telemetry are called and managed.

Fixes: #1156 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
