### PR TITLE
Add HEAD and OPTIONS on healthz

### DIFF
--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -98,7 +98,7 @@ func GenerateRouter(apiConf *Config, promqlConf *query.Config, client *pgclient.
 	apiV1.Path("/label/{name}/values").Methods(http.MethodGet).HandlerFunc(labelValuesHandler)
 
 	healthChecker := func() error { return client.HealthCheck() }
-	router.Path("/healthz").Methods(http.MethodGet).HandlerFunc(Health(healthChecker))
+	router.Path("/healthz").Methods(http.MethodGet, http.MethodOptions, http.MethodHead).HandlerFunc(Health(healthChecker))
 	router.Path(apiConf.TelemetryPath).Methods(http.MethodGet).HandlerFunc(promhttp.Handler().ServeHTTP)
 
 	jaeger.ExtendQueryAPIs(router, client.Connection, query)


### PR DESCRIPTION
Load balancers prefer to make HEAD or OPTIONS requests for health checks
as they are cheaper.

Related https://github.com/timescale/promscale/issues/710
Also some community users encountered this problem  https://timescaledb.slack.com/archives/C011FC0PPC5/p1653384295441989?thread_ts=1652775715.500199&cid=C011FC0PPC5

