### PR TITLE
deploy/helm-chart: add readinessProbe

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
+        with:
+          version: v3.6.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -61,8 +63,29 @@ jobs:
         uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Install TimescaleDB in the cluster
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm repo add timescale 'https://charts.timescale.com'
+          helm repo update
+          helm install \
+            --set image.tag="pg14.3-ts2.7.0-p0" \
+            --set replicaCount=1 \
+            timescaledb timescale/timescaledb-single
+          kubectl rollout status statefulset timescaledb
+
       - name: Run chart-testing (install)
-        run: ct install --config ct.yaml
+        run: |
+          PGPASSWORD_POSTGRES=$(kubectl \
+            get secret \
+            --namespace default \
+            timescaledb-credentials \
+            -o jsonpath="{.data.PATRONI_SUPERUSER_PASSWORD}" | \
+            base64 --decode \
+          )
+          ct install \
+            --config ct.yaml \
+            --helm-extra-set-args="--set=connection.uri=postgres://postgres:$PGPASSWORD_POSTGRES@timescaledb.default.svc.cluster.local:5432/postgres?sslmode=require"
 
   publish-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.2.1
         with:
+          # FIXME(onprem): Remove this once chart-testing-action has a new release with ct v3.6.0 by default.
           version: v3.6.0
 
       - name: Run chart-testing (list-changed)
@@ -68,6 +69,7 @@ jobs:
         run: |
           helm repo add timescale 'https://charts.timescale.com'
           helm repo update
+          # FIXME(onprem): Remove the image.tag override once new timescaledb-single helm chart is released.
           helm install \
             --set image.tag="pg14.3-ts2.7.0-p0" \
             --set replicaCount=1 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ We use the following categories for changes:
 
 ### Added
 - `-enable-feature=promql-per-step-stats` feature for statistics in PromQL evaluation
+- Add `readinessProbe` in helm chart [#1266]
 
 ## [0.11.0] - 2022-05-11
 

--- a/deploy/helm-chart/templates/deployment-promscale.yaml
+++ b/deploy/helm-chart/templates/deployment-promscale.yaml
@@ -65,6 +65,14 @@ spec:
               name: metrics-port
             - containerPort: 9202
               name: otel-port
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics-port
+              scheme: HTTP
+            failureThreshold: 3
+            timeoutSeconds: 15
+            periodSeconds: 15
           volumeMounts:
             - name: configs
               mountPath: /etc/promscale/

--- a/deploy/static/deploy.yaml
+++ b/deploy/static/deploy.yaml
@@ -119,6 +119,14 @@ spec:
               name: metrics-port
             - containerPort: 9202
               name: otel-port
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics-port
+              scheme: HTTP
+            failureThreshold: 3
+            timeoutSeconds: 15
+            periodSeconds: 15
           volumeMounts:
             - name: configs
               mountPath: /etc/promscale/


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

Adding readiness probe to use `/healthz` endpoint as a source of information for kubernetes traffic steering (by default kubernetes won't allow traffic flow to pod that is unhealthy).

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
