### PR TITLE
Fix two-step aggregate tests

### DIFF
--- a/pkg/tests/end_to_end_tests/continuous_agg_test.go
+++ b/pkg/tests/end_to_end_tests/continuous_agg_test.go
@@ -435,7 +435,7 @@ func TestContinuousAgg2StepAgg(t *testing.T) {
 		dbSuper, err := pgxpool.Connect(context.Background(), testhelpers.PgConnectURL(*testDatabase, testhelpers.Superuser))
 		require.NoError(t, err)
 		defer dbSuper.Close()
-		_, err = dbSuper.Exec(context.Background(), "CREATE EXTENSION timescaledb_toolkit")
+		_, err = dbSuper.Exec(context.Background(), "CREATE EXTENSION IF NOT EXISTS timescaledb_toolkit")
 		require.NoError(t, err)
 
 		// Ingest test dataset.


### PR DESCRIPTION
## Description

With the timescaledb_toolkit extension being pre-installed in the
timescaledb-ha docker image, extension creation can fail. So now we
create the extension with `IF NOT EXISTS`.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
