### PR TITLE
Handle pre-release tags in CICD

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -69,10 +69,17 @@ jobs:
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.IO_PACKAGECLOUD_TOKEN }}
         run: |
+          version="$(echo "${GITHUB_REF}" | sed -e 's|refs/tags/||')";
+          # a dash indicates a pre-release version in semver
+          if [[ "$version" =~ '-' ]]; then \
+            repo='timescale/timescaledb-exp'; \
+          else \
+            repo='timescale/timescaledb'; \
+          fi;
           ls dist/*.deb
-          package_cloud push timescale/timescaledb/debian/stretch dist/*.deb
-          package_cloud push timescale/timescaledb/debian/buster dist/*.deb
-          package_cloud push timescale/timescaledb/debian/bullseye dist/*.deb
+          package_cloud push ${repo}/debian/stretch dist/*.deb
+          package_cloud push ${repo}/debian/buster dist/*.deb
+          package_cloud push ${repo}/debian/bullseye dist/*.deb
           ls dist/*.rpm
-          package_cloud push timescale/timescaledb/el/7 dist/*.rpm
-          package_cloud push timescale/timescaledb/el/8 dist/*.rpm
+          package_cloud push ${repo}/el/7 dist/*.rpm
+          package_cloud push ${repo}/el/8 dist/*.rpm


### PR DESCRIPTION
This PR changes things so that pre-release tag packages are
sent to the timescaledb-exp package cloud repo and not
the standard ones.

Docker images are already correctly handled by the use of
skip_publish = auto for the latest and major.minor tags
in .goreleaser.yml

The github release is already created in draft.

## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
