### PR TITLE
Disable Renovate bot for managing Go dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,8 @@
       "addLabels": ["go"],
       "groupName": "golang dependencies",
       "matchManagers": ["gomod"],
-      "commitMessageExtra": ""
+      "commitMessageExtra": "",
+      "enabled": false
     },
     {
       "addLabels": ["github_actions"],


### PR DESCRIPTION
## Description

Disabling Renovate to update Go deps temporarily to reduce the amount of
maintenance time necessary to keep them up to date. This should be re-enabled
once we reach a more stable point in the project (e.g. version 1.0).

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
