### PR TITLE
Fix batch flush size

### DIFF
--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -50,7 +50,8 @@ func NewPendingBuffer() *pendingBuffer {
 }
 
 func (p *pendingBuffer) IsFull() bool {
-	return p.batch.CountSeries() > metrics.FlushSize
+	samples, exemplars := p.batch.Count()
+	return samples+exemplars >= metrics.FlushSize
 }
 
 func (p *pendingBuffer) IsEmpty() bool {

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -14,10 +14,8 @@ import (
 // Keep these const values in pgmodel/metrics to avoid cyclic import since 'trace' may also need this.
 const (
 	MetricBatcherChannelCap = 1000
-	// FlushSize is the maximum number of insertDataRequests that should be buffered before the
-	// insertHandler flushes to the next layer. We don't want too many as this
-	// increases the number of lost writes if the connector dies. This number
-	// was chosen arbitrarily.
+	// FlushSize defines the batch size. It is the maximum number of samples/exemplars per insert batch.
+	// This translates to the max array size that we pass into `insert_metric_row`
 	FlushSize           = 2000
 	MaxInsertStmtPerTxn = 100
 )

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -16,8 +16,13 @@ const (
 	MetricBatcherChannelCap = 1000
 	// FlushSize defines the batch size. It is the maximum number of samples/exemplars per insert batch.
 	// This translates to the max array size that we pass into `insert_metric_row`
-	FlushSize           = 2000
-	MaxInsertStmtPerTxn = 100
+	FlushSize = 500
+	// MaxInsertStmtPerTxn and FlushSize should be looked at together: MaxInsertStmtPerTxn * FlushSize defines
+	// the maximum number of rows we might attempt to insert. Max is only reached in case copiers are not able
+	// to catch up with incoming batches. Currently we aim at 5K max however we might tune it further upon running
+	// more benchmarks. Obviously increasing the number of rows we insert within a transaction also increases the
+	// transaction time and might lead to increased lock contention (which we want to avoid).
+	MaxInsertStmtPerTxn = 10
 )
 
 var (


### PR DESCRIPTION
There are two things addressed within this PR: 

  1.  Fix batch `IsFull` check
    We should count the number of samples and exemplars and not the number of series.
    The count of series is usually less then the number of samples/exemplars.
    This makes it hard to reason and control how much rows we insert per one statement. 

2. Lower `FlushSize` and `MaxInsertStmtPerTxn` in order to reduce number of rows per transaction

    Previous settings meant that we can get 200K rows inside one transaction.
    Such a huge number of rows within a transaction decreases system ingest performance,
    leads to increased transaction time and can cause more lock contention. i
    New max rows per transaction limit is 5K (`FlushSize` * `MaxInsertStmtPerTxn`).