### PR TITLE
.github: switch code ownership to subteams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,31 +1,23 @@
-* @timescale/o11y-eng
+* @timescale/o11y-applications
 
 # sql related stuff
-*.sql @jgpruitt
-
-/cmd/prom-migrator @Harkishen-Singh
+*.sql @timescale/o11y-data-platform
 
 # Go deps
-go.mod @antekresic
-go.sum @antekresic
+go.mod @antekresic @paulfantom
+go.sum @antekresic @paulfantom
+
+# CI system and repository configuration
+.github/ @cevian @paulfantom
 
 # Go packages
-/pkg @niksajakovljevic
 /pkg/api @antekresic @Harkishen-Singh
-/pkg/ewma @Harkishen-Singh
-/pkg/ha @antekresic
-/pkg/internal @antekresic
-/pkg/migrations/ @jgpruitt
-/pkg/migration-tool @Harkishen-Singh
-/pkg/pgmodel/ingestor @niksajakovljevic @antekresic @Harkishen-Singh
-/pkg/pgmodel/querier @JamesGuthrie
-/pkg/promql @Harkishen-Singh
-/pkg/runner @antekresic
-/pkg/telemetry @Harkishen-Singh
-/pkg/tenancy @Harkishen-Singh
-/pkg/tests/test_migrations/ @jgpruitt
-/pkg/tests/testdata/ @jgpruitt
-/pkg/tests/upgrade_tests/ @jgpruitt
+/pkg/migrations/ @timescale/o11y-data-platform
+/pkg/migration-tool @timescale/o11y-applications
+/pkg/pgmodel/querier @timescale/o11y-data-platform
+/pkg/tests/test_migrations/ @timescale/o11y-data-platform
+/pkg/tests/testdata/ @timescale/o11y-data-platform
+/pkg/tests/upgrade_tests/ @timescale/o11y-data-platform
 
 # helm and kubernetes related parts
-/deploy @cevian @VineethReddy02 @paulfantom @JamesGuthrie
+/deploy @cevian @paulfantom @JamesGuthrie


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

Changes:
- Default codeownership is assigned to @o11y-applications sub-team
- Code ownership of every package that had just a single code owner is transferred to that persons sub-team
- Since I was creating renovate and dependabot pipelines, I am stepping up as a code owner of `go.sum` and `go.mod` alongside Ante.
- CI system and repository configuration ownership is transferred to Mat and myself
- Vineeth is removed from being a code owner due to position change

Those changes should allow better automatic reviewer assignment by GitHub and are in line with recent slack discussion.

cc @peppercoffee 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
