### PR TITLE
Ingest metric data with COPY to get better performance

### DIFF
--- a/.github/workflows/go-e2e.yml
+++ b/.github/workflows/go-e2e.yml
@@ -61,9 +61,9 @@ jobs:
           extension_version=$(cat EXTENSION_VERSION | tr -d '[:space:]')
           stable_branch_tag=$(echo ${extension_version}-ts2)
           image_base="ghcr.io/timescale/dev_promscale_extension"
-          docker_image_12=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg12 ${image_base}:${stable_branch_tag}-pg12)
-          docker_image_13=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg13 ${image_base}:${stable_branch_tag}-pg13)
-          docker_image_14=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg14 ${image_base}:${stable_branch_tag}-pg14)
+          docker_image_12=${image_base}:${stable_branch_tag}-pg12
+          docker_image_13=${image_base}:${stable_branch_tag}-pg13
+          docker_image_14=${image_base}:${stable_branch_tag}-pg14
         fi;
         echo "::set-output name=docker_image_12::${docker_image_12}"
         echo "::set-output name=docker_image_13::${docker_image_13}"

--- a/EXTENSION_VERSION
+++ b/EXTENSION_VERSION
@@ -1,1 +1,1 @@
-0.5.2
+niksa-new-arg-for-create-ingest-table

--- a/pkg/pgmodel/common/schema/schema.go
+++ b/pkg/pgmodel/common/schema/schema.go
@@ -14,4 +14,10 @@ const (
 	LockID = 0x4D829C732AAFCEDE // Chosen randomly.
 
 	PromDataSeries = "prom_data_series"
+	PsTrace        = "_ps_trace"
+)
+
+var (
+	PromDataColumns     = []string{"time", "value", "series_id"}
+	PromExemplarColumns = []string{"time", "series_id", "exemplar_label_values", "value"}
 )

--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -14,16 +14,22 @@ import (
 	"time"
 
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgx/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/timescale/promscale/pkg/log"
+	"github.com/timescale/promscale/pkg/pgmodel/common/schema"
 	"github.com/timescale/promscale/pkg/pgmodel/metrics"
 	pgmodel "github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/pgxconn"
 	"github.com/timescale/promscale/pkg/tracer"
+)
+
+const (
+	sqlInsertIntoFrom = "INSERT INTO %[1]s.%[2]s(%[3]s) SELECT %[3]s FROM %[4]s ON CONFLICT DO NOTHING"
 )
 
 type copyRequest struct {
@@ -197,10 +203,16 @@ hot_gather:
 func doInsertOrFallback(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest) {
 	ctx, span := tracer.Default().Start(ctx, "do-insert-or-fallback")
 	defer span.End()
-	err, _ := insertSeries(ctx, conn, reqs...)
+	err, _ := insertSeries(ctx, conn, false, reqs...)
 	if err != nil {
-		insertBatchErrorFallback(ctx, conn, reqs...)
-		return
+		if isPGUniqueViolation(err) {
+			err, _ = insertSeries(ctx, conn, true, reqs...)
+		}
+		if err != nil {
+			log.Error("msg", err)
+			insertBatchErrorFallback(ctx, conn, reqs...)
+			return
+		}
 	}
 
 	for i := range reqs {
@@ -209,11 +221,23 @@ func doInsertOrFallback(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyR
 	}
 }
 
+// check if we got error for duplicates
+func isPGUniqueViolation(err error) bool {
+	if err == nil {
+		return false
+	}
+	pgErr, ok := err.(*pgconn.PgError)
+	if ok && pgErr.Code == "23505" {
+		return true
+	}
+	return false
+}
+
 func insertBatchErrorFallback(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest) {
 	ctx, span := tracer.Default().Start(ctx, "insert-batch-error-fallback")
 	defer span.End()
 	for i := range reqs {
-		err, minTime := insertSeries(ctx, conn, reqs[i])
+		err, minTime := insertSeries(ctx, conn, true, reqs[i])
 		if err != nil {
 			err = tryRecovery(ctx, conn, err, reqs[i], minTime)
 		}
@@ -287,7 +311,10 @@ func retryAfterDecompression(ctx context.Context, conn pgxconn.PgxConn, req copy
 
 	metrics.IngestorDecompressCalls.With(prometheus.Labels{"type": "metric", "kind": "sample"}).Inc()
 	metrics.IngestorDecompressEarliest.With(prometheus.Labels{"type": "metric", "kind": "sample", "table": table}).Set(float64(minTime.UnixNano()) / 1e9)
-	err, _ := insertSeries(ctx, conn, req) // Attempt an insert again.
+	err, _ := insertSeries(ctx, conn, false, req) // Attempt an insert again.
+	if isPGUniqueViolation(err) {
+		err, _ = insertSeries(ctx, conn, true, req) // And again :)
+	}
 	return err
 }
 
@@ -310,17 +337,31 @@ func debugInsert() {
 var labelsCopier = prometheus.Labels{"type": "metric", "subsystem": "copier"}
 
 // insertSeries performs the insertion of time-series into the DB.
-func insertSeries(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest) (error, int64) {
+func insertSeries(ctx context.Context, conn pgxconn.PgxConn, onConflict bool, reqs ...copyRequest) (error, int64) {
 	_, span := tracer.Default().Start(ctx, "insert-series")
 	defer span.End()
-	batch := conn.NewBatch()
-
 	numRowsPerInsert := make([]int, 0, len(reqs))
+	insertedRows := make([]int, 0, len(reqs))
 	numRowsTotal := 0
 	totalSamples := 0
 	totalExemplars := 0
+	var sampleRows [][]interface{}
+	var exemplarRows [][]interface{}
+	insertStart := time.Now()
 	lowestEpoch := pgmodel.SeriesEpoch(math.MaxInt64)
 	lowestMinTime := int64(math.MaxInt64)
+	tx, err := conn.BeginTx(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start transaction for inserting metrics: %v", err), lowestMinTime
+	}
+	defer func() {
+		if tx != nil {
+			if err := tx.Rollback(ctx); err != nil {
+				log.Error(err)
+			}
+		}
+	}()
+
 	for r := range reqs {
 		req := &reqs[r]
 		// Since seriesId order is not guaranteed we need to sort it to avoid row deadlock when duplicates are sent (eg. Prometheus retry)
@@ -345,45 +386,24 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest
 		var (
 			hasSamples   bool
 			hasExemplars bool
-
-			timeSamples   []time.Time
-			timeExemplars []time.Time
-
-			valSamples   []float64
-			valExemplars []float64
-
-			seriesIdSamples   []int64
-			seriesIdExemplars []int64
-
-			exemplarLbls [][]string
 		)
 
 		if numSamples > 0 {
-			timeSamples = make([]time.Time, 0, numSamples)
-			valSamples = make([]float64, 0, numSamples)
-			seriesIdSamples = make([]int64, 0, numSamples)
+			sampleRows = make([][]interface{}, 0, numSamples)
 		}
 		if numExemplars > 0 {
-			timeExemplars = make([]time.Time, 0, numExemplars)
-			valExemplars = make([]float64, 0, numExemplars)
-			seriesIdExemplars = make([]int64, 0, numExemplars)
-			exemplarLbls = make([][]string, 0, numExemplars)
+			exemplarRows = make([][]interface{}, 0, numExemplars)
 		}
 
 		visitor := req.data.batch.Visitor()
-		err := visitor.Visit(
+		err = visitor.Visit(
 			func(t time.Time, v float64, seriesId int64) {
 				hasSamples = true
-				timeSamples = append(timeSamples, t)
-				valSamples = append(valSamples, v)
-				seriesIdSamples = append(seriesIdSamples, seriesId)
+				sampleRows = append(sampleRows, []interface{}{t, v, seriesId})
 			},
 			func(t time.Time, v float64, seriesId int64, lvalues []string) {
 				hasExemplars = true
-				timeExemplars = append(timeExemplars, t)
-				valExemplars = append(valExemplars, v)
-				seriesIdExemplars = append(seriesIdExemplars, seriesId)
-				exemplarLbls = append(exemplarLbls, lvalues)
+				exemplarRows = append(exemplarRows, []interface{}{t, seriesId, lvalues, v})
 			},
 		)
 		if err != nil {
@@ -401,20 +421,53 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest
 		numRowsTotal += numSamples + numExemplars
 		totalSamples += numSamples
 		totalExemplars += numExemplars
+
+		copyFromFunc := func(tableName, schemaName string, isExemplar bool) error {
+			columns := schema.PromDataColumns
+			tempTablePrefix := fmt.Sprintf("s%d_", r)
+			rows := sampleRows
+			if isExemplar {
+				columns = schema.PromExemplarColumns
+				tempTablePrefix = fmt.Sprintf("s%d_", r)
+				rows = exemplarRows
+			}
+			table := pgx.Identifier{schemaName, tableName}
+			if onConflict {
+				// we append table prefix to make sure that temp table name is unique
+				table, err = createTempIngestTable(ctx, tx, tableName, schemaName, tempTablePrefix)
+				if err != nil {
+					return err
+				}
+			}
+			inserted, err := tx.CopyFrom(ctx, table, columns, pgx.CopyFromRows(rows))
+			if err != nil {
+				return err
+			}
+			if onConflict {
+				res, err := tx.Exec(ctx,
+					fmt.Sprintf(sqlInsertIntoFrom, schemaName, pgx.Identifier{tableName}.Sanitize(),
+						strings.Join(columns[:], ","), table.Sanitize()))
+				if err != nil {
+					return err
+				}
+				inserted = res.RowsAffected()
+
+			}
+			insertedRows = append(insertedRows, int(inserted))
+			return nil
+		}
+
 		if hasSamples {
 			numRowsPerInsert = append(numRowsPerInsert, numSamples)
-			batch.Queue("SELECT _prom_catalog.insert_metric_row($1, $2::TIMESTAMPTZ[], $3::DOUBLE PRECISION[], $4::BIGINT[])", req.info.TableName, timeSamples, valSamples, seriesIdSamples)
+			if err = copyFromFunc(req.info.TableName, req.info.TableSchema, false); err != nil {
+				return err, lowestMinTime
+			}
 		}
 		if hasExemplars {
-			// We cannot send 2-D [][]TEXT to postgres via the pgx.encoder. For this and easier querying reasons, we create a
-			// new type in postgres by the name prom_api.label_value_array and use that type as array (which forms a 2D array of TEXT)
-			// which is then used to push using the unnest method apprach.
-			labelValues := pgmodel.GetCustomType(pgmodel.LabelValueArray)
-			if err := labelValues.Set(exemplarLbls); err != nil {
-				return fmt.Errorf("setting prom_api.label_value_array[] value: %w", err), lowestMinTime
+			numRowsPerInsert = append(numRowsPerInsert, numSamples)
+			if err = copyFromFunc(req.info.TableName, schema.PromDataExemplar, true); err != nil {
+				return err, lowestMinTime
 			}
-			numRowsPerInsert = append(numRowsPerInsert, numExemplars)
-			batch.Queue("SELECT _prom_catalog.insert_exemplar_row($1::NAME, $2::TIMESTAMPTZ[], $3::BIGINT[], $4::prom_api.label_value_array[], $5::DOUBLE PRECISION[])", req.info.TableName, timeExemplars, seriesIdExemplars, labelValues, valExemplars)
 		}
 	}
 
@@ -422,42 +475,40 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, reqs ...copyRequest
 	//thus we don't need row locking here. Note by doing this check at the end we can
 	//have some wasted work for the inserts before this fails but this is rare.
 	//avoiding an additional loop or memoization to find the lowest epoch ahead of time seems worth it.
-	batch.Queue("SELECT CASE current_epoch > $1::BIGINT + 1 WHEN true THEN _prom_catalog.epoch_abort($1) END FROM _prom_catalog.ids_epoch LIMIT 1", int64(lowestEpoch))
-
-	metrics.IngestorRowsPerBatch.With(labelsCopier).Observe(float64(numRowsTotal))
-	metrics.IngestorInsertsPerBatch.With(labelsCopier).Observe(float64(len(reqs)))
-	start := time.Now()
-	results, err := conn.SendBatch(context.Background(), batch)
-	if err != nil {
+	row := tx.QueryRow(ctx, "SELECT CASE current_epoch > $1::BIGINT + 1 WHEN true THEN _prom_catalog.epoch_abort($1) END FROM _prom_catalog.ids_epoch LIMIT 1", int64(lowestEpoch))
+	var val []byte
+	if err = row.Scan(&val); err != nil {
 		return err, lowestMinTime
 	}
-	defer results.Close()
+
+	if err = tx.Commit(ctx); err != nil {
+		return err, lowestMinTime
+	}
+	metrics.IngestorRowsPerBatch.With(labelsCopier).Observe(float64(numRowsTotal))
+	metrics.IngestorInsertsPerBatch.With(labelsCopier).Observe(float64(len(reqs)))
 
 	var affectedMetrics uint64
-	for _, numRows := range numRowsPerInsert {
-		var insertedRows int64
-		err := results.QueryRow().Scan(&insertedRows)
-		if err != nil {
-			return err, lowestMinTime
-		}
-		numRowsExpected := int64(numRows)
-		if numRowsExpected != insertedRows {
+	for idx, numRows := range numRowsPerInsert {
+		if numRows != insertedRows[idx] {
 			affectedMetrics++
-			registerDuplicates(numRowsExpected - insertedRows)
+			registerDuplicates(int64(numRows - insertedRows[idx]))
 		}
 	}
 	metrics.IngestorItems.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "sample"}).Add(float64(totalSamples))
 	metrics.IngestorItems.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "exemplar"}).Add(float64(totalExemplars))
 
-	var val []byte
-	row := results.QueryRow()
-	err = row.Scan(&val)
-	if err != nil {
-		return err, lowestMinTime
-	}
 	reportDuplicates(affectedMetrics)
-	metrics.IngestorInsertDuration.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "sample"}).Observe(time.Since(start).Seconds())
+	metrics.IngestorInsertDuration.With(prometheus.Labels{"type": "metric", "subsystem": "copier", "kind": "sample"}).Observe(time.Since(insertStart).Seconds())
 	return nil, lowestMinTime
+}
+
+func createTempIngestTable(ctx context.Context, tx pgx.Tx, table, schema, prefix string) (pgx.Identifier, error) {
+	var tempTableNameRawString string
+	row := tx.QueryRow(ctx, "SELECT _prom_catalog.create_ingest_temp_table($1, $2, $3)", table, schema, prefix)
+	if err := row.Scan(&tempTableNameRawString); err != nil {
+		return nil, err
+	}
+	return pgx.Identifier{tempTableNameRawString}, nil
 }
 
 func insertMetadata(conn pgxconn.PgxConn, reqs []pgmodel.Metadata) (insertedRows uint64, err error) {

--- a/pkg/pgxconn/pgx_conn.go
+++ b/pkg/pgxconn/pgx_conn.go
@@ -70,6 +70,7 @@ type PgxConn interface {
 	NewBatch() PgxBatch
 	SendBatch(ctx context.Context, b PgxBatch) (pgx.BatchResults, error)
 	Acquire(ctx context.Context) (*pgxpool.Conn, error)
+	BeginTx(ctx context.Context) (pgx.Tx, error)
 }
 
 type PgxRows interface {
@@ -204,6 +205,10 @@ func (p *connImpl) SendBatch(ctx context.Context, b PgxBatch) (pgx.BatchResults,
 
 func (p *connImpl) Acquire(ctx context.Context) (*pgxpool.Conn, error) {
 	return p.Conn.Acquire(ctx)
+}
+
+func (p *connImpl) BeginTx(ctx context.Context) (pgx.Tx, error) {
+	return p.Conn.BeginTx(ctx, pgx.TxOptions{})
 }
 
 // filters out indentation characters from the

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -72,3 +72,4 @@ func (mockPgxConn) SendBatch(ctx context.Context, b pgxconn.PgxBatch) (pgx.Batch
 	return nil, nil
 }
 func (mockPgxConn) Acquire(ctx context.Context) (*pgxpool.Conn, error) { return nil, nil }
+func (mockPgxConn) BeginTx(ctx context.Context) (pgx.Tx, error)        { return nil, nil }

--- a/pkg/tests/end_to_end_tests/concurrent_sql_test.go
+++ b/pkg/tests/end_to_end_tests/concurrent_sql_test.go
@@ -25,10 +25,10 @@ func testConcurrentMetricTable(t testing.TB, db *pgxpool.Pool, metricName string
 	var name *string
 	err := db.QueryRow(context.Background(), "SELECT id, table_name FROM _prom_catalog.get_or_create_metric_table_name($1)", metricName).Scan(&id, &name)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if id == nil || name == nil || *name == "" {
-		t.Fatalf("NULL found")
+		t.Error("NULL found")
 	}
 	return *id
 }
@@ -37,10 +37,10 @@ func testConcurrentNewLabel(t testing.TB, db *pgxpool.Pool, labelName string) in
 	var id *int64
 	err := db.QueryRow(context.Background(), "SELECT _prom_catalog.get_new_label_id($1, $1)", labelName).Scan(&id)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if id == nil {
-		t.Fatalf("NULL found")
+		t.Error("NULL found")
 	}
 	return *id
 }
@@ -50,10 +50,10 @@ func testConcurrentCreateSeries(t testing.TB, db *pgxpool.Pool, index int, metri
 	err := db.QueryRow(context.Background(), "SELECT _prom_catalog.create_series((SELECT id FROM _prom_catalog.metric WHERE metric_name=$3), $1, array[(SELECT id FROM _prom_catalog.label WHERE key = '__name__' AND value=$3), $2::int])",
 		metricName, index, metricName).Scan(&id)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if id == nil {
-		t.Fatalf("NULL found")
+		t.Error("NULL found")
 	}
 	return *id
 }
@@ -63,10 +63,10 @@ func testConcurrentGetSeries(t testing.TB, db *pgxpool.Pool, metricName string) 
 	err := db.QueryRow(context.Background(), "SELECT series_id FROM _prom_catalog.get_or_create_series_id_for_kv_array($1, array['__name__'], array[$1])",
 		metricName).Scan(&id)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if id == nil {
-		t.Fatalf("NULL found")
+		t.Error("NULL found")
 	}
 	return *id
 }
@@ -76,10 +76,10 @@ func testConcurrentGOCMetricTable(t testing.TB, db *pgxpool.Pool, metricName str
 	var name *string
 	err := db.QueryRow(context.Background(), "SELECT id, table_name FROM _prom_catalog.get_or_create_metric_table_name($1)", metricName).Scan(&id, &name)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if id == nil || name == nil {
-		t.Fatalf("NULL found")
+		t.Error("NULL found")
 	}
 	return *id
 }
@@ -144,7 +144,7 @@ func TestConcurrentSQL(t *testing.T) {
 				defer wg.Done()
 				_, err := db.Exec(context.Background(), "CALL _prom_catalog.finalize_metric_creation()")
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
 				}
 			}()
 			metric := fmt.Sprintf("test1"+strings.Repeat("long_name_", 10)+"goc_metric_%d", i)
@@ -168,7 +168,7 @@ func TestConcurrentSQL(t *testing.T) {
 				defer wg.Done()
 				_, err := db.Exec(context.Background(), "CALL _prom_catalog.finalize_metric_creation()")
 				if err != nil {
-					t.Fatal(err)
+					t.Error(err)
 				}
 			}()
 			metric = fmt.Sprintf("test2"+strings.Repeat("long_name_", 10)+"goc_metric_%d", i)
@@ -224,12 +224,12 @@ func testConcurrentInsertSimple(t testing.TB, db *pgxpool.Pool, metric string) {
 
 	ingestor, err := ingstr.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	defer ingestor.Close()
 	_, _, err = ingestor.Ingest(context.Background(), newWriteRequestWithTs(copyMetrics(metrics)))
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 
@@ -283,13 +283,13 @@ func testConcurrentInsertAdvanced(t testing.TB, db *pgxpool.Pool) {
 
 	ingestor, err := ingstr.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	defer ingestor.Close()
 	_, _, err = ingestor.Ingest(context.Background(), newWriteRequestWithTs(copyMetrics(metrics)))
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 }
 

--- a/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
+++ b/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
@@ -498,7 +498,7 @@ func TestHAMultipleChecksBetweenTicks(t *testing.T) {
 }
 
 func checkDbState(t testing.TB, db *pgxpool.Pool, output haTestOutput) bool {
-	row := db.QueryRow(context.Background(), "SELECT max(time), count(*) FROM metric")
+	row := db.QueryRow(context.Background(), "SELECT max(time), count(*) FROM prom_data.metric")
 	var maxTimeInDb time.Time
 	var rowsInDb int
 	if err := row.Scan(&maxTimeInDb, &rowsInDb); err != nil {

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -182,16 +182,16 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 
 				tsResp, tsErr := client.Do(tsReq)
 				if tsErr != nil {
-					t.Fatalf("unexpected error returned from TS client:\n%s\n", tsErr.Error())
+					t.Errorf("unexpected error returned from TS client:\n%s\n", tsErr.Error())
 					return
 				}
 				if failOnStatusErrors && tsResp.StatusCode != http.StatusOK {
-					t.Fatalf("promscale: expected status code %d, received %d. Info: %v", http.StatusOK, tsResp.StatusCode, log)
+					t.Errorf("promscale: expected status code %d, received %d. Info: %v", http.StatusOK, tsResp.StatusCode, log)
 				}
 
 				promResp, promErr := client.Do(promReq)
 				if promErr != nil {
-					t.Fatalf("unexpected error returned from Prometheus client:\n%s\n", promErr.Error())
+					t.Errorf("unexpected error returned from Prometheus client:\n%s\n", promErr.Error())
 					return
 				}
 
@@ -201,13 +201,13 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 					promResp, promErr = client.Do(promReq)
 
 					if promErr != nil {
-						t.Fatalf("unexpected error returned from Prometheus client when retrying:\n%s\n", promErr.Error())
+						t.Errorf("unexpected error returned from Prometheus client when retrying:\n%s\n", promErr.Error())
 						return
 					}
 				}
 
 				if failOnStatusErrors && promResp.StatusCode != http.StatusOK {
-					t.Fatalf("prometheus: expected status code %d, received %d", http.StatusOK, tsResp.StatusCode)
+					t.Errorf("prometheus: expected status code %d, received %d", http.StatusOK, tsResp.StatusCode)
 				}
 
 				compareHTTPHeaders(t, promResp.Header, tsResp.Header)
@@ -215,7 +215,7 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 				promContent, err := ioutil.ReadAll(promResp.Body)
 
 				if err != nil {
-					t.Fatalf("unexpected error returned when reading Prometheus response body:\n%s\n", err.Error())
+					t.Errorf("unexpected error returned when reading Prometheus response body:\n%s\n", err.Error())
 					return
 				}
 				defer promResp.Body.Close()
@@ -223,14 +223,14 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 				tsContent, err := ioutil.ReadAll(tsResp.Body)
 
 				if err != nil {
-					t.Fatalf("unexpected error returned when reading connector response body:\n%s\n", err.Error())
+					t.Errorf("unexpected error returned when reading connector response body:\n%s\n", err.Error())
 					return
 				}
 				defer tsResp.Body.Close()
 
 				err = comparator(promContent, tsContent, log)
 				if err != nil {
-					t.Fatalf("%s gives %s", log, err)
+					t.Errorf("%s gives %s", log, err)
 					return
 				}
 			}()

--- a/pkg/tests/testsupport/metric_loader.go
+++ b/pkg/tests/testsupport/metric_loader.go
@@ -264,9 +264,9 @@ func (si *sampleIngestor) ingestSamples(ingest IngestFunc) {
 			counter := 0
 			for ts := range si.shards[shard] {
 				if counter == si.batchSize {
-					req = prompb.WriteRequest{Timeseries: make([]prompb.TimeSeries, si.batchSize)}
 					reqCh <- req
 					counter = 0
+					req = prompb.WriteRequest{Timeseries: make([]prompb.TimeSeries, si.batchSize)}
 				} else {
 					req.Timeseries[counter] = ts
 					counter++


### PR DESCRIPTION
We try COPY into metric table. If there is a conflict situation
(eg. duplicate key violation) we catch it on client and retry
by COPYing to temporary table and doing ON CONFLICT insert from there.