### PR TITLE
Fix `promscale_ingest_max_sent_timestamp` value for traces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We use the following categories for changes:
 - Register `promscale_ingest_channel_len_bucket` metric and make it a gauge [#1177]
 - Log warning when failing to write response to remote read requests [#1180]
 - Fix Promscale running even when some component may fail to start [#1217]
+- Fix `promscale_ingest_max_sent_timestamp_milliseconds` metric for tracing [#1270]
 
 ## [0.10.0] - 2022-02-17
 


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Fixes: #1239

After the fix, the metric now looks like

![image](https://user-images.githubusercontent.com/33792202/160805215-f9644877-921f-4a82-8ca1-7ace1e148933.png)


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
