### PR TITLE
deploy/helm-chart: conditionally set password and user in connection secret

### DIFF
--- a/deploy/helm-chart/templates/secret-connection.yaml
+++ b/deploy/helm-chart/templates/secret-connection.yaml
@@ -17,11 +17,29 @@ stringData:
   {{- if ne (.Values.connection.uri | toString) "" }}
   PROMSCALE_DB_URI: {{ tpl .Values.connection.uri . | toString | quote }}
   {{- else }}
-  PROMSCALE_DB_PORT: {{ .Values.connection.port | toString | quote }}
-  PROMSCALE_DB_USER: {{ .Values.connection.user | toString | quote }}
+  {{- /* password and user can be set conditionally to allow potential password injection from other sources */}}
+  {{- if ne (.Values.connection.password | toString) "" }}
   PROMSCALE_DB_PASSWORD: {{ .Values.connection.password | toString | quote }}
+  {{- end }}
+  {{- if ne (.Values.connection.user | toString) "" }}
+  PROMSCALE_DB_USER: {{ .Values.connection.user | toString | quote }}
+  {{- end }}
+  PROMSCALE_DB_PORT: {{ .Values.connection.port | toString | quote }}
   PROMSCALE_DB_HOST: {{ tpl .Values.connection.host . | toString | quote }}
   PROMSCALE_DB_NAME: {{ .Values.connection.dbName | toString | quote }}
   PROMSCALE_DB_SSL_MODE: {{ .Values.connection.sslMode | toString | quote }}
   {{- end }}
+{{- /*
+  During upgrades we want to preserve password and user set from other sources.
+  This is done in `data` field as Secrets are base64 encoded and it is easier to not decode them and place in `stringData` field. 
+*/}}
+{{- if .Release.IsUpgrade }}
+data:
+  {{- if eq (.Values.connection.password | toString) "" }}
+  PROMSCALE_DB_PASSWORD: {{ index (lookup "v1" "Secret" .Release.Namespace (include "promscale.fullname" .) ).data "PROMSCALE_DB_PASSWORD" }}
+  {{- end }}
+  {{- if eq (.Values.connection.user | toString) "" }}
+  PROMSCALE_DB_USER: {{ index (lookup "v1" "Secret" .Release.Namespace (include "promscale.fullname" .) ).data "PROMSCALE_DB_USER" }}
+  {{- end }}
+{{- end }}
 {{ end }}

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -40,7 +40,7 @@ connection:
   # sslMode properties are used.
   uri: ""
   # user used to connect to TimescaleDB
-  user: postgres
+  user: ""
   password: ""
   host: "timescaledb.{{ .Release.Namespace }}.svc.cluster.local"
   port: 5432

--- a/deploy/static/deploy.yaml
+++ b/deploy/static/deploy.yaml
@@ -33,8 +33,6 @@ metadata:
     app.kubernetes.io/component: "connector"
 stringData:
   PROMSCALE_DB_PORT: "5432"
-  PROMSCALE_DB_USER: "postgres"
-  PROMSCALE_DB_PASSWORD: ""
   PROMSCALE_DB_HOST: "timescaledb.default.svc.cluster.local"
   PROMSCALE_DB_NAME: "tsdb"
   PROMSCALE_DB_SSL_MODE: "require"
@@ -101,7 +99,7 @@ spec:
         app.kubernetes.io/part-of: "promscale-connector"
         app.kubernetes.io/component: "connector"
       annotations: 
-        checksum/config: af0eae966aacabe43c12f83955e5a5cbf0c4853b5678c536b9f84d83b9d658b7
+        checksum/config: ff05ff54cbc0eadd9ce97781ed753f30c19ece1aa39b35d2eb5a70ad656daf69
         checksum/dataset: 917edb0f9f4467795390e9087696a76af67a9df6de793a132c5406c1e8f54ddd
         prometheus.io/path: /metrics
         prometheus.io/port: "9201"


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

Since tobs modify this secret to inject password, we need a way to not override those changes during tobs upgrades. 

This PR doesn't change anything for regular users, but allows setting user and password from external sources by manipulating the connection secret with other tools.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
