### PR TITLE
deploy/helm-chart: add ability to set dataset config parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ We use the following categories for changes:
 - Add database SQL stats as Prometheus metrics. These can be queried under `promscale_sql` namespace [#1193]
 - Add alerts for database SQL metrics [#1193]
 - Query Jaeger traces directly through Promscale [#1224]
-- Additional dataset configuration options via `-startup.dataset.config` flag. Read more (here)[docs/dataset.md] [#1276]
+- Additional dataset configuration options via `-startup.dataset.config` flag. Read more (here)[docs/dataset.md] [#1276, #1310]
 
 ### Changed
 - Enable tracing by default [#1213], [#1290]

--- a/deploy/helm-chart/README.md
+++ b/deploy/helm-chart/README.md
@@ -126,6 +126,7 @@ helm install --name my-release -f myvalues.yaml .
 | `connection.port`                 | Port the db listens to                      | `5432`                             |
 | `connection.dbName`               | Database name in TimescaleDB to connect to  | `timescale`                        |
 | `connection.sslMode`              | SSL mode for connection                     | `require`                          |
+| `datasetConfig`                   | Dataset configuration options. Full list of options is available at [docs/dataset.md](https://github.com/timescale/promscale/blob/master/docs/dataset.md)                     | ``                          |
 | `prometheus.port`                 | Port the connector Service accepts prometheus remote_write connections on | `9201`              |
 | `prometheus.annotations`          | Annotations to allow prometheus metrics collection. | `{ "prometheus.io/scrape": 'true', "prometheus.io/port": '9201', "prometheus.io/path": '/metrics'}` |
 | `openTelemetry.port`              | Port the connector Service will accept otlp connections on | `9202`               |

--- a/deploy/helm-chart/templates/config.yaml
+++ b/deploy/helm-chart/templates/config.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "promscale.fullname" . }}
+  namespace: {{ template "promscale.namespace" . }}
+  labels:
+    app: {{ template "promscale.fullname" . }}
+    chart: {{ template "promscale.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: "promscale-connector"
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/part-of: "promscale-connector"
+    app.kubernetes.io/component: "connector"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,post-delete
+    "helm.sh/hook-weight": "0"
+data:
+  dataset.yaml: |
+    {{ toYaml .Values.datasetConfig | nindent 4 }}

--- a/deploy/helm-chart/templates/deployment-promscale.yaml
+++ b/deploy/helm-chart/templates/deployment-promscale.yaml
@@ -30,7 +30,8 @@ spec:
         app.kubernetes.io/part-of: "promscale-connector"
         app.kubernetes.io/component: "connector"
       annotations: 
-        checksum/config: {{ printf "%s" .Values.connection | sha256sum -}}
+        checksum/config: {{ printf "%s" .Values.connection | sha256sum }}
+        checksum/dataset: {{ printf "%s" .Values.datasetConfig | sha256sum }}
         {{- if .Values.prometheus.annotations }}
         {{- .Values.prometheus.annotations | toYaml | nindent 8 }}
         {{- end }}
@@ -40,6 +41,7 @@ spec:
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           name: promscale-connector
           args:
+          - "-startup.dataset.config=/etc/promscale/dataset.yaml"
           {{- with .Values.extraArgs }}
           {{ toYaml . | nindent 10 }}
           {{- end }}
@@ -63,6 +65,13 @@ spec:
               name: metrics-port
             - containerPort: 9202
               name: otel-port
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/promscale/
+      volumes:
+        - name: configs
+          configMap:
+            name: {{ include "promscale.fullname" . }}
       serviceAccountName: {{ template "promscale.fullname" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -49,6 +49,15 @@ connection:
   # must be created before start
   dbName: tsdb
 
+# dataset configuration options. Values presented in this section are defaults. For full list of settings
+# and their default values go to https://github.com/timescale/promscale/blob/master/docs/dataset.md
+datasetConfig:
+  metrics:
+    compress_data: true
+    default_retention_period: 90d
+  traces:
+    default_retention_period: 30d
+
 # Enable ServiceMonitor used by prometheus-operator to configure prometheus for metrics scraping
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

As in title. This allows setting dataset config values in helm chart values.yaml file.

This PR on purpose does not set all default values in a ConfigMap, but only a small subset. This is done to show that values can be set, but at the same time to reduce maintenance over the list of values.

Changing any value in `datasetConfig` will result in Promscale redeployment due to different checksum annotation.

Resolves https://github.com/timescale/o11y-team-applications/issues/185
Related to https://github.com/timescale/promscale/pull/1276

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
