### PR TITLE
Remove timescaledb_toolkit extension in test setup

### DIFF
--- a/pkg/internal/testhelpers/postgres_container.go
+++ b/pkg/internal/testhelpers/postgres_container.go
@@ -270,6 +270,11 @@ func DbSetup(DBName string, superuser SuperuserStatus, deferNode2Setup bool, ext
 		// that case timescaledb should always be installed by the time the
 		// connector runs)
 		_, err = ourDb.Exec(context.Background(), "DROP EXTENSION IF EXISTS timescaledb")
+		// Some docker images may also have timescaledb_toolkit installed in
+		// a template, but this messes with our upgrade tests because toolkit
+		// was not always present. It's easier to remove it here and install it
+		// in the specific tests which require toolkit.
+		_, err = ourDb.Exec(context.Background(), "DROP EXTENSION IF EXISTS timescaledb_toolkit")
 		if err != nil {
 			_ = ourDb.Close(context.Background())
 			return nil, err

--- a/pkg/tests/upgrade_tests/shapshot.go
+++ b/pkg/tests/upgrade_tests/shapshot.go
@@ -55,7 +55,6 @@ var schemas = []string{
 	"ps_trace",
 	"public",
 	"timescaledb_information",
-	"toolkit_experimental",
 }
 
 var schemasWOTimescaleDB = []string{


### PR DESCRIPTION
## Description

In 3fb6f85d we already tried to address the presence of the toolkit
extension in the `timescale/timescaledb-ha` docker image. Unfortunately
that approach ended up with a mixed situation with toolkit sometimes
being present, and sometimes not. This ended up with a hard-to-reconcile
situation in the database snapshotting tooling.

The simplest fix to this is to drop the timescaledb_toolkit extension
from the database on test setup. Tests that require the toolkit to be
present will install it themselves anyway, so nothing is lost with this
approach.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
