### PR TITLE
Use getter/setters for default values

### DIFF
--- a/pkg/dataset/config.go
+++ b/pkg/dataset/config.go
@@ -20,18 +20,12 @@ const (
 )
 
 var (
-	setDefaultMetricChunkIntervalSQL = "SELECT prom_api.set_default_chunk_interval($1)"
-	setDefaultMetricCompressionSQL   = "SELECT prom_api.set_default_compression_setting($1)"
-	// TODO: Add proper SQL function for setting this.
-	setDefaultMetricHAReleaseRefreshSQL = `INSERT INTO _prom_catalog.default(key, value)
-		VALUES ('ha_lease_refresh', $1::text)
-		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`
-	// TODO: Add proper SQL function for setting this.
-	setDefaultMetricHAReleaseTimeoutSQL = `INSERT INTO _prom_catalog.default(key, value)
-		VALUES ('ha_lease_timeout', $1::text)
-		ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`
-	setDefaultMetricRetentionPeriodSQL = "SELECT prom_api.set_default_retention_period($1)"
-	setDefaultTraceRetentionPeriodSQL  = "SELECT ps_trace.set_trace_retention_period($1)"
+	setDefaultMetricChunkIntervalSQL    = "SELECT prom_api.set_default_chunk_interval($1)"
+	setDefaultMetricCompressionSQL      = "SELECT prom_api.set_default_compression_setting($1)"
+	setDefaultMetricHAReleaseRefreshSQL = `SELECT _prom_catalog.set_default_value('ha_lease_refresh', $1::text)`
+	setDefaultMetricHAReleaseTimeoutSQL = `SELECT _prom_catalog.set_default_value('ha_lease_timeout', $1::text)`
+	setDefaultMetricRetentionPeriodSQL  = "SELECT prom_api.set_default_retention_period($1)"
+	setDefaultTraceRetentionPeriodSQL   = "SELECT ps_trace.set_trace_retention_period($1)"
 
 	defaultMetricCompressionVar = defaultMetricCompression
 )

--- a/pkg/pgmodel/metrics/database/metrics.go
+++ b/pkg/pgmodel/metrics/database/metrics.go
@@ -2,9 +2,10 @@ package database
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/timescale/promscale/pkg/util"
-	"strings"
 )
 
 var (
@@ -89,7 +90,7 @@ var metrics = []metricQueryWrap{
 				Help:      "Compression status in TimescaleDB.",
 			},
 		),
-		query: `select (case when (value = 'true') then 1 else 0 end) from _prom_catalog.default where key = 'metric_compression'`,
+		query: `select (case when (value = 'true') then 1 else 0 end) from _prom_catalog.get_default_value('metric_compression') value`,
 	}, {
 		metric: prometheus.NewGauge(
 			prometheus.GaugeOpts{

--- a/pkg/tests/end_to_end_tests/config_dataset_test.go
+++ b/pkg/tests/end_to_end_tests/config_dataset_test.go
@@ -80,14 +80,14 @@ func getMetricsDefaultCompressionSetting(t testing.TB, conn *pgx.Conn) (compress
 	return compressionSetting
 }
 func getMetricsDefaultHALeaseRefresh(t testing.TB, conn *pgx.Conn) (haRefresh time.Duration) {
-	err := conn.QueryRow(context.Background(), "SELECT value::interval from _prom_catalog.default where key = 'ha_lease_refresh' LIMIT 1").Scan(&haRefresh)
+	err := conn.QueryRow(context.Background(), "SELECT _prom_catalog.get_default_value('ha_lease_refresh')::interval").Scan(&haRefresh)
 	if err != nil {
 		t.Fatal("error getting default metric HA lease refresh duration", err)
 	}
 	return haRefresh
 }
 func getMetricsDefaultHALeaseTimeout(t testing.TB, conn *pgx.Conn) (haTimeout time.Duration) {
-	err := conn.QueryRow(context.Background(), "SELECT value::interval from _prom_catalog.default where key = 'ha_lease_timeout' LIMIT 1").Scan(&haTimeout)
+	err := conn.QueryRow(context.Background(), "SELECT _prom_catalog.get_default_value('ha_lease_timeout')::interval").Scan(&haTimeout)
 	if err != nil {
 		t.Fatal("error getting default metric HA lease timeout duration", err)
 	}


### PR DESCRIPTION
## Description

We refactored _prom_catalog.default and wrapped it with a getter/setter. This updates the connector code that directly accessed the table to use the getter/setter instead.

This PR corresponds to [this extension PR.](https://github.com/timescale/promscale_extension/pull/185)

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
