### PR TITLE
Re-enabling PG12 tests.

### DIFF
--- a/.github/workflows/go-e2e.yml
+++ b/.github/workflows/go-e2e.yml
@@ -147,7 +147,7 @@ jobs:
 
     - name: Test ${{ matrix.test-setups.name }}
       env:
-        DOCKER_IMAGE:  ${{  needs.pick_docker_image.outputs.docker_image_13 }}
+        DOCKER_IMAGE:  ${{  needs.pick_docker_image.outputs.docker_image_12 }}
       run: go test -race -v -timeout=30m ./pkg/tests/upgrade_tests/ -timescale-docker-image=$DOCKER_IMAGE
 
   # Added to summarize the matrix

--- a/.github/workflows/go-e2e.yml
+++ b/.github/workflows/go-e2e.yml
@@ -77,8 +77,7 @@ jobs:
         - {name: "Singlenode (13)",          shortname: "singlenode-13",  tsdb: true,  multi: false, pg: 13}
         - {name: "Singlenode",               shortname: "singlenode-14",  tsdb: true,  multi: false, pg: 14}
         - {name: "Without TimescaleDB",      shortname: "no-timescaledb", tsdb: false, multi: false, pg: 14}
-        # TODO (mat) re-enable PG12 tests 
-        # - {name: "Singlenode (12)",          shortname: "singlenode-12",  tsdb: true,  multi: false, pg: 12}
+        - {name: "Singlenode (12)",          shortname: "singlenode-12",  tsdb: true,  multi: false, pg: 12}
         # TODO (james): Skipping multinode because tests are broken for now
         # - {name: "Multinode",                shortname: "multinode",      tsdb: true,  multi: true,  pg: 14}
     steps:

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -71,18 +71,18 @@ func TestMain(m *testing.M) {
 
 /* Prev image is the db image with the old promscale extension. We do NOT test timescaleDB extension upgrades here. */
 func getDBImages(extensionState testhelpers.TestOptions) (prev string, clean string, err error) {
-	// using pg13 until we deal with the lack of "trusted" support in pg12
-	//if !extensionState.UsesPG12() {
-	//	//using the oldest supported version of PG seems sufficient.
-	//	//we don't want to use any features in a newer PG version that isn't available in an older one
-	//	//but migration code that works in an older PG version should generally work in a newer one.
-	//	panic("Only use pg12 for upgrade tests")
-	//}
 	// TODO: Extracting the pg version from the docker image name is a nasty hack. How can we avoid this?
 	dockerImageName := extensionState.GetDockerImageName()
 	pgVersion, err := extensionState.TryGetDockerImagePgVersion()
 	if err != nil {
 		panic("unable to get docker image version")
+	}
+
+	if pgVersion != "12" {
+		//using the oldest supported version of PG seems sufficient.
+		//we don't want to use any features in a newer PG version that isn't available in an older one
+		//but migration code that works in an older PG version should generally work in a newer one.
+		panic("Only use pg12 for upgrade tests")
 	}
 
 	//return "timescaledev/promscale-extension:0.1.2-ts2-pg" + pgVersion, dockerImageName, nil


### PR DESCRIPTION
## Description

Addresses #1274 & #1257

## Merge requirements

The corresponding changes on the extension side need to be merged first https://github.com/timescale/promscale_extension/pull/171

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
