### PR TITLE
docker-compose: switch to using newer HA deployment model

### DIFF
--- a/docker-compose/high-availability/prometheus1.yml
+++ b/docker-compose/high-availability/prometheus1.yml
@@ -9,7 +9,7 @@ global:
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
       cluster: 'monitoring-cluster'
-      __replica__: 'promscale_deploy_ha-promscale-connector1-1'
+      __replica__: 'prometheus1'
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
@@ -18,8 +18,10 @@ rule_files:
 
 remote_write:
     - url: "http://promscale-connector1:9201/write"
+    - url: "http://promscale-connector2:9201/write"
 remote_read:
     - url: "http://promscale-connector1:9201/read"
+    - url: "http://promscale-connector2:9201/read"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.

--- a/docker-compose/high-availability/prometheus2.yml
+++ b/docker-compose/high-availability/prometheus2.yml
@@ -9,7 +9,7 @@ global:
   # external systems (federation, remote storage, Alertmanager).
   external_labels:
       cluster: 'monitoring-cluster'
-      __replica__: 'promscale_deploy_ha-promscale-connector2-1'
+      __replica__: 'prometheus2'
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
@@ -17,8 +17,10 @@ rule_files:
   # - "second.rules"
 
 remote_write:
+    - url: "http://promscale-connector1:9201/write"
     - url: "http://promscale-connector2:9201/write"
 remote_read:
+    - url: "http://promscale-connector1:9201/read"
     - url: "http://promscale-connector2:9201/read"
 
 # A scrape configuration containing exactly one endpoint to scrape:


### PR DESCRIPTION
## Description

It turns out that the HA test script was still working under the old HA
model, so it had to be reworked.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
