### PR TITLE
Disable running Promscale in both HA and read-only mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use the following categories for changes:
 ### Changed
 - Enable tracing by default [#1213]
 - The Promscale extension is now required, while the Timescaledb extension remains optional. The minimum Timescaledb version supported is now 2.6.0 [#1132]
+- Disable running Promscale in HA and read-only simultaneously [#1254]
 
 ### Fixed
 - Register `promscale_ingest_channel_len_bucket` metric and make it a gauge [#1177]

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -208,6 +208,9 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 		if flagset["install-extensions"] && cfg.InstallExtensions {
 			return nil, fmt.Errorf("Cannot install or update TimescaleDB extension in read-only mode")
 		}
+		if flagset["metrics.high-availability"] && cfg.APICfg.HighAvailability {
+			return nil, fmt.Errorf("cannot run Promscale in both HA and read-only mode")
+		}
 		cfg.Migrate = false
 		cfg.StopAfterMigrate = false
 		cfg.UseVersionLease = false

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -108,7 +108,7 @@ func TestParseFlags(t *testing.T) {
 		{
 			name: "Running HA and read-only error",
 			args: []string{
-				"-leader-election-pg-advisory-lock-id", "1",
+				"-metrics.high-availability",
 				"-read-only",
 			},
 			shouldError: true,


### PR DESCRIPTION
## Description

This was not possible before with legacy HA, but was missed when
updating to non-legacy HA. It doesn't make sense to try to combine these
two operation modes.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
