### PR TITLE
Fix overflowing pendingBuffers and make them respect flush limit. [WIP]

### DIFF
--- a/docker-compose/test.sh
+++ b/docker-compose/test.sh
@@ -10,7 +10,7 @@ echo "running tests"
 #build latest image
 docker build -t timescale/promscale:latest ../ --file ../build/Dockerfile
 
-docker-compose -p test_docker-compose up -d
+docker compose -p test_docker-compose up -d
 
 cleanup() {
     if (( $? != 0 )); then
@@ -41,7 +41,7 @@ done
 ## sleep for 30s so we can find ingestion logs in promscale
 sleep 30
 
-writeLog=$(docker logs test_docker-compose_promscale_1  2>&1| grep samples/sec | tail -n 1 || true)
+writeLog=$(docker logs test_docker-compose-promscale-1  2>&1| grep samples/sec | tail -n 1 || true)
    if [ -n "$writeLog" ]; then
     echo "promscale is ingesting data"
 else

--- a/pkg/pgmodel/model/batch.go
+++ b/pkg/pgmodel/model/batch.go
@@ -65,6 +65,28 @@ func (t *Batch) AppendSlice(s []Insertable) {
 	}
 }
 
+// ResizeTo resizes the batch to the specified size and returns the
+// array of the overflown data.
+func (t *Batch) ResizeTo(size int) []Insertable {
+	if len(t.data) <= size {
+		return nil
+	}
+
+	overflow := t.data[size:]
+
+	for _, d := range overflow {
+		switch d.Type() {
+		case Sample:
+			t.numSamples -= 1
+		case Exemplar:
+			t.numExemplars -= 1
+		}
+	}
+
+	t.data = t.data[:size]
+	return overflow
+}
+
 func (t *Batch) Visitor() *batchVisitor {
 	return getBatchVisitor(t)
 }


### PR DESCRIPTION
## Description

Previously, we have only checked if the pendingBuffer is full before sending to the
copier. In certain instances, if the incoming data is already bigger than the
flush size, we would be sending the oversized buffers which could cause
oversized ingest transactions. This change checks full pendingBuffers and
resizes them to the max while pushing the overflown data into a new pendingBuffer
which can be used later on to batch with other incoming data.
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
