### PR TITLE
Adjust to handle new default search path

### DIFF
--- a/pkg/pgmodel/querier/query_builder.go
+++ b/pkg/pgmodel/querier/query_builder.go
@@ -347,7 +347,7 @@ func buildPromQlFunctionCallAggregator(selectHints *storage.SelectHints, funcNam
 	// buildSingleMetricSamplesQuery
 
 	qf := aggregators{
-		valueClause: "prom_" + funcName + "($%d, $%d, $%d, $%d, time, value)",
+		valueClause: "_prom_ext.prom_" + funcName + "($%d, $%d, $%d, $%d, time, value)",
 		valueParams: []interface{}{model.Time(selectHints.Start).Time(), model.Time(selectHints.End).Time(), stepDuration.Milliseconds(), rangeDuration.Milliseconds()},
 		unOrdered:   false,
 		tsSeries:    newRegularTimestampSeries(model.Time(resultStart).Time(), model.Time(selectHints.End).Time(), stepDuration),
@@ -395,7 +395,7 @@ func buildVectorSelectorFunctionCallAggregator(lookback int64, selectHints *stor
 	resultStart := selectHints.Start + lookback
 	resultEnd := selectHints.End
 	qf := aggregators{
-		valueClause: "vector_selector($%d, $%d, $%d, $%d, time, value)",
+		valueClause: "_prom_ext.vector_selector($%d, $%d, $%d, $%d, time, value)",
 		valueParams: []interface{}{model.Time(resultStart).Time(), model.Time(resultEnd).Time(), selectHints.Step, lookback},
 		unOrdered:   true,
 		tsSeries:    newRegularTimestampSeries(model.Time(resultStart).Time(), model.Time(resultEnd).Time(), time.Duration(selectHints.Step)*time.Millisecond),

--- a/pkg/tests/end_to_end_tests/sql_bench_test.go
+++ b/pkg/tests/end_to_end_tests/sql_bench_test.go
@@ -316,7 +316,7 @@ func BenchmarkGetOrCreateMetricTableName(b *testing.B) {
 
 func keyValueArrayToLabelArray(db *pgxpool.Pool, metricName string, keys []string, values []string) error {
 	var labelArray []int
-	return db.QueryRow(context.Background(), "SELECT get_or_create_label_array($1, $2, $3)", metricName, keys, values).Scan(&labelArray)
+	return db.QueryRow(context.Background(), "SELECT _prom_catalog.get_or_create_label_array($1, $2, $3)", metricName, keys, values).Scan(&labelArray)
 }
 
 func createMetricTableName(db *pgxpool.Pool, name string) (metricID int64, tableName string, err error) {

--- a/pkg/tests/end_to_end_tests/telemetry_test.go
+++ b/pkg/tests/end_to_end_tests/telemetry_test.go
@@ -296,7 +296,7 @@ func TestTelemetrySQLStats(t *testing.T) {
 		require.Equal(t, "0", metrics) // Without promscale_extension, this will give error saying "no rows in result set".
 
 		// Add dummy metric.
-		_, err = conn.Exec(context.Background(), "SELECT create_metric_table('test_metric')")
+		_, err = conn.Exec(context.Background(), "SELECT _prom_catalog.create_metric_table('test_metric')")
 		require.NoError(t, err)
 
 		// Update the last_updated of counter_reset row so that it allows us to scan. Otherwise, the next scan allowed would be after 1 hour.


### PR DESCRIPTION
## Description

In [1] we set the default search path to only contain "public" schemas.
In particular, the two schemas "_prom_ext" and "_prom_catalog" are no
longer on the default search path.

This makes usages of those functions fully schema-qualified.

[1]: https://github.com/timescale/promscale_extension/pull/198

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
