### PR TITLE
Use int32 for metric and label ids

### DIFF
--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -98,7 +98,7 @@ func (m mockLabelsReader) LabelValues(string) ([]string, error) {
 	return nil, nil
 }
 
-func (m mockLabelsReader) LabelsForIdMap(idMap map[int64]labels.Label) (err error) {
+func (m mockLabelsReader) LabelsForIdMap(idMap map[int32]labels.Label) (err error) {
 	return nil
 }
 

--- a/pkg/pgmodel/ingestor/ingestor_sql_test.go
+++ b/pkg/pgmodel/ingestor/ingestor_sql_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	metricID  int64  = 1
+	metricID  int32  = 1
 	tableName string = "table name"
 )
 
@@ -543,7 +543,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"metric_0"},
-					Results: model.RowResults{{int64(1), "metric_0", false}},
+					Results: model.RowResults{{int32(1), "metric_0", false}},
 					Err:     error(nil),
 				},
 				{
@@ -580,7 +580,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"metric_0"},
-					Results: model.RowResults{{int64(1), "metric_0", false}},
+					Results: model.RowResults{{int32(1), "metric_0", false}},
 					Err:     error(nil),
 				},
 
@@ -640,7 +640,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"metric_0"},
-					Results: model.RowResults{{int64(1), "metric_0", false}},
+					Results: model.RowResults{{int32(1), "metric_0", false}},
 					Err:     error(nil),
 				},
 
@@ -702,7 +702,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"metric_0"},
-					Results: model.RowResults{{int64(1), "metric_0", false}},
+					Results: model.RowResults{{int32(1), "metric_0", false}},
 					Err:     error(nil),
 				},
 
@@ -785,7 +785,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"metric_0"},
-					Results: model.RowResults{{int64(1), "metric_0", true}},
+					Results: model.RowResults{{int32(1), "metric_0", true}},
 					Err:     error(nil),
 				},
 				{Sql: "CALL _prom_catalog.finalize_metric_creation()"},

--- a/pkg/pgmodel/ingestor/metric_batcher_test.go
+++ b/pkg/pgmodel/ingestor/metric_batcher_test.go
@@ -21,7 +21,7 @@ func TestMetricTableName(t *testing.T) {
 	testCases := []struct {
 		name        string
 		tableName   string
-		metricID    int64
+		metricID    int32
 		errExpected bool
 		sqlQueries  []model.SqlQuery
 	}{
@@ -33,7 +33,7 @@ func TestMetricTableName(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"t1"},
-					Results: model.RowResults{{int64(23), "res1", true}},
+					Results: model.RowResults{{int32(23), "res1", true}},
 				},
 			},
 		},
@@ -45,7 +45,7 @@ func TestMetricTableName(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 					Args:    []interface{}{"t1"},
-					Results: model.RowResults{{int64(24), "res2", true}},
+					Results: model.RowResults{{int32(24), "res2", true}},
 				},
 			},
 		},
@@ -105,12 +105,12 @@ func TestMetricTableName(t *testing.T) {
 func TestInitializeMetricBatcher(t *testing.T) {
 	metricName := "mock_metric"
 	metricTableName := "mock_metric_table_name"
-	metricID := int64(1)
+	metricID := int32(1)
 	sqlQueries := []model.SqlQuery{
 		{
 			Sql:     "SELECT id, table_name, possibly_new FROM _prom_catalog.get_or_create_metric_table_name($1)",
 			Args:    []interface{}{metricName},
-			Results: model.RowResults{{int64(1), metricTableName, true}},
+			Results: model.RowResults{{int32(1), metricTableName, true}},
 		},
 	}
 	mock := model.NewSqlRecorder(sqlQueries, t)

--- a/pkg/pgmodel/model/metric.go
+++ b/pkg/pgmodel/model/metric.go
@@ -2,11 +2,11 @@ package model
 
 // MetricInfo contains all the database specific metric data.
 type MetricInfo struct {
-	MetricID                            int64
+	MetricID                            int32
 	TableSchema, TableName, SeriesTable string
 }
 
 // Len returns the memory size of MetricInfo in bytes.
 func (v MetricInfo) Len() int {
-	return 8 + len(v.TableSchema) + len(v.TableName) + len(v.SeriesTable)
+	return 4 + len(v.TableSchema) + len(v.TableName) + len(v.SeriesTable)
 }

--- a/pkg/pgmodel/querier/querier.go
+++ b/pkg/pgmodel/querier/querier.go
@@ -67,5 +67,5 @@ func (e errorSeriesSet) Warnings() storage.Warnings { return nil }
 func (e errorSeriesSet) Close()                     {}
 
 type labelQuerier interface {
-	LabelsForIdMap(idMap map[int64]labels.Label) (err error)
+	LabelsForIdMap(idMap map[int32]labels.Label) (err error)
 }

--- a/pkg/pgmodel/querier/querier_sql_test.go
+++ b/pkg/pgmodel/querier/querier_sql_test.go
@@ -133,7 +133,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "foo"},
-					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Results: model.RowResults{{int32(1), "prom_data", "foo", "foo"}},
 					Err:     error(nil),
 				},
 				{
@@ -253,7 +253,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "foo"},
-					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Results: model.RowResults{{int32(1), "prom_data", "foo", "foo"}},
 					Err:     error(nil),
 				},
 				{
@@ -266,13 +266,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"AND time <= '1970-01-01T00:00:02Z'\n\t" +
 						"GROUP BY s.id",
 					Args:    []interface{}(nil),
-					Results: model.RowResults{{[]int64{1}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{1}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:    []interface{}{[]int64{1}},
-					Results: model.RowResults{{[]int64{1}, []string{"__name__"}, []string{"foo"}}},
+					Args:    []interface{}{[]int32{1}},
+					Results: model.RowResults{{[]int32{1}, []string{"__name__"}, []string{"foo"}}},
 					Err:     error(nil),
 				},
 			},
@@ -296,7 +296,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "bar"},
-					Results: model.RowResults{{int64(1), "prom_data", "bar", "bar"}},
+					Results: model.RowResults{{int32(1), "prom_data", "bar", "bar"}},
 					Err:     error(nil),
 				},
 				{
@@ -310,13 +310,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 						GROUP BY series_id
 						) as result ON (result.value_array is not null AND result.series_id = series.id)`,
 					Args:    nil,
-					Results: model.RowResults{{[]int64{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:    []interface{}{[]int64{2}},
-					Results: model.RowResults{{[]int64{2}, []string{"__name__"}, []string{"bar"}}},
+					Args:    []interface{}{[]int32{2}},
+					Results: model.RowResults{{[]int32{2}, []string{"__name__"}, []string{"bar"}}},
 					Err:     error(nil),
 				},
 			},
@@ -343,7 +343,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "custom"},
-					Results: model.RowResults{{int64(1), "custom_schema", "custom", "bar"}},
+					Results: model.RowResults{{int32(1), "custom_schema", "custom", "bar"}},
 					Err:     error(nil),
 				},
 				{
@@ -357,13 +357,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 						GROUP BY series_id
 						) as result ON (result.value_array is not null AND result.series_id = series.id)`,
 					Args:    nil,
-					Results: model.RowResults{{[]int64{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:    []interface{}{[]int64{2}},
-					Results: model.RowResults{{[]int64{2}, []string{"__name__"}, []string{"bar"}}},
+					Args:    []interface{}{[]int32{2}},
+					Results: model.RowResults{{[]int32{2}, []string{"__name__"}, []string{"bar"}}},
 					Err:     error(nil),
 				},
 			},
@@ -391,7 +391,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "bar"},
-					Results: model.RowResults{{int64(1), "prom_data", "bar", "bar"}},
+					Results: model.RowResults{{int32(1), "prom_data", "bar", "bar"}},
 					Err:     error(nil),
 				},
 				{
@@ -405,13 +405,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 						GROUP BY series_id
 						) as result ON (result.value_array is not null AND result.series_id = series.id)`,
 					Args:    nil,
-					Results: model.RowResults{{[]int64{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:    []interface{}{[]int64{2}},
-					Results: model.RowResults{{[]int64{2}, []string{"__name__"}, []string{"bar"}}},
+					Args:    []interface{}{[]int32{2}},
+					Results: model.RowResults{{[]int32{2}, []string{"__name__"}, []string{"bar"}}},
 					Err:     error(nil),
 				},
 			},
@@ -451,13 +451,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "foo"},
-					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Results: model.RowResults{{int32(1), "prom_data", "foo", "foo"}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "bar"},
-					Results: model.RowResults{{int64(1), "prom_data", "bar", "bar"}},
+					Results: model.RowResults{{int32(1), "prom_data", "bar", "bar"}},
 					Err:     error(nil),
 				},
 				{
@@ -470,7 +470,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"AND time <= '1970-01-01T00:00:02Z'\n\t" +
 						"GROUP BY s.id",
 					Args:    []interface{}(nil),
-					Results: model.RowResults{{[]int64{3}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{3}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
@@ -483,14 +483,14 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"AND time <= '1970-01-01T00:00:02Z'\n\t" +
 						"GROUP BY s.id",
 					Args:    []interface{}(nil),
-					Results: model.RowResults{{[]int64{4}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{4}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:           "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:          []interface{}{[]int64{3, 4}},
+					Args:          []interface{}{[]int32{3, 4}},
 					ArgsUnordered: true,
-					Results:       model.RowResults{{[]int64{3, 4}, []string{"__name__", "__name__"}, []string{"foo", "bar"}}},
+					Results:       model.RowResults{{[]int32{3, 4}, []string{"__name__", "__name__"}, []string{"foo", "bar"}}},
 					Err:           error(nil),
 				},
 			},
@@ -510,7 +510,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "foo"},
-					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Results: model.RowResults{{int32(1), "prom_data", "foo", "foo"}},
 					Err:     error(nil),
 				},
 				{
@@ -555,7 +555,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "metric"},
-					Results: model.RowResults{{int64(1), "prom_data", "metric", "metric"}},
+					Results: model.RowResults{{int32(1), "prom_data", "metric", "metric"}},
 					Err:     error(nil),
 				},
 				{
@@ -568,13 +568,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"AND time <= '1970-01-01T00:00:02Z'\n\t" +
 						"GROUP BY s.id",
 					Args:    []interface{}(nil),
-					Results: model.RowResults{{[]int64{7}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{7}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:    []interface{}{[]int64{7}},
-					Results: model.RowResults{{[]int64{7}, []string{"foo"}, []string{"bar"}}},
+					Args:    []interface{}{[]int32{7}},
+					Results: model.RowResults{{[]int32{7}, []string{"foo"}, []string{"bar"}}},
 					Err:     error(nil),
 				},
 			},
@@ -616,7 +616,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "metric"},
-					Results: model.RowResults{{int64(1), "prom_data", "metric", "metric"}},
+					Results: model.RowResults{{int32(1), "prom_data", "metric", "metric"}},
 					Err:     error(nil),
 				},
 				{
@@ -629,14 +629,14 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"AND time <= '1970-01-01T00:00:02Z'\n\t" +
 						"GROUP BY s.id",
 					Args:    []interface{}(nil),
-					Results: model.RowResults{{[]int64{8, 9}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{8, 9}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:           "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:          []interface{}{[]int64{9, 8}},
+					Args:          []interface{}{[]int32{9, 8}},
 					ArgsUnordered: true,
-					Results:       model.RowResults{{[]int64{8, 9}, []string{"foo", "foo2"}, []string{"bar", "bar2"}}},
+					Results:       model.RowResults{{[]int32{8, 9}, []string{"foo", "foo2"}, []string{"bar", "bar2"}}},
 					Err:           error(nil),
 				},
 			},
@@ -677,7 +677,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "metric"},
-					Results: model.RowResults{{int64(1), "prom_data", "metric", "metric"}},
+					Results: model.RowResults{{int32(1), "prom_data", "metric", "metric"}},
 					Err:     error(nil),
 				},
 				{
@@ -690,13 +690,13 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"AND time <= '1970-01-01T00:00:02Z'\n\t" +
 						"GROUP BY s.id",
 					Args:    []interface{}(nil),
-					Results: model.RowResults{{[]int64{10}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
+					Results: model.RowResults{{[]int32{10}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
-					Args:    []interface{}{[]int64{10}},
-					Results: model.RowResults{{[]int64{10}, []string{"foo2"}, []string{"bar2"}}},
+					Args:    []interface{}{[]int32{10}},
+					Results: model.RowResults{{[]int32{10}, []string{"foo2"}, []string{"bar2"}}},
 					Err:     error(nil),
 				},
 			},

--- a/pkg/pgmodel/querier/query_builder.go
+++ b/pkg/pgmodel/querier/query_builder.go
@@ -97,7 +97,7 @@ func BuildSubQueries(matchers []*labels.Matcher) (*clauseBuilder, error) {
 	return cb, err
 }
 
-func initLabelIdIndexForSamples(index map[int64]labels.Label, rows []sampleRow) {
+func initLabelIdIndexForSamples(index map[int32]labels.Label, rows []sampleRow) {
 	for i := range rows {
 		for _, id := range rows[i].labelIds {
 			//id==0 means there is no label for the key, so nothing to look up
@@ -111,7 +111,7 @@ func initLabelIdIndexForSamples(index map[int64]labels.Label, rows []sampleRow) 
 
 func buildTimeSeries(rows []sampleRow, lr lreader.LabelsReader) ([]*prompb.TimeSeries, error) {
 	results := make([]*prompb.TimeSeries, 0, len(rows))
-	labelIDMap := make(map[int64]labels.Label)
+	labelIDMap := make(map[int32]labels.Label)
 	initLabelIdIndexForSamples(labelIDMap, rows)
 
 	err := lr.LabelsForIdMap(labelIDMap)

--- a/pkg/pgmodel/querier/row.go
+++ b/pkg/pgmodel/querier/row.go
@@ -133,7 +133,7 @@ func (dstwrapper *float8ArrayWrapper) DecodeBinary(ci *pgtype.ConnInfo, src []by
 }
 
 type sampleRow struct {
-	labelIds       []int64
+	labelIds       []int32
 	times          TimestampSeries
 	values         *pgtype.Float8Array
 	err            error

--- a/pkg/pgmodel/querier/series_exemplar.go
+++ b/pkg/pgmodel/querier/series_exemplar.go
@@ -24,7 +24,7 @@ const getExemplarLabelPositions = "SELECT * FROM _prom_catalog.get_exemplar_labe
 
 type exemplarSeriesRow struct {
 	metricName string
-	labelIds   []int64
+	labelIds   []int32
 	data       []exemplarRow
 }
 
@@ -46,7 +46,7 @@ func getExemplarSeriesRows(metricName string, in pgxconn.PgxRows) (rows []exempl
 		var (
 			err      error
 			row      exemplarRow
-			labelIds []int64
+			labelIds []int32
 		)
 		err = in.Scan(&labelIds, &row.time, &row.value, &row.labelValues)
 		if err != nil {
@@ -88,7 +88,7 @@ func prepareExemplarQueryResult(tools *queryTools, queryResult exemplarSeriesRow
 		metric   = queryResult.metricName
 		labelIds = queryResult.labelIds
 	)
-	index := make(map[int64]labels.Label)
+	index := make(map[int32]labels.Label)
 	initLabelIdIndexForExemplars(index, queryResult.labelIds)
 
 	labelsReader := tools.labelsReader
@@ -142,7 +142,7 @@ func getPositionIndex(tools *queryTools, posCache cache.PositionCache, metric st
 	return keyPosIndex, nil
 }
 
-func initLabelIdIndexForExemplars(index map[int64]labels.Label, labelIds []int64) {
+func initLabelIdIndexForExemplars(index map[int32]labels.Label, labelIds []int32) {
 	for _, labelId := range labelIds {
 		if labelId == 0 {
 			// no label to look-up for.

--- a/pkg/pgmodel/querier/series_exemplar_test.go
+++ b/pkg/pgmodel/querier/series_exemplar_test.go
@@ -29,10 +29,10 @@ func TestPrepareExemplarQueryResult(t *testing.T) {
 	}
 	seriesRow := exemplarSeriesRow{
 		metricName: "test_metric_exemplar",
-		labelIds:   []int64{1, 3},
+		labelIds:   []int32{1, 3},
 		data:       exemplarRows,
 	}
-	lrCache := newMockLabelsReader([]int64{1, 3}, []labels.Label{{Name: "__name__", Value: "test_metric_exemplar"}, {Name: "instance", Value: "localhost:9100"}})
+	lrCache := newMockLabelsReader([]int32{1, 3}, []labels.Label{{Name: "__name__", Value: "test_metric_exemplar"}, {Name: "instance", Value: "localhost:9100"}})
 
 	conn := model.NewSqlRecorder([]model.SqlQuery{}, t)
 	exemplarCache := cache.NewExemplarLabelsPosCache(cache.Config{ExemplarKeyPosCacheSize: 3})
@@ -63,14 +63,14 @@ func getExemplarPosIndices() map[string]int {
 }
 
 type mockLabelsReader struct {
-	items map[int64]labels.Label
+	items map[int32]labels.Label
 }
 
-func newMockLabelsReader(keys []int64, lbls []labels.Label) mockLabelsReader {
+func newMockLabelsReader(keys []int32, lbls []labels.Label) mockLabelsReader {
 	if len(keys) != len(lbls) {
 		panic("keys length and labels length must be same")
 	}
-	items := make(map[int64]labels.Label)
+	items := make(map[int32]labels.Label)
 	l := len(keys)
 	for i := 0; i < l; i++ {
 		items[keys[i]] = lbls[i]
@@ -87,7 +87,7 @@ func (m mockLabelsReader) LabelValues(_ string) ([]string, error) {
 	return nil, nil
 }
 
-func (m mockLabelsReader) LabelsForIdMap(index map[int64]labels.Label) error {
+func (m mockLabelsReader) LabelsForIdMap(index map[int32]labels.Label) error {
 	for seriesId := range index {
 		if lbls, present := m.items[seriesId]; present {
 			index[seriesId] = lbls
@@ -97,6 +97,6 @@ func (m mockLabelsReader) LabelsForIdMap(index map[int64]labels.Label) error {
 }
 
 // LabelsForIds returns label names and values for the supplied IDs.
-func (m mockLabelsReader) LabelsForIds(ids []int64) (lls labels.Labels, err error) {
+func (m mockLabelsReader) LabelsForIds(ids []int32) (lls labels.Labels, err error) {
 	return nil, nil
 }

--- a/pkg/pgmodel/querier/series_set.go
+++ b/pkg/pgmodel/querier/series_set.go
@@ -26,7 +26,7 @@ const (
 type pgxSamplesSeriesSet struct {
 	rowIdx     int
 	rows       []sampleRow
-	labelIDMap map[int64]labels.Label
+	labelIDMap map[int32]labels.Label
 	err        error
 	querier    labelQuerier
 }
@@ -35,7 +35,7 @@ type pgxSamplesSeriesSet struct {
 var _ storage.SeriesSet = (*pgxSamplesSeriesSet)(nil)
 
 func buildSeriesSet(rows []sampleRow, querier labelQuerier) SeriesSet {
-	labelIDMap := make(map[int64]labels.Label)
+	labelIDMap := make(map[int32]labels.Label)
 	initLabelIdIndexForSamples(labelIDMap, rows)
 
 	err := querier.LabelsForIdMap(labelIDMap)
@@ -114,7 +114,7 @@ func (p *pgxSamplesSeriesSet) At() storage.Series {
 	return ps
 }
 
-func getLabelsFromLabelIds(labelIds []int64, index map[int64]labels.Label) (labels.Labels, error) {
+func getLabelsFromLabelIds(labelIds []int32, index map[int32]labels.Label) (labels.Labels, error) {
 	lls := make([]labels.Label, 0, len(labelIds))
 	for _, id := range labelIds {
 		if id == 0 {


### PR DESCRIPTION
## Description

In the database, these ids are stored as INTEGER values which correspond
to int32.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
