### PR TITLE
Minor refactoring for clarification

### DIFF
--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -192,8 +192,8 @@ func (ingestor *DBIngestor) ingestTimeseries(ctx context.Context, timeseries []p
 		if len(ts.Labels) == 0 {
 			continue
 		}
-		// Normalize and canonicalize t.Labels.
-		// After this point t.Labels should never be used again.
+		// Normalize and canonicalize ts.Labels.
+		// After this point ts.Labels should never be used again.
 		series, metricName, err = ingestor.sCache.GetSeriesFromProtos(ts.Labels)
 		if err != nil {
 			return 0, err

--- a/pkg/pgmodel/ingestor/series_writer.go
+++ b/pkg/pgmodel/ingestor/series_writer.go
@@ -288,7 +288,7 @@ func (h *seriesWriter) fillLabelIDs(ctx context.Context, infos map[string]*perMe
 			for i := range pos {
 				res := cache.NewLabelInfo(labelIDs[i], pos[i])
 				key := cache.NewLabelKey(info.metricName, names[i], values[i])
-				if !h.labelsCache.Put(cache.NewLabelKey(info.metricName, names[i], values[i]), cache.NewLabelInfo(labelIDs[i], pos[i])) {
+				if !h.labelsCache.Put(key, res) {
 					log.Warn("failed to add label ID to inverted cache")
 				}
 				_, ok := labelMap[key]

--- a/pkg/pgmodel/model/series.go
+++ b/pkg/pgmodel/model/series.go
@@ -27,10 +27,10 @@ func (s SeriesID) String() string {
 	return strconv.FormatInt(int64(s), 10)
 }
 
-//Epoch represents the series epoch
+// SeriesEpoch represents the series epoch
 type SeriesEpoch int64
 
-// Series stores a labels.Series in its canonical string representation
+// Series stores a Prometheus labels.Labels in its canonical string representation
 type Series struct {
 	//protects names, values, seriesID, epoch
 	//str and metricName are immutable and doesn't need a lock


### PR DESCRIPTION
## Description

- Some comments reference structs or methods which have been renamed
- Change parameter name from 'builder' to 'keyBuffer' in `generateKey`
- Remove double-creation of key and value in series_writer.go

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
