### PR TITLE
readme: update link to prom-migrator readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This repository also contains the source code for **prom-migrator**. **Prom-migr
 an **open-source**, **community-driven** and **free-to-use**, **universal prometheus
 data migration tool**, that migrates data from one storage system to another, leveraging Prometheus's
 remote storage endpoints. For more information about prom-migrator, visit
-[prom-migrator's README](https://github.com/timescale/promscale/blob/master/cmd/prom-migrator/README.md).
+[prom-migrator's README](https://github.com/timescale/promscale/blob/master/migration-tool/cmd/prom-migrator/README.md).
 
 # Documentation
 


### PR DESCRIPTION
## Description

The prom-migrator tool moved from `cmd/prom-migrator` to `migration-tool/cmd/prom-migrator`. This is a one-line change to update the link in the top-level readme to point at  the new location.

Other places the link should be updated:
- timescale/docs/pull/1061
- blog post: [Introducing Prom-migrator](https://www.timescale.com/blog/introducing-prom-migrator-a-universal-open-source-prometheus-data-migration-tool/)


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] ~CHANGELOG entry for user-facing changes~ n/a
- [x] Updated the relevant documentation
