### PR TITLE
.github: do not assign extension update to any group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
   "regexManagers": [
     {
       "fileMatch": ["^EXTENSION_VERSION$"],
-      "matchStrings": ["(?<currentValue>.*?)"],
+      "matchStrings": ["(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "timescale/promscale_extension"
     },
@@ -59,10 +59,6 @@
     {
       "groupName": "docker-compose",
       "matchManagers": ["docker-compose"]
-    },
-    {
-      "groupName": "extension",
-      "matchPaths": ["EXTENSION_VERSION"]
     }
   ]
 }


### PR DESCRIPTION
## Description

*Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.*

This was tested using [renovate docker image](https://hub.docker.com/repository/docker/renovate/renovate) and [my forked repository](https://github.com/paulfantom/promscale/pulls).

Process was as follows:
1. `docker pull renovate/renovate`
2. `docker run -it renovate/renovate bash`
3. From now on all commands were executed in the docker container and changes to the repository were done in a separate terminal by pushing commits to `master` branch.
4. `renovate timescale/promscale --dry-run --token $GH_TOKEN` which failed spectaculary
5. `renovate paulfantom/promscale --renovate-fork --fork-mode --token $GH_TOKEN` was used repeatedly to figure out what is the proper `renovate.json` configuration

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
