### PR TITLE
Adds support for reading Prometheus config and links ruler with runner 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use the following categories for changes:
 - Add alerts for database SQL metrics [#1193]
 - Query Jaeger traces directly through Promscale [#1224]
 - Additional dataset configuration options via `-startup.dataset.config` flag. Read more [here](docs/dataset.md) [#1276, #1310]
+- Adds support for alerting and recording rules in Promscale [#1286, #1315]
 
 ### Changed
 - Enable tracing by default [#1213], [#1290]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,15 @@ The following subsections cover all CLI flags which promscale supports. You can 
 | metrics.promql.max-samples | integer64 | 50000000 | Maximum number of samples a single query can load into memory. Note that queries will fail if they try to load more samples than this into memory, so this also limits the number of samples a query can return. |
 | metrics.promql.query-timeout | duration | 2 minutes | Maximum time a query may take before being aborted. This option sets both the default and maximum value of the 'timeout' parameter in '/api/v1/query.*' endpoints. |
 
+### Recording and Alerting rules flags
+| Flag |   Type   | Default | Description |
+|------|:--------:|:------:|:------------|
+| metrics.rules.grace-period | duration | 10 minutes | Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. |
+| metrics.rules.notification-queue-capacity | integer  | 10000 | The capacity of the queue for pending Alertmanager notifications. |
+| metrics.rules.outage-tolerance | duration | 1 hour | Max time to tolerate Promscale outage for restoring "for" state of alert. |
+| metrics.rules.resend-delay | duration | 1 minute | Minimum amount of time to wait before resending an alert to Alertmanager. |
+| metrics.rules.prometheus-config | string | "" | Address of the Prometheus configuration. This is used to extract the alertmanager configuration and the addresses of rules files. Note: If this is empty or `rule_files` is empty, Promscale rule-manager will not start. If `alertmanager_config` is empty, alerting will not be initialized. |
+
 ### Startup process flags
 
 | Flag | Type | Default | Description |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,10 +112,10 @@ The following subsections cover all CLI flags which promscale supports. You can 
 ### Recording and Alerting rules flags
 | Flag |   Type   | Default | Description |
 |------|:--------:|:------:|:------------|
-| metrics.rules.grace-period | duration | 10 minutes | Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. |
-| metrics.rules.notification-queue-capacity | integer  | 10000 | The capacity of the queue for pending Alertmanager notifications. |
-| metrics.rules.outage-tolerance | duration | 1 hour | Max time to tolerate Promscale outage for restoring "for" state of alert. |
-| metrics.rules.resend-delay | duration | 1 minute | Minimum amount of time to wait before resending an alert to Alertmanager. |
+| metrics.alertmanager.notification-queue-capacity | integer  | 10000 | The capacity of the queue for pending Alertmanager notifications. |
+| metrics.rules.alert.for-grace-period | duration | 10 minutes | Minimum duration between alert and restored "for" state. This is maintained only for alerts with configured "for" time greater than grace period. |
+| metrics.rules.alert.for-outage-tolerance | duration | 1 hour | Max time to tolerate Promscale outage for restoring "for" state of alert. |
+| metrics.rules.alert.resend-delay | duration | 1 minute | Minimum amount of time to wait before resending an alert to Alertmanager. |
 | metrics.rules.prometheus-config | string | "" | Address of the Prometheus configuration. This is used to extract the alertmanager configuration and the addresses of rules files. Note: If this is empty or `rule_files` is empty, Promscale rule-manager will not start. If `alertmanager_config` is empty, alerting will not be initialized. |
 
 ### Startup process flags

--- a/pkg/rules/config.go
+++ b/pkg/rules/config.go
@@ -1,0 +1,79 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package rules
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	prometheus_config "github.com/prometheus/prometheus/config"
+
+	"github.com/timescale/promscale/pkg/log"
+)
+
+const (
+	DefaultQueueCapacity   = 10000
+	DefaultOutageTolerance = time.Hour
+	DefaultForGracePeriod  = time.Minute * 10
+	DefaultResendDelay     = time.Minute
+)
+
+type Config struct {
+	QueueCapacity           int
+	OutageTolerance         time.Duration
+	ForGracePeriod          time.Duration
+	ResendDelay             time.Duration
+	PrometheusConfigAddress string
+	Opts                    Options
+}
+
+type Options struct {
+	ContainsAlertingConfig bool
+	AlertingConfig         prometheus_config.AlertingConfig
+	UseRulesManager        bool
+	RulesFiles             []string
+}
+
+func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
+	fs.IntVar(&cfg.QueueCapacity, "metrics.rules.notification-queue-capacity", DefaultQueueCapacity, "The capacity of the queue for pending Alertmanager notifications.")
+	fs.DurationVar(&cfg.OutageTolerance, "metrics.rules.outage-tolerance", DefaultOutageTolerance, "Max time to tolerate Promscale outage for restoring \"for\" state of alert.")
+	fs.DurationVar(&cfg.ForGracePeriod, "metrics.rules.grace-period", DefaultForGracePeriod, "Minimum duration between alert and restored \"for\" state. This is maintained only for alerts with configured \"for\" time greater than grace period.")
+	fs.DurationVar(&cfg.ResendDelay, "metrics.rules.resend-delay", DefaultResendDelay, "Minimum amount of time to wait before resending an alert to Alertmanager.")
+	fs.StringVar(&cfg.PrometheusConfigAddress, "metrics.rules.prometheus-config", "", "Address of the Prometheus configuration. This is used to extract the"+
+		" alertmanager configuration and the addresses of rules files."+
+		"Note: If this is empty or `rule_files` is empty, Promscale rule-manager will not start. If `alertmanager_config` is empty, alerting will not be initialized.")
+	return cfg
+}
+
+// Validate validates the configuration file and runs validation against (if) provided
+// Prometheus configuration file.
+func Validate(cfg *Config) error {
+	if cfg.PrometheusConfigAddress == "" {
+		return nil
+	}
+	promCfg, err := prometheus_config.LoadFile(cfg.PrometheusConfigAddress, false, true, log.GetLogger())
+	if err != nil {
+		return fmt.Errorf("error loading Prometheus configuration file: %w", err)
+	}
+
+	if len(promCfg.RuleFiles) > 0 {
+		cfg.Opts.UseRulesManager = true
+		cfg.Opts.RulesFiles = promCfg.RuleFiles
+
+		// Only check alerting config if rules files are available. Otherwise, there is no use for
+		// checking alerting config.
+		if promCfg.AlertingConfig.AlertRelabelConfigs == nil && promCfg.AlertingConfig.AlertmanagerConfigs == nil {
+			// todo: test this and see if it works
+			log.Info("msg", "Alerting configuration not present in the given Prometheus configuration file. Alerting will not be initialized")
+		} else {
+			cfg.Opts.ContainsAlertingConfig = true
+			cfg.Opts.AlertingConfig = promCfg.AlertingConfig
+		}
+	} else {
+		log.Info("msg", "Rules files not found in the given Prometheus configuration file. Both rule-manager and alerting will not be initialized")
+	}
+	return nil
+}

--- a/pkg/rules/config.go
+++ b/pkg/rules/config.go
@@ -15,42 +15,49 @@ import (
 )
 
 const (
-	DefaultQueueCapacity   = 10000
-	DefaultOutageTolerance = time.Hour
-	DefaultForGracePeriod  = time.Minute * 10
-	DefaultResendDelay     = time.Minute
+	defaultNotificationQueueCapacity = 10000
+	defaultOutageTolerance           = time.Hour
+	defaultForGracePeriod            = time.Minute * 10
+	defaultResendDelay               = time.Minute
 )
 
 type Config struct {
-	QueueCapacity           int
-	OutageTolerance         time.Duration
-	ForGracePeriod          time.Duration
-	ResendDelay             time.Duration
-	PrometheusConfigAddress string
-	PrometheusConfig        *prometheus_config.Config
-	Opts                    Options
+	NotificationQueueCapacity int
+	OutageTolerance           time.Duration
+	ForGracePeriod            time.Duration
+	ResendDelay               time.Duration
+	PrometheusConfigAddress   string
+	PrometheusConfig          *prometheus_config.Config
 }
 
-type Options struct {
-	ContainsAlertingConfig bool
-	AlertingConfig         prometheus_config.AlertingConfig
-	UseRulesManager        bool
-	RulesFiles             []string
+func (cfg *Config) ContainsRules() bool {
+	if cfg.PrometheusConfig == nil {
+		return false
+	}
+	promCfg := cfg.PrometheusConfig
+	if len(promCfg.RuleFiles) == 0 {
+		log.Info("msg", "Rules files not found in the given Prometheus configuration file. Both rule-manager and alerting will not be initialized")
+		return false
+	}
+
+	if promCfg.AlertingConfig.AlertRelabelConfigs == nil && promCfg.AlertingConfig.AlertmanagerConfigs == nil {
+		// This is true when alerting config is not applied.
+		log.Info("msg", "Alerting configuration not present in the given Prometheus configuration file. Alerting will not be initialized")
+	}
+	return true
 }
 
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
-	fs.IntVar(&cfg.QueueCapacity, "metrics.rules.notification-queue-capacity", DefaultQueueCapacity, "The capacity of the queue for pending Alertmanager notifications.")
-	fs.DurationVar(&cfg.OutageTolerance, "metrics.rules.outage-tolerance", DefaultOutageTolerance, "Max time to tolerate Promscale outage for restoring \"for\" state of alert.")
-	fs.DurationVar(&cfg.ForGracePeriod, "metrics.rules.grace-period", DefaultForGracePeriod, "Minimum duration between alert and restored \"for\" state. This is maintained only for alerts with configured \"for\" time greater than grace period.")
-	fs.DurationVar(&cfg.ResendDelay, "metrics.rules.resend-delay", DefaultResendDelay, "Minimum amount of time to wait before resending an alert to Alertmanager.")
+	fs.IntVar(&cfg.NotificationQueueCapacity, "metrics.alertmanager.notification-queue-capacity", defaultNotificationQueueCapacity, "The capacity of the queue for pending Alertmanager notifications.")
+	fs.DurationVar(&cfg.OutageTolerance, "metrics.rules.alert.for-outage-tolerance", defaultOutageTolerance, "Max time to tolerate Promscale outage for restoring \"for\" state of alert.")
+	fs.DurationVar(&cfg.ForGracePeriod, "metrics.rules.alert.for-grace-period", defaultForGracePeriod, "Minimum duration between alert and restored \"for\" state. This is maintained only for alerts with configured \"for\" time greater than grace period.")
+	fs.DurationVar(&cfg.ResendDelay, "metrics.rules.alert.resend-delay", defaultResendDelay, "Minimum amount of time to wait before resending an alert to Alertmanager.")
 	fs.StringVar(&cfg.PrometheusConfigAddress, "metrics.rules.prometheus-config", "", "Address of the Prometheus configuration. This is used to extract the"+
 		" alertmanager configuration and the addresses of rules files."+
 		"Note: If this is empty or `rule_files` is empty, Promscale rule-manager will not start. If `alertmanager_config` is empty, alerting will not be initialized.")
 	return cfg
 }
 
-// Validate validates the configuration file and runs validation against (if) provided
-// Prometheus configuration file.
 func Validate(cfg *Config) error {
 	if cfg.PrometheusConfigAddress == "" {
 		return nil
@@ -60,22 +67,5 @@ func Validate(cfg *Config) error {
 		return fmt.Errorf("error loading Prometheus configuration file: %w", err)
 	}
 	cfg.PrometheusConfig = promCfg
-
-	if len(promCfg.RuleFiles) > 0 {
-		cfg.Opts.UseRulesManager = true
-		cfg.Opts.RulesFiles = promCfg.RuleFiles
-
-		// Only check alerting config if rules files are available. Otherwise, there is no use for
-		// checking alerting config.
-		if promCfg.AlertingConfig.AlertRelabelConfigs == nil && promCfg.AlertingConfig.AlertmanagerConfigs == nil {
-			// todo: test this and see if it works
-			log.Info("msg", "Alerting configuration not present in the given Prometheus configuration file. Alerting will not be initialized")
-		} else {
-			cfg.Opts.ContainsAlertingConfig = true
-			cfg.Opts.AlertingConfig = promCfg.AlertingConfig
-		}
-	} else {
-		log.Info("msg", "Rules files not found in the given Prometheus configuration file. Both rule-manager and alerting will not be initialized")
-	}
 	return nil
 }

--- a/pkg/rules/config.go
+++ b/pkg/rules/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ForGracePeriod          time.Duration
 	ResendDelay             time.Duration
 	PrometheusConfigAddress string
+	PrometheusConfig        *prometheus_config.Config
 	Opts                    Options
 }
 
@@ -58,6 +59,7 @@ func Validate(cfg *Config) error {
 	if err != nil {
 		return fmt.Errorf("error loading Prometheus configuration file: %w", err)
 	}
+	cfg.PrometheusConfig = promCfg
 
 	if len(promCfg.RuleFiles) > 0 {
 		cfg.Opts.UseRulesManager = true

--- a/pkg/rules/config_test.go
+++ b/pkg/rules/config_test.go
@@ -17,19 +17,25 @@ import (
 
 func TestValidate(t *testing.T) {
 	cases := []struct {
-		name            string
-		config          Config
-		expectedOptions Options
-		shouldError     bool
+		name           string
+		config         Config
+		expectedConfig Config
+		containsRules  bool
+		shouldError    bool
 	}{
 		{
-			name:   "no prometheus config",
-			config: Config{},
+			name:           "no prometheus config",
+			config:         Config{},
+			expectedConfig: Config{},
 		},
 		{
 			name: "healthy config with no rules",
 			config: Config{
 				PrometheusConfigAddress: "./testdata/no_rules.good.config.yaml",
+			},
+			expectedConfig: Config{
+				PrometheusConfigAddress: "./testdata/no_rules.good.config.yaml",
+				PrometheusConfig:        &prometheus_config.DefaultConfig,
 			},
 		},
 		{
@@ -37,58 +43,65 @@ func TestValidate(t *testing.T) {
 			config: Config{
 				PrometheusConfigAddress: "./testdata/rules.good.config.yaml",
 			},
-			expectedOptions: Options{
-				UseRulesManager: true,
-				RulesFiles:      []string{"testdata/rules.yaml"},
+			expectedConfig: Config{
+				PrometheusConfigAddress: "./testdata/rules.good.config.yaml",
+				PrometheusConfig:        prometheusConfigWithRules("testdata/rules.yaml"),
 			},
+			containsRules: true,
 		},
 		{
 			name: "bad config",
 			config: Config{
 				PrometheusConfigAddress: "./testdata/no_rules.bad.config.yaml",
 			},
+			expectedConfig: Config{
+				PrometheusConfigAddress: "testdata/no_rules.bad.config.yaml",
+			},
 			shouldError: true,
 		},
 		{
-			name: "bad config with non existent rules",
+			name: "config with non existent rules",
 			config: Config{
 				PrometheusConfigAddress: "./testdata/non_existent_rules.good.config.yaml",
 			},
-			expectedOptions: Options{
-				UseRulesManager: true,
-				RulesFiles:      []string{"testdata/non_existent_rules.yaml"},
+			expectedConfig: Config{
+				PrometheusConfigAddress: "./testdata/non_existent_rules.good.config.yaml", // This won't give an error since rules file addresses are validated when they are applied to rules-manager, not in Prometheus config loading.
+				PrometheusConfig:        prometheusConfigWithRules("testdata/non_existent_rules.yaml"),
 			},
-			// No error since rules file addresses are validated when they are applied to rules-manager, not in Prometheus config loading.
+			containsRules: true,
 		},
 		{
 			name: "good with alerting config",
 			config: Config{
 				PrometheusConfigAddress: "./testdata/alert_config.good.config.yaml",
 			},
-			expectedOptions: Options{
-				ContainsAlertingConfig: true,
-				AlertingConfig: prometheus_config.AlertingConfig{
-					AlertRelabelConfigs: nil,
-					AlertmanagerConfigs: prometheus_config.AlertmanagerConfigs{
-						{
-							ServiceDiscoveryConfigs: discovery.Configs{
-								discovery.StaticConfig{
-									{
-										Targets: []model.LabelSet{},
-										Source:  "0",
+			expectedConfig: Config{
+				PrometheusConfigAddress: "./testdata/alert_config.good.config.yaml",
+				PrometheusConfig: &prometheus_config.Config{
+					GlobalConfig: prometheus_config.DefaultGlobalConfig,
+					AlertingConfig: prometheus_config.AlertingConfig{
+						AlertRelabelConfigs: nil,
+						AlertmanagerConfigs: prometheus_config.AlertmanagerConfigs{
+							{
+								ServiceDiscoveryConfigs: discovery.Configs{
+									discovery.StaticConfig{
+										{
+											Targets: []model.LabelSet{},
+											Source:  "0",
+										},
 									},
 								},
+								HTTPClientConfig: prometheus_common_config.HTTPClientConfig{FollowRedirects: true},
+								Scheme:           "https",
+								APIVersion:       "v2",
+								Timeout:          model.Duration(10000000000),
 							},
-							HTTPClientConfig: prometheus_common_config.HTTPClientConfig{FollowRedirects: true},
-							Scheme:           "https",
-							APIVersion:       "v2",
-							Timeout:          model.Duration(10000000000),
 						},
 					},
+					RuleFiles: []string{"testdata/rules.yaml"},
 				},
-				UseRulesManager: true,
-				RulesFiles:      []string{"testdata/rules.yaml"},
 			},
+			containsRules: true,
 		},
 	}
 	for _, c := range cases {
@@ -98,6 +111,20 @@ func TestValidate(t *testing.T) {
 		} else {
 			require.Nil(t, err, c.name)
 		}
-		require.Equal(t, c.expectedOptions, c.config.Opts, c.name)
+
+		require.Equal(t, c.containsRules, c.config.ContainsRules(), c.name)
+
+		if c.config.PrometheusConfig != nil {
+			if c.expectedConfig.PrometheusConfig.RuleFiles == nil {
+				c.expectedConfig.PrometheusConfig.RuleFiles = []string{}
+			}
+			require.Equal(t, c.expectedConfig, c.config, c.name)
+		}
 	}
+}
+
+func prometheusConfigWithRules(files ...string) *prometheus_config.Config {
+	c := prometheus_config.DefaultConfig
+	c.RuleFiles = files
+	return &c
 }

--- a/pkg/rules/config_test.go
+++ b/pkg/rules/config_test.go
@@ -1,0 +1,103 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package rules
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	prometheus_common_config "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	prometheus_config "github.com/prometheus/prometheus/config"
+	"github.com/prometheus/prometheus/discovery"
+)
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name            string
+		config          Config
+		expectedOptions Options
+		shouldError     bool
+	}{
+		{
+			name:   "no prometheus config",
+			config: Config{},
+		},
+		{
+			name: "healthy config with no rules",
+			config: Config{
+				PrometheusConfigAddress: "./testdata/no_rules.good.config.yaml",
+			},
+		},
+		{
+			name: "healthy config with rules",
+			config: Config{
+				PrometheusConfigAddress: "./testdata/rules.good.config.yaml",
+			},
+			expectedOptions: Options{
+				UseRulesManager: true,
+				RulesFiles:      []string{"testdata/rules.yaml"},
+			},
+		},
+		{
+			name: "bad config",
+			config: Config{
+				PrometheusConfigAddress: "./testdata/no_rules.bad.config.yaml",
+			},
+			shouldError: true,
+		},
+		{
+			name: "bad config with non existent rules",
+			config: Config{
+				PrometheusConfigAddress: "./testdata/non_existent_rules.good.config.yaml",
+			},
+			expectedOptions: Options{
+				UseRulesManager: true,
+				RulesFiles:      []string{"testdata/non_existent_rules.yaml"},
+			},
+			// No error since rules file addresses are validated when they are applied to rules-manager, not in Prometheus config loading.
+		},
+		{
+			name: "good with alerting config",
+			config: Config{
+				PrometheusConfigAddress: "./testdata/alert_config.good.config.yaml",
+			},
+			expectedOptions: Options{
+				ContainsAlertingConfig: true,
+				AlertingConfig: prometheus_config.AlertingConfig{
+					AlertRelabelConfigs: nil,
+					AlertmanagerConfigs: prometheus_config.AlertmanagerConfigs{
+						{
+							ServiceDiscoveryConfigs: discovery.Configs{
+								discovery.StaticConfig{
+									{
+										Targets: []model.LabelSet{},
+										Source:  "0",
+									},
+								},
+							},
+							HTTPClientConfig: prometheus_common_config.HTTPClientConfig{FollowRedirects: true},
+							Scheme:           "https",
+							APIVersion:       "v2",
+							Timeout:          model.Duration(10000000000),
+						},
+					},
+				},
+				UseRulesManager: true,
+				RulesFiles:      []string{"testdata/rules.yaml"},
+			},
+		},
+	}
+	for _, c := range cases {
+		err := Validate(&c.config)
+		if c.shouldError {
+			require.NotNil(t, err, c.name)
+		} else {
+			require.Nil(t, err, c.name)
+		}
+		require.Equal(t, c.expectedOptions, c.config.Opts, c.name)
+	}
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -32,7 +32,7 @@ func NewManager(ctx context.Context, r prometheus.Registerer, client *pgclient.C
 	discoveryManagerNotify := discovery.NewManager(ctx, log.GetLogger(), discovery.Name("notify"))
 
 	notifierManager := notifier.NewManager(&notifier.Options{
-		QueueCapacity: cfg.QueueCapacity,
+		QueueCapacity: cfg.NotificationQueueCapacity,
 		Registerer:    r,
 		Do:            do,
 	}, log.GetLogger())

--- a/pkg/rules/testdata/alert_config.good.config.yaml
+++ b/pkg/rules/testdata/alert_config.good.config.yaml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 20s
+  evaluation_interval: 30s
+
+alerting:
+  alertmanagers:
+  - scheme: https
+    static_configs:
+    - targets: []
+
+rule_files:
+  - rules.yaml

--- a/pkg/rules/testdata/alert_config.good.config.yaml
+++ b/pkg/rules/testdata/alert_config.good.config.yaml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 20s
-  evaluation_interval: 30s
+  scrape_interval: 1m
+  evaluation_interval: 1m
 
 alerting:
   alertmanagers:

--- a/pkg/rules/testdata/no_rules.bad.config.yaml
+++ b/pkg/rules/testdata/no_rules.bad.config.yaml
@@ -1,0 +1,5 @@
+global:
+  scrape_interval: 20s
+  evaluation_interval: 30s
+
+rules_files: []

--- a/pkg/rules/testdata/no_rules.good.config.yaml
+++ b/pkg/rules/testdata/no_rules.good.config.yaml
@@ -1,0 +1,5 @@
+global:
+  scrape_interval: 20s
+  evaluation_interval: 30s
+
+rule_files: []

--- a/pkg/rules/testdata/no_rules.good.config.yaml
+++ b/pkg/rules/testdata/no_rules.good.config.yaml
@@ -1,5 +1,5 @@
 global:
-  scrape_interval: 20s
-  evaluation_interval: 30s
+  scrape_interval: 1m
+  evaluation_interval: 1m
 
 rule_files: []

--- a/pkg/rules/testdata/non_existent_rules.good.config.yaml
+++ b/pkg/rules/testdata/non_existent_rules.good.config.yaml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 20s
-  evaluation_interval: 30s
+  scrape_interval: 1m
+  evaluation_interval: 1m
 
 rule_files:
 - non_existent_rules.yaml

--- a/pkg/rules/testdata/non_existent_rules.good.config.yaml
+++ b/pkg/rules/testdata/non_existent_rules.good.config.yaml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 20s
+  evaluation_interval: 30s
+
+rule_files:
+- non_existent_rules.yaml

--- a/pkg/rules/testdata/rules.good.config.yaml
+++ b/pkg/rules/testdata/rules.good.config.yaml
@@ -1,6 +1,6 @@
 global:
-  scrape_interval: 20s
-  evaluation_interval: 30s
+  scrape_interval: 1m
+  evaluation_interval: 1m
 
 rule_files:
 - rules.yaml

--- a/pkg/rules/testdata/rules.good.config.yaml
+++ b/pkg/rules/testdata/rules.good.config.yaml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 20s
+  evaluation_interval: 30s
+
+rule_files:
+- rules.yaml

--- a/pkg/rules/testdata/rules.yaml
+++ b/pkg/rules/testdata/rules.yaml
@@ -1,0 +1,7 @@
+groups:
+- name: promscale-general
+  rules:
+  - record: Rule
+    expr: up
+    labels:
+      component: rule

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -18,6 +18,7 @@ import (
 	"github.com/timescale/promscale/pkg/log"
 	"github.com/timescale/promscale/pkg/pgclient"
 	"github.com/timescale/promscale/pkg/query"
+	"github.com/timescale/promscale/pkg/rules"
 	"github.com/timescale/promscale/pkg/tenancy"
 	"github.com/timescale/promscale/pkg/tracer"
 	"github.com/timescale/promscale/pkg/util"
@@ -34,6 +35,7 @@ type Config struct {
 	LimitsCfg                   limits.Config
 	TenancyCfg                  tenancy.Config
 	PromQLCfg                   query.Config
+	RulesCfg                    rules.Config
 	ConfigFile                  string
 	DatasetConfig               string
 	TLSCertFile                 string
@@ -126,6 +128,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	limits.ParseFlags(fs, &cfg.LimitsCfg)
 	tenancy.ParseFlags(fs, &cfg.TenancyCfg)
 	query.ParseFlags(fs, &cfg.PromQLCfg)
+	rules.ParseFlags(fs, &cfg.RulesCfg)
 
 	fs.StringVar(&cfg.ConfigFile, "config", "config.yml", "YAML configuration file path for Promscale.")
 	fs.StringVar(&cfg.ListenAddr, "web.listen-address", ":9201", "Address to listen on for web endpoints.")
@@ -232,6 +235,9 @@ func validate(cfg *Config) error {
 	}
 	if err := tenancy.Validate(&cfg.TenancyCfg); err != nil {
 		return fmt.Errorf("error validating multi-tenancy configuration: %w", err)
+	}
+	if err := rules.Validate(&cfg.RulesCfg); err != nil {
+		return fmt.Errorf("error validating rules configuration: %w", err)
 	}
 	return nil
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -220,7 +220,7 @@ func Run(cfg *Config) error {
 		},
 	)
 
-	if cfg.RulesCfg.Opts.UseRulesManager {
+	if cfg.RulesCfg.ContainsRules() {
 		rulesCtx, stopRuler := context.WithCancel(context.Background())
 		defer stopRuler()
 		manager, err := rules.NewManager(rulesCtx, prometheus.DefaultRegisterer, client, &cfg.RulesCfg)


### PR DESCRIPTION
## Description

Fixes: https://github.com/timescale/o11y-team-applications/issues/180

This PR adds support for reading the Prometheus configuration file, validates it, and logs as per content in the file. Based on the details in configuration, it starts the rules-manager. This PR also contains tests for reading and validating Prometheus configuration.

Next PRs will be:
1. Implement the `/api/v1/rules` API
2. E2E tests for Rules-manager

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
