### PR TITLE
.github: add @onprem as code owner for deployment methods and monitoring mixin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@ go.sum @antekresic @paulfantom
 /pkg/tests/testdata/ @timescale/o11y-data-platform
 /pkg/tests/upgrade_tests/ @timescale/o11y-data-platform
 
-/docs/mixin @paulfantom 
+/docs/mixin @paulfantom @onprem
 
 # helm and kubernetes related parts
-/deploy @cevian @paulfantom @JamesGuthrie
+/deploy @cevian @paulfantom @onprem @JamesGuthrie


### PR DESCRIPTION
## Description

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue._

As in the title. Adding Prem as an explicit owner of deployment models and monitoring mixin.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
