### PR TITLE
Filter on jsonb hash so planner can use index

### DIFF
--- a/pkg/jaeger/query/get_operations.go
+++ b/pkg/jaeger/query/get_operations.go
@@ -26,7 +26,7 @@ WHERE
 		FROM _ps_trace.tag
 		WHERE key = 'service.name'
 		AND key_id = 1
-		AND value = to_jsonb($1::text)
+		AND _prom_ext.jsonb_digest(value) = _prom_ext.jsonb_digest(to_jsonb($1::text))
 	)
 	AND %s
 `

--- a/pkg/jaeger/query/trace_query.go
+++ b/pkg/jaeger/query/trace_query.go
@@ -156,7 +156,7 @@ func buildTraceIDSubquery(q *spanstore.TraceQueryParameters) (string, []interfac
 			FROM _ps_trace.tag
 			WHERE key = 'service.name'
 			AND key_id = 1
-			AND value = to_jsonb($%d::text)
+			AND _prom_ext.jsonb_digest(value) = _prom_ext.jsonb_digest(to_jsonb($%d::text))
 		)`, len(params))
 		operation_clauses = append(operation_clauses, qual)
 	}


### PR DESCRIPTION
Recent changes in the Promscale extension introduced index on jsonb hash.
