### PR TITLE
Add test case for `reset_metric_retention_period` with two-step agg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use the following categories for changes:
 - Log warning when failing to write response to remote read requests [#1180]
 - Fix Promscale running even when some component may fail to start [#1217]
 - Fix `promscale_ingest_max_sent_timestamp_milliseconds` metric for tracing [#1270]
+- Fix `prom_api.reset_metric_retention_period` on two-step continuous aggregates [#1294]
 
 ### Removed
 - Remove deprecated flags. More info can be found [here](docs/configuration.md#old-flag-removal-in-version-0.11.0) [#1229]


### PR DESCRIPTION
## Description

In [1] we fixed some typos in the `reset_metric_retention_period`
function which caused the function to break when used with two-step
continuous aggregates.

This change adds tests cases to exercise `reset_metric_retention_period`
with two-step aggregates.


[1]: https://github.com/timescale/promscale_extension/pull/180

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [] ~~Updated the relevant documentation~~
