### PR TITLE
Fix batch IsFull check

### DIFF
--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -50,7 +50,8 @@ func NewPendingBuffer() *pendingBuffer {
 }
 
 func (p *pendingBuffer) IsFull() bool {
-	return p.batch.CountSeries() > metrics.FlushSize
+	samples, exemplars := p.batch.Count()
+	return samples+exemplars >= metrics.FlushSize
 }
 
 func (p *pendingBuffer) IsEmpty() bool {

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -14,10 +14,8 @@ import (
 // Keep these const values in pgmodel/metrics to avoid cyclic import since 'trace' may also need this.
 const (
 	MetricBatcherChannelCap = 1000
-	// FlushSize is the maximum number of insertDataRequests that should be buffered before the
-	// insertHandler flushes to the next layer. We don't want too many as this
-	// increases the number of lost writes if the connector dies. This number
-	// was chosen arbitrarily.
+	// FlushSize defines the batch size. It is the maximum number of samples/exemplars per insert batch.
+	// This translates to the max array size that we pass into `insert_metric_row`
 	FlushSize           = 2000
 	MaxInsertStmtPerTxn = 100
 )


### PR DESCRIPTION
We should count the number of samples and exemplars and not the number of series.
The count of series is usually less than the number of samples/exemplars.
This means that batch size can have samples than defined flush limit.
