### PR TITLE
Run e2e tests against current master of promscale extension

### DIFF
--- a/.github/workflows/go-e2e.yml
+++ b/.github/workflows/go-e2e.yml
@@ -16,7 +16,7 @@ on:
       docker_image_prefix:
         description: 'Docker image prefix'
         required: true
-        default: 'ghcr.io/timescale/dev_promscale_extension:develop-ts2'
+        default: 'ghcr.io/timescale/dev_promscale_extension:master-ts2'
 
 env:
   golang-version: 1.18.1
@@ -46,11 +46,11 @@ jobs:
       run: |
         branch_name=$(echo ${{github.head_ref || github.ref_name}} | sed 's#/#-#')
         possible_branch_tag=$(echo ${branch_name}-ts2)
-        develop_branch_tag=$(echo develop-ts2)
+        master_branch_tag=$(echo master-ts2)
         image_base="ghcr.io/timescale/dev_promscale_extension"
-        docker_image_12=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg12 ${image_base}:${develop_branch_tag}-pg12)
-        docker_image_13=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg13 ${image_base}:${develop_branch_tag}-pg13)
-        docker_image_14=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg14 ${image_base}:${develop_branch_tag}-pg14)
+        docker_image_12=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg12 ${image_base}:${master_branch_tag}-pg12)
+        docker_image_13=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg13 ${image_base}:${master_branch_tag}-pg13)
+        docker_image_14=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg14 ${image_base}:${master_branch_tag}-pg14)
         echo "::set-output name=docker_image_12::${docker_image_12}"
         echo "::set-output name=docker_image_13::${docker_image_13}"
         echo "::set-output name=docker_image_14::${docker_image_14}"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,9 +38,9 @@ jobs:
       run: |
         branch_name=$(echo ${{github.head_ref || github.ref_name}} | sed 's#/#-#')
         possible_branch_tag=$(echo ${branch_name}-ts2-pg${{matrix.pg}})
-        develop_branch_tag=$(echo develop-ts2-pg${{matrix.pg}})
+        master_branch_tag=$(echo master-ts2-pg${{matrix.pg}})
         image_base="ghcr.io/timescale/dev_promscale_extension"
-        docker_image=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag} ${image_base}:${develop_branch_tag})
+        docker_image=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag} ${image_base}:${master_branch_tag})
         echo "::set-output name=docker_image::${docker_image}"
 
     - name: TimescaleDB 2.x with Promscale extension (pg${{matrix.pg}})

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ pkg/tests/testdata/traces-dataset.sz:
 
 .PHONY: e2e
 e2e: CURRENT_BRANCH?=$(shell git branch --show-current | sed 's#/#-#')
-e2e: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg14 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg14 $(GHCR_DOCKER_BASE):develop-ts2-pg14)
+e2e: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg14 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg14 $(GHCR_DOCKER_BASE):master-ts2-pg14)
 e2e: pkg/tests/testdata/traces-dataset.sz generate
 	go test -v ./pkg/tests/end_to_end_tests/ -timescale-docker-image=$(DOCKER_IMAGE)
 	go test -v ./pkg/tests/end_to_end_tests/ -use-timescaledb=false -timescale-docker-image=$(DOCKER_IMAGE)
@@ -34,7 +34,7 @@ e2e: pkg/tests/testdata/traces-dataset.sz generate
 
 .PHONY: upgrade-test
 upgrade-test: CURRENT_BRANCH?=$(shell git branch --show-current | sed 's#/#-#')
-upgrade-test: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg13 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg13 $(GHCR_DOCKER_BASE):develop-ts2-pg13)
+upgrade-test: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg13 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg13 $(GHCR_DOCKER_BASE):master-ts2-pg13)
 upgrade-test:
 	go test -v ./pkg/tests/upgrade_tests/ -timescale-docker-image=$(DOCKER_IMAGE)
 

--- a/pkg/internal/testhelpers/containers_test.go
+++ b/pkg/internal/testhelpers/containers_test.go
@@ -47,7 +47,7 @@ func TestWithDB(t *testing.T) {
 		t.Skip("skipping integration test")
 	}
 	// TODO (james): Replace hardcoded value
-	extensionState := NewTestOptions(timescaleBit, "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14")
+	extensionState := NewTestOptions(timescaleBit, "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14")
 	WithDB(t, *testDatabase, Superuser, false, extensionState, func(db *pgxpool.Pool, t testing.TB, connectURL string) {
 		var res int
 		err := db.QueryRow(context.Background(), "SELECT 1").Scan(&res)
@@ -64,7 +64,7 @@ func runMain(m *testing.M) int {
 	flag.Parse()
 	ctx := context.Background()
 	// TODO (james): Replace hardcoded value
-	extensionState := NewTestOptions(timescaleBit, "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14")
+	extensionState := NewTestOptions(timescaleBit, "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14")
 	if !testing.Short() && *useDocker {
 		_, closer, err := StartPGContainer(ctx, nil, extensionState, "", false)
 		if err != nil {

--- a/pkg/tests/end_to_end_tests/main_test.go
+++ b/pkg/tests/end_to_end_tests/main_test.go
@@ -36,7 +36,7 @@ var (
 	useDocker         = flag.Bool("use-docker", true, "start database using a docker container")
 	useTimescaleDB    = flag.Bool("use-timescaledb", true, "use TimescaleDB")
 	// TODO (james): Replace hardcoded value
-	timescaleDockerImage  = flag.String("timescale-docker-image", "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14", "TimescaleDB docker image to run tests against")
+	timescaleDockerImage  = flag.String("timescale-docker-image", "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14", "TimescaleDB docker image to run tests against")
 	useMultinode          = flag.Bool("use-multinode", false, "use TimescaleDB Multinode")
 	useTimescaleDBNightly = flag.Bool("use-timescaledb-nightly", false, "use TimescaleDB nightly images")
 	printLogs             = flag.Bool("print-logs", false, "print TimescaleDB logs")

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -43,7 +43,7 @@ var (
 	testDatabase = flag.String("database", "tmp_db_timescale_upgrade_test", "database to run integration tests on")
 	printLogs    = flag.Bool("print-logs", false, "print TimescaleDB logs")
 	// use "local/dev_promscale_extension:head-ts2-pg13" for local testing
-	dockerImage        = flag.String("timescale-docker-image", "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14", "TimescaleDB docker image for latest version to run tests against")
+	dockerImage        = flag.String("timescale-docker-image", "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14", "TimescaleDB docker image for latest version to run tests against")
 	baseExtensionState testhelpers.TestOptions
 )
 
@@ -790,7 +790,7 @@ func startDB(t *testing.T, ctx context.Context) (*pgx.Conn, testcontainers.Conta
 	}
 
 	// TODO (james): Replace hardcoded value
-	extensionState := testhelpers.NewTestOptions(testhelpers.Timescale, "ghcr.io/timescale/dev_promscale_extension:develop-ts2-pg14")
+	extensionState := testhelpers.NewTestOptions(testhelpers.Timescale, "ghcr.io/timescale/dev_promscale_extension:master-ts2-pg14")
 
 	dbContainer, closer, err := testhelpers.StartDatabaseImage(ctx, t, "timescaledev/promscale-extension:testing-extension-upgrade", tmpDir, dataDir, *printLogs, extensionState)
 	if err != nil {


### PR DESCRIPTION
## Description

In the extension we're switching to a master-based development model. It
was agreed that the Promscale Connector's releases will follow those of
the extension, so end-to-end tests should be run against the current
extension master.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
