### PR TITLE
Manage stopping of ingest components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.6.3
 	go.opentelemetry.io/otel/sdk v1.6.3
 	go.opentelemetry.io/otel/trace v1.6.3
+	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/automaxprocs v1.5.1
 	go.uber.org/goleak v1.1.12
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150

--- a/pkg/pgmodel/ingestor/ingestor_test.go
+++ b/pkg/pgmodel/ingestor/ingestor_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"testing"
 
+	"go.uber.org/atomic"
+
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/pgmodel/common/errors"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
@@ -264,6 +266,7 @@ func TestDBIngestorIngest(t *testing.T) {
 			i := DBIngestor{
 				dispatcher: &inserter,
 				sCache:     sCache,
+				closed:     atomic.NewBool(false),
 			}
 
 			wr := NewWriteRequest()


### PR DESCRIPTION
We make sure to keep the state of ingest components and to block
race condition where component might be stopped but we still try
to ingest.

We also don't allow for closing of already closed components as that
can cause panic.

For rule manager we  wait for all group actors to stop before returning. Otherwise
a race condition might happen as sub components might continue running.