### PR TITLE
goreleaser: Fix deprecated 'use_buildx'

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -126,7 +126,7 @@ dockers:
   ids: []
   skip_push: false
   dockerfile: ./build/Dockerfile
-  use_buildx: true
+  use: buildx
   build_flag_templates:
   - "--pull"
   - "--label=org.opencontainers.image.created={{.Date}}"
@@ -142,7 +142,7 @@ dockers:
   ids: []
   skip_push: false
   dockerfile: ./build/Dockerfile
-  use_buildx: true
+  use: buildx
   build_flag_templates:
   - "--pull"
   - "--label=org.opencontainers.image.created={{.Date}}"


### PR DESCRIPTION
## Description

As in title.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
