### PR TITLE
List label values of allowed tenants only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We use the following categories for changes:
   - Tags from process table in Jaeger UI [#1385]
   - Tags that have a numeric value, like `http.status_code=200` [#1385]
   - Tags that involve status code [#1384]
+- List label values of allowed tenants only [#1427] 
 
 ## [0.11.0] - 2022-05-11
 

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -142,7 +142,7 @@ func NewClientWithPool(cfg *Config, numCopiers int, connPool *pgxpool.Pool, mt t
 		AsyncAcks:              cfg.AsyncAcks,
 	}
 
-	labelsReader := lreader.NewLabelsReader(dbConn, labelsCache)
+	labelsReader := lreader.NewLabelsReader(dbConn, labelsCache, mt.ReadAuthorizer())
 	exemplarKeyPosCache := cache.NewExemplarLabelsPosCache(cfg.CacheConfig)
 
 	dbQuerierConn := pgxconn.NewQueryLoggingPgxConn(connPool)

--- a/pkg/pgmodel/querier/querier_sql_test.go
+++ b/pkg/pgmodel/querier/querier_sql_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/timescale/promscale/pkg/pgmodel/lreader"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/prompb"
+	"github.com/timescale/promscale/pkg/tenancy"
 )
 
 func TestPGXQuerierQuery(t *testing.T) {
@@ -720,7 +721,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error setting up mock cache: %s", err.Error())
 			}
-			querier := pgxQuerier{&queryTools{conn: mock, metricTableNames: mockMetrics, labelsReader: lreader.NewLabelsReader(mock, clockcache.WithMax(0))}}
+			querier := pgxQuerier{&queryTools{conn: mock, metricTableNames: mockMetrics, labelsReader: lreader.NewLabelsReader(mock, clockcache.WithMax(0), tenancy.NewNoopAuthorizer().ReadAuthorizer())}}
 
 			result, err := querier.RemoteReadQuerier().Query(c.query)
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -251,8 +251,9 @@ func Run(cfg *Config) error {
 	mux.Handle("/", router)
 
 	server := http.Server{
-		Addr:    cfg.ListenAddr,
-		Handler: mux,
+		Addr:              cfg.ListenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: time.Second * 30, // To mitigate Slowloris DDoS attack. Value is arbitrary picked
 	}
 	group.Add(
 		func() error {

--- a/pkg/tests/end_to_end_tests/continuous_agg_test.go
+++ b/pkg/tests/end_to_end_tests/continuous_agg_test.go
@@ -211,7 +211,7 @@ WITH (timescaledb.continuous) AS
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		queryable := query.NewQueryable(r, labelsReader)
 		queryEngine, err := query.NewEngine(log.GetLogger(), time.Minute, time.Minute*5, time.Minute, 50000000, nil)

--- a/pkg/tests/end_to_end_tests/exemplar_test.go
+++ b/pkg/tests/end_to_end_tests/exemplar_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/timescale/promscale/pkg/pgxconn"
 	"github.com/timescale/promscale/pkg/prompb"
 	"github.com/timescale/promscale/pkg/query"
+	"github.com/timescale/promscale/pkg/tenancy"
 )
 
 var rawExemplar = []prompb.Exemplar{
@@ -198,7 +199,7 @@ func TestExemplarQueryingAPI(t *testing.T) {
 		// We do not check num of insertablesIngested and metadataIngested returned above from ingestor.Ingest,
 		// since the return will be 0, as they have already been ingested by TestExemplarIngestion.
 
-		labelsReader := lreader.NewLabelsReader(pgxconn.NewPgxConn(db), cache.NewLabelsCache(cache.DefaultConfig))
+		labelsReader := lreader.NewLabelsReader(pgxconn.NewPgxConn(db), cache.NewLabelsCache(cache.DefaultConfig), tenancy.NewNoopAuthorizer().ReadAuthorizer())
 		r := querier.NewQuerier(
 			pgxconn.NewPgxConn(db),
 			cache.NewMetricCache(cache.DefaultConfig),

--- a/pkg/tests/end_to_end_tests/main_test.go
+++ b/pkg/tests/end_to_end_tests/main_test.go
@@ -8,12 +8,14 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	constants "github.com/timescale/promscale/pkg/tests"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/timescale/promscale/pkg/tenancy"
+	constants "github.com/timescale/promscale/pkg/tests"
 
 	"github.com/docker/go-connections/nat"
 	"github.com/jackc/pgx/v4"
@@ -60,6 +62,7 @@ var (
 	// timeseriesWithExemplars is a singleton instance for testing generated timeseries for exemplars based E2E tests.
 	// The called must ensure to use by call/copy only.
 	timeseriesWithExemplars []prompb.TimeSeries
+	noopReadAuthorizer      = tenancy.NewNoopAuthorizer().ReadAuthorizer()
 )
 
 func init() {

--- a/pkg/tests/end_to_end_tests/multi_tenancy_test.go
+++ b/pkg/tests/end_to_end_tests/multi_tenancy_test.go
@@ -51,7 +51,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(db)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, mt.ReadAuthorizer())
 		qr := querier.NewQuerier(dbConn, mCache, labelsReader, nil, mt.ReadAuthorizer())
 
 		// ----- query-test: querying a single tenant (tenant-a) -----
@@ -244,7 +244,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(db)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, mt.ReadAuthorizer())
 		qr := querier.NewQuerier(dbConn, mCache, labelsReader, nil, mt.ReadAuthorizer())
 
 		// ----- query-test: querying a valid tenant (tenant-a) -----
@@ -367,7 +367,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 		mt, err = tenancy.NewAuthorizer(cfg)
 		require.NoError(t, err)
 
-		labelsReader = lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader = lreader.NewLabelsReader(dbConn, lCache, mt.ReadAuthorizer())
 		qr = querier.NewQuerier(dbConn, mCache, labelsReader, nil, mt.ReadAuthorizer())
 
 		expectedResult = []prompb.TimeSeries{}
@@ -445,7 +445,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(db)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, mt.ReadAuthorizer())
 		qr := querier.NewQuerier(dbConn, mCache, labelsReader, nil, mt.ReadAuthorizer())
 
 		// ----- query-test: querying a non-tenant -----
@@ -532,7 +532,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 		mt, err = tenancy.NewAuthorizer(cfg)
 		require.NoError(t, err)
 
-		labelsReader = lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader = lreader.NewLabelsReader(dbConn, lCache, mt.ReadAuthorizer())
 		qr = querier.NewQuerier(dbConn, mCache, labelsReader, nil, mt.ReadAuthorizer())
 
 		expectedResult = []prompb.TimeSeries{
@@ -638,7 +638,7 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(db)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, mt.ReadAuthorizer())
 		qr := querier.NewQuerier(dbConn, mCache, labelsReader, nil, mt.ReadAuthorizer())
 
 		// ----- query-test: querying a single tenant (tenant-b) -----

--- a/pkg/tests/end_to_end_tests/nan_test.go
+++ b/pkg/tests/end_to_end_tests/nan_test.go
@@ -127,7 +127,7 @@ func TestSQLStaleNaN(t *testing.T) {
 			mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 			lCache := clockcache.WithMax(100)
 			dbConn := pgxconn.NewPgxConn(db)
-			labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+			labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 			r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 			resp, err := r.RemoteReadQuerier().Query(c.query)
 			if err != nil {

--- a/pkg/tests/end_to_end_tests/null_chars_test.go
+++ b/pkg/tests/end_to_end_tests/null_chars_test.go
@@ -65,7 +65,7 @@ func TestOperationWithNullChars(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(db)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		resp, err := r.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{

--- a/pkg/tests/end_to_end_tests/promql_label_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_label_endpoint_test.go
@@ -110,7 +110,7 @@ func TestPromQLLabelEndpoint(t *testing.T) {
 
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		labelNames, err := labelsReader.LabelNames()
 		if err != nil {
 			t.Fatalf("could not get label names from querier")

--- a/pkg/tests/end_to_end_tests/query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/query_integration_test.go
@@ -112,7 +112,7 @@ func TestDroppedViewQuery(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		_, err := r.RemoteReadQuerier().Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
@@ -690,7 +690,7 @@ func TestSQLQuery(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		for _, c := range testCases {
 			tester.Run(c.name, func(t *testing.T) {
@@ -1064,7 +1064,7 @@ func TestPromQL(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		for _, c := range testCases {
 			tester.Run(c.name, func(t *testing.T) {
@@ -1265,7 +1265,7 @@ func TestPushdownDelta(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		queryable := query.NewQueryable(r, labelsReader)
 		queryEngine, err := query.NewEngine(log.GetLogger(), time.Minute, time.Minute*5, time.Minute, 50000000, nil)
@@ -1340,7 +1340,7 @@ func TestPushdownVecSel(t *testing.T) {
 		mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 		lCache := clockcache.WithMax(100)
 		dbConn := pgxconn.NewPgxConn(readOnly)
-		labelsReader := lreader.NewLabelsReader(dbConn, lCache)
+		labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 		r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
 		queryable := query.NewQueryable(r, labelsReader)
 		queryEngine, err := query.NewEngine(log.GetLogger(), time.Minute, time.Minute*5, time.Minute, 50000000, nil)


### PR DESCRIPTION
If allowed tenants are configured we only list those when showing `__tenant__` values.

Fixes https://github.com/timescale/promscale/issues/1194