### PR TITLE
Log mandatory requirement of Promscale extension when upgrading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use the following categories for changes:
 - Additional dataset configuration options via `-startup.dataset.config` flag. Read more [here](docs/dataset.md) [#1276, #1310]
 - Support for alerting and recording rules in Promscale [#1286, #1315]
 - Support for `/api/v1/rules` & `/api/v1/alerts` API [#1320]
+- Log mandatory requirement of Promscale extension when upgrading from older versions [#1329]
 
 ### Changed
 - Enable tracing by default [#1213], [#1290]


### PR DESCRIPTION

## Description

As of version 0.11.0, Promscale extension is required for all operation.
This commit adds logging when upgrading from older versions that the latest
version of extension is missing and necessary to proceed.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
