### PR TITLE
.github: add extension group to renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,10 @@
     {
       "groupName": "docker-compose",
       "matchManagers": ["docker-compose"]
+    },
+    {
+      "groupName": "extension",
+      "matchPaths": ["EXTENSION_VERSION"]
     }
   ]
 }


### PR DESCRIPTION
## Description

*Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.*

Right now renovate knows how to match extension version to a file, but without the change in this PR it doesn't know what to do with that match.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
