### PR TITLE
Tweaks for local go bench

### DIFF
--- a/pkg/tests/end_to_end_tests/metric_ingest_bench_test.go
+++ b/pkg/tests/end_to_end_tests/metric_ingest_bench_test.go
@@ -21,7 +21,7 @@ var prometheusDataGzip = "../testdata/prometheus-data.tar.gz"
 func TestPromLoader(t *testing.T) {
 	data, err := extractPrometheusData(prometheusDataGzip, t.TempDir())
 	require.NoError(t, err, "failed to extract prometheus data")
-	loader, err := testsupport.NewPromLoader(data)
+	loader, err := testsupport.NewPromLoader(data, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func BenchmarkMetricIngest(b *testing.B) {
 	if err != nil {
 		b.Fatalf("failed to extract prometheus data: %v", err)
 	}
-	loader, err := testsupport.NewPromLoader(data)
+	loader, err := testsupport.NewPromLoader(data, true) // load whole dataset in memory so we can better track allocations during ingest
 	require.NoError(b, err)
 	defer func() {
 		if err := loader.Close(); err != nil {


### PR DESCRIPTION
Allow loading the whole test data set into memory which can be useful when
benchmarking memory allocations. It also helps avoid any i/o related issues 
when loading chunk data in streaming fashion (Prometheus uses mmap files), although
I haven't see any so far (the numbers are just slightly better when ingesting from memory)

Don't block on sending ingest requests while creating batches which improves
data load speed.

I've also tried using sync Pool to ease GC, however it slowed down the benchmark so I gave up on that (which makes sense since sync.Pool requres more CPU work then just creating new instance)