### PR TITLE
Use glob filter for mbox instead of find

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,16 +53,15 @@ deploy/helm-chart/templates/prometheus-rule.yaml:
 	./scripts/generate-helm-alerts.sh
 
 MDOX_VALIDATE_CONFIG?=.mdox.validate.yaml
-MD_FILES_TO_FORMAT=$(shell find -type f -name '*.md')
 .PHONY: docs
 docs:
 	@echo ">> formatting and local/remote links"
-	$(MDOX_BIN) fmt --soft-wraps -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) $(MD_FILES_TO_FORMAT)
+	$(MDOX_BIN) fmt --soft-wraps -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) **/*.md
 
 .PHONY: check-docs
 check-docs:
 	@echo ">> checking formatting and local/remote links"
-	$(MDOX_BIN) fmt --soft-wraps --check -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) $(MD_FILES_TO_FORMAT)
+	$(MDOX_BIN) fmt --soft-wraps --check -l --links.validate.config-file=$(MDOX_VALIDATE_CONFIG) **/*.md
 
 .PHONY: all
 all: build test go-fmt go-lint


### PR DESCRIPTION
## Description

`find -type f -name '*.md'` does not work on "stock" macOS, and it's not actually needed anyway. This replaces the subshell usage of `find` in the makefile with a glob that produces the same result and allows us "stock" macOS users to run these make targets.

https://stackoverflow.com/questions/25840713/illegal-option-error-when-using-find-on-macos 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
