### PR TITLE
Support slices in traces attributes

### DIFF
--- a/pkg/jaeger/query/trace_scan.go
+++ b/pkg/jaeger/query/trace_scan.go
@@ -273,25 +273,13 @@ func makeAttributes(tagsJson pgtype.JSONB) (map[string]pcommon.Value, error) {
 	if err := tagsJson.AssignTo(&tags); err != nil {
 		return nil, fmt.Errorf("tags assign to: %w", err)
 	}
-
+	otMap := pcommon.NewMapFromRaw(tags)
 	m := make(map[string]pcommon.Value, len(tags))
-	// todo: attribute val as array?
-	for k, v := range tags {
-		switch val := v.(type) {
-		case int64:
-			m[k] = pcommon.NewValueInt(val)
-		case bool:
-			m[k] = pcommon.NewValueBool(val)
-		case string:
-			m[k] = pcommon.NewValueString(val)
-		case float64:
-			m[k] = pcommon.NewValueDouble(val)
-		case []byte:
-			m[k] = pcommon.NewValueBytes(val)
-		default:
-			return nil, fmt.Errorf("unknown tag type %T", v)
-		}
+	populateMap := func(k string, v pcommon.Value) bool {
+		m[k] = v
+		return true
 	}
+	otMap.Range(populateMap)
 	return m, nil
 }
 

--- a/pkg/tests/end_to_end_tests/dataset_traces_test.go
+++ b/pkg/tests/end_to_end_tests/dataset_traces_test.go
@@ -109,6 +109,7 @@ func initResourceAttributes(dest pdata.Map, index int) {
 	tmpl := pdata.NewAttributeMapFromMap(map[string]pdata.Value{
 		"resource-attr": pcommon.NewValueString(fmt.Sprintf("resource-attr-val-%d", index%2)),
 		"service.name":  pcommon.NewValueString(fmt.Sprintf("service-name-%d", index)),
+		"test-slice":    pcommon.NewValueSlice(),
 	})
 	dest.Clear()
 	tmpl.CopyTo(dest)


### PR DESCRIPTION
open-telemetry collector does not have proper API support for slices so we
needed a different approach when it comes to processing JSON.

Closes https://github.com/timescale/promscale/issues/1379
