### PR TITLE
Track number of ingested bytes for metrics and traces

### DIFF
--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -151,6 +151,14 @@ var (
 			Help:      "Total items (samples/exemplars/spans) received.",
 		}, []string{"type", "kind"},
 	)
+	IngestorBytes = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: util.PromNamespace,
+			Subsystem: "ingest",
+			Name:      "requests_bytes_total",
+			Help:      "Total requests bytes ingested for traces or metrics",
+		}, []string{"type"},
+	)
 	IngestorRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: util.PromNamespace,
@@ -188,6 +196,7 @@ func init() {
 		IngestorActiveWriteRequests,
 		IngestorDuration,
 		IngestorItems,
+		IngestorBytes,
 		IngestorItemsReceived,
 		IngestorRequests,
 		InsertBatchSize,


### PR DESCRIPTION
We use the size of received Protobuf message to calculate bytes.

Tracking ingested bytes is useful when comparing Promscale to competitors... 

Later on we might expose this in Telemetry but we need schema migration completed before.