### PR TITLE
Set number of copiers based on DB CPU count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We use the following categories for changes:
 - `-enable-feature=promql-per-step-stats` feature for statistics in PromQL evaluation
 - Add `readinessProbe` in helm chart [#1266]
 - Telemetry for recording rules and alerting [#1424]
+- Set number of ingest copiers to the number of DB CPUs [#1387]
 
 ### Fixed
 - Trace query returns empty result when queried with 


### PR DESCRIPTION
## Description

Promscale extension now exposes the number of CPUs that are available to
the database. We can use this information to set the appropriate number of
copiers so we can utilize the database in an efficient manner.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
