### PR TITLE
deploy/helm-chart: (ab)use telemetry to check how many people use promscale helm chart directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ We use the following categories for changes:
 - Add `readinessProbe` in helm chart [#1266]
 - Telemetry for recording rules and alerting [#1424]
 - Set number of ingest copiers to the number of DB CPUs [#1387]
+- Telemetry for helm chart installations [#1429]
 
 ### Fixed
 - Trace query returns empty result when queried with 

--- a/deploy/helm-chart/templates/deployment-promscale.yaml
+++ b/deploy/helm-chart/templates/deployment-promscale.yaml
@@ -45,8 +45,12 @@ spec:
           {{- with .Values.extraArgs }}
           {{ toYaml . | nindent 10 }}
           {{- end }}
-          {{- if .Values.extraEnv }}
           env:
+            - name: TOBS_TELEMETRY_INSTALLED_BY
+              value: "promscale"
+            - name: "TOBS_TELEMETRY_VERSION"
+              value: "{{ .Chart.Version }}"
+          {{- if .Values.extraEnv }}
             {{- range $.Values.extraEnv }}
             - name: {{ .name }}
               value: {{ tpl (.value | quote) $ }}

--- a/deploy/static/deploy.yaml
+++ b/deploy/static/deploy.yaml
@@ -111,6 +111,11 @@ spec:
           name: promscale-connector
           args:
           - "-config=/etc/promscale/config.yaml"
+          env:
+            - name: TOBS_TELEMETRY_INSTALLED_BY
+              value: "promscale"
+            - name: "TOBS_TELEMETRY_VERSION"
+              value: "0.11.0"
           envFrom:
           - secretRef:
               name: promscale


### PR DESCRIPTION
## Description

*Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.*

As in title.

Tobs will use `TOBS_TELEMETRY_INSTALLED_BY: "tobs"` for helm installation.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
