### PR TITLE
Publish packages for ubuntu distros

### DIFF
--- a/.github/workflows/go-releaser.yml
+++ b/.github/workflows/go-releaser.yml
@@ -68,6 +68,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.IO_PACKAGECLOUD_TOKEN }}
+          DEBIAN_DISTROS: debian/stretch debian/buster debian/bullseye ubuntu/bionic ubuntu/focal ubuntu/hirsute ubuntu/impish ubuntu/jammy
+          RHEL_DISTROS: el/7 el/8
         run: |
           version="$(echo "${GITHUB_REF}" | sed -e 's|refs/tags/||')";
           # a dash indicates a pre-release version in semver
@@ -77,9 +79,10 @@ jobs:
             repo='timescale/timescaledb'; \
           fi;
           ls dist/*.deb
-          package_cloud push ${repo}/debian/stretch dist/*.deb
-          package_cloud push ${repo}/debian/buster dist/*.deb
-          package_cloud push ${repo}/debian/bullseye dist/*.deb
+          for distro in ${DEBIAN_DISTROS}; do
+            package_cloud push "${repo}/${distro}" dist/*.deb
+          done
           ls dist/*.rpm
-          package_cloud push ${repo}/el/7 dist/*.rpm
-          package_cloud push ${repo}/el/8 dist/*.rpm
+          for distro in ${RHEL_DISTROS}; do
+            package_cloud push "${repo}/${distro}" dist/*.rpm
+          done


### PR DESCRIPTION
## Description

We were previously only publishing packages for Debian. We now cover the
same Ubuntu versions as TimescaleDB and the Promscale Extension.

Closes #1341

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
