### PR TITLE
Reuse temp table for trace ingest

### DIFF
--- a/pkg/pgmodel/ingestor/trace/writer.go
+++ b/pkg/pgmodel/ingestor/trace/writer.go
@@ -390,7 +390,7 @@ func (t *traceWriterImpl) insertRows(ctx context.Context, table string, columns 
 		}
 	}()
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE temp ON COMMIT DROP AS TABLE _ps_trace.%s WITH NO DATA", table)); err != nil {
+	if _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE IF NOT EXISTS trace_writer_temp ON COMMIT DELETE ROWS AS TABLE _ps_trace.%s WITH NO DATA", table)); err != nil {
 		return err
 	}
 
@@ -398,7 +398,7 @@ func (t *traceWriterImpl) insertRows(ctx context.Context, table string, columns 
 		return err
 	}
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("INSERT INTO _ps_trace.%s(%[2]s) SELECT %[2]s FROM temp ON CONFLICT DO NOTHING", table, strings.Join(columns, ","))); err != nil {
+	if _, err = tx.Exec(ctx, fmt.Sprintf("INSERT INTO _ps_trace.%s(%[2]s) SELECT %[2]s FROM trace_writer_temp ON CONFLICT DO NOTHING", table, strings.Join(columns, ","))); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/pkg/pgmodel/ingestor/trace/writer.go
+++ b/pkg/pgmodel/ingestor/trace/writer.go
@@ -390,15 +390,15 @@ func (t *traceWriterImpl) insertRows(ctx context.Context, table string, columns 
 		}
 	}()
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE IF NOT EXISTS trace_writer_temp ON COMMIT DELETE ROWS AS TABLE _ps_trace.%s WITH NO DATA", table)); err != nil {
+	if _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE IF NOT EXISTS _trace_writer_temp ON COMMIT DELETE ROWS AS TABLE _ps_trace.%s WITH NO DATA", table)); err != nil {
 		return err
 	}
 
-	if _, err = tx.CopyFrom(ctx, pgx.Identifier{"temp"}, columns, pgx.CopyFromRows(data)); err != nil {
+	if _, err = tx.CopyFrom(ctx, pgx.Identifier{"_trace_writer_temp"}, columns, pgx.CopyFromRows(data)); err != nil {
 		return err
 	}
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("INSERT INTO _ps_trace.%s(%[2]s) SELECT %[2]s FROM trace_writer_temp ON CONFLICT DO NOTHING", table, strings.Join(columns, ","))); err != nil {
+	if _, err = tx.Exec(ctx, fmt.Sprintf("INSERT INTO _ps_trace.%s(%[2]s) SELECT %[2]s FROM _trace_writer_temp ON CONFLICT DO NOTHING", table, strings.Join(columns, ","))); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)

--- a/pkg/pgmodel/ingestor/trace/writer.go
+++ b/pkg/pgmodel/ingestor/trace/writer.go
@@ -390,15 +390,18 @@ func (t *traceWriterImpl) insertRows(ctx context.Context, table string, columns 
 		}
 	}()
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE IF NOT EXISTS _trace_writer_temp ON COMMIT DELETE ROWS AS TABLE _ps_trace.%s WITH NO DATA", table)); err != nil {
+	tempTableName := pgx.Identifier{"_trace_temp_" + table}
+	tempTableNameString := tempTableName.Sanitize()
+
+	if _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TEMPORARY TABLE IF NOT EXISTS %s ON COMMIT DELETE ROWS AS TABLE _ps_trace.%s WITH NO DATA", tempTableNameString, table)); err != nil {
 		return err
 	}
 
-	if _, err = tx.CopyFrom(ctx, pgx.Identifier{"_trace_writer_temp"}, columns, pgx.CopyFromRows(data)); err != nil {
+	if _, err = tx.CopyFrom(ctx, tempTableName, columns, pgx.CopyFromRows(data)); err != nil {
 		return err
 	}
 
-	if _, err = tx.Exec(ctx, fmt.Sprintf("INSERT INTO _ps_trace.%s(%[2]s) SELECT %[2]s FROM _trace_writer_temp ON CONFLICT DO NOTHING", table, strings.Join(columns, ","))); err != nil {
+	if _, err = tx.Exec(ctx, fmt.Sprintf("INSERT INTO _ps_trace.%[1]s(%[2]s) SELECT %[2]s FROM %[3]s ON CONFLICT DO NOTHING", table, strings.Join(columns, ","), tempTableNameString)); err != nil {
 		return err
 	}
 	return tx.Commit(ctx)


### PR DESCRIPTION
## Description

Reusing the temp table will reduce catalog bloat and logging. No need to recreate it continuously.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
