### PR TITLE
Thread-safe test result verification

### DIFF
--- a/pkg/internal/testhelpers/postgres_container.go
+++ b/pkg/internal/testhelpers/postgres_container.go
@@ -7,7 +7,6 @@ package testhelpers
 import (
 	"context"
 	"fmt"
-	"github.com/blang/semver/v4"
 	"io"
 	"os"
 	"regexp"
@@ -15,12 +14,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blang/semver/v4"
+
 	"github.com/docker/go-connections/nat"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	_ "github.com/jackc/pgx/v4/stdlib"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -154,27 +155,27 @@ func getRoleUser(role string) string {
 func setupRole(t testing.TB, dbName string, role string) {
 	user := getRoleUser(role)
 	dbOwner, err := pgx.Connect(context.Background(), PgConnectURL(dbName, Superuser))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer dbOwner.Close(context.Background())
 
 	_, err = dbOwner.Exec(context.Background(), fmt.Sprintf("CALL _prom_catalog.execute_everywhere(NULL, $$ GRANT %s TO %s $$);", role, user))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func MakePromUserPromAdmin(t testing.TB, dbName string) {
 	db, err := pgx.Connect(context.Background(), PgConnectURL(dbName, Superuser))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer db.Close(context.Background())
 
 	_, err = db.Exec(context.Background(), fmt.Sprintf("CALL _prom_catalog.execute_everywhere('distributed_prom_user', $$ GRANT prom_admin TO %s $$);", promUser))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func PgxPoolWithRole(t testing.TB, dbName string, role string) *pgxpool.Pool {
 	user := getRoleUser(role)
 	setupRole(t, dbName, role)
 	pool, err := pgxpool.Connect(context.Background(), PgConnectURLUser(dbName, user))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	return pool
 }
 
@@ -195,7 +196,7 @@ func GetReadOnlyConnection(t testing.TB, DBName string) *pgxpool.Pool {
 	setupRole(t, DBName, role)
 
 	pgConfig, err := pgxpool.ParseConfig(PgConnectURLUser(DBName, user))
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	pgConfig.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
 		_, err := conn.Exec(context.Background(), "SET SESSION CHARACTERISTICS AS TRANSACTION READ ONLY")

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -19,7 +19,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/sergi/go-diff/diffmatchpatch"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"github.com/timescale/promscale/pkg/pgmodel/common/errors"
 	"github.com/timescale/promscale/pkg/pgmodel/model/pgutf8str"
 	"github.com/timescale/promscale/pkg/pgxconn"
@@ -145,21 +145,21 @@ func (r *SqlRecorder) checkQuery(sql string, args ...interface{}) (RowResults, e
 		r.t.Errorf("@ %d unexpected query:\ngot:\n\t'%s'\nexpected:\n\t'%s'\ndiff:\n\t%v", idx, sql, row.Sql, dmp.DiffPrettyText(diffs))
 	}
 
-	require.Equal(r.t, len(row.Args), len(args), "Args of different lengths @ %d %s", idx, sql)
+	assert.Equal(r.t, len(row.Args), len(args), "Args of different lengths @ %d %s", idx, sql)
 	for i := range row.Args {
 		switch row.Args[i].(type) {
 		case pgtype.TextEncoder:
 			ci := pgtype.NewConnInfo()
 			got, err := args[i].(pgtype.TextEncoder).EncodeText(ci, nil)
-			require.NoError(r.t, err)
+			assert.NoError(r.t, err)
 			expected, err := row.Args[i].(pgtype.TextEncoder).EncodeText(ci, nil)
-			require.NoError(r.t, err)
-			require.Equal(r.t, string(expected), string(got), "sql args aren't equal for query # %v: %v", idx, sql)
+			assert.NoError(r.t, err)
+			assert.Equal(r.t, string(expected), string(got), "sql args aren't equal for query # %v: %v", idx, sql)
 		default:
 			if !row.ArgsUnordered {
-				require.Equal(r.t, row.Args[i], args[i], "sql args aren't equal for query # %v: %v", idx, sql)
+				assert.Equal(r.t, row.Args[i], args[i], "sql args aren't equal for query # %v: %v", idx, sql)
 			} else {
-				require.ElementsMatch(r.t, row.Args[i], args[i], "sql args aren't equal for query # %v: %v", idx, sql)
+				assert.ElementsMatch(r.t, row.Args[i], args[i], "sql args aren't equal for query # %v: %v", idx, sql)
 			}
 		}
 	}

--- a/pkg/promql/test.go
+++ b/pkg/promql/test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb"
 	"github.com/prometheus/prometheus/util/teststorage"
 	"github.com/prometheus/prometheus/util/testutil"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"github.com/timescale/promscale/pkg/pgmodel/querier"
 )
 
@@ -62,7 +62,7 @@ type TestStorage struct {
 // that removes all associated files on closing.
 func NewTestStorage(t testutil.T) *TestStorage {
 	dir, err := ioutil.TempDir("", "test_storage")
-	require.NoError(t, err, "opening test dir failed")
+	assert.NoError(t, err, "opening test dir failed")
 
 	// Tests just load data for a series sequentially. Thus we
 	// need a long appendable window.
@@ -70,7 +70,7 @@ func NewTestStorage(t testutil.T) *TestStorage {
 	opts.MinBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	opts.MaxBlockDuration = int64(24 * time.Hour / time.Millisecond)
 	db, err := tsdb.Open(dir, nil, nil, opts, nil)
-	require.NoError(t, err, "opening test storage failed")
+	assert.NoError(t, err, "opening test storage failed")
 
 	return &TestStorage{DB: db, dir: dir}
 }
@@ -671,7 +671,7 @@ func (t *Test) exec(tc testCommand) error {
 func (t *Test) clear() {
 	if t.storage != nil {
 		err := t.storage.Close()
-		require.NoError(t.T, err, "Unexpected error while closing test storage.")
+		assert.NoError(t.T, err, "Unexpected error while closing test storage.")
 	}
 	if t.cancelCtx != nil {
 		t.cancelCtx()
@@ -696,7 +696,7 @@ func (t *Test) clear() {
 // Close closes resources associated with the Test.
 func (t *Test) Close() {
 	t.cancelCtx()
-	require.NoError(t.T, t.Storage().Close())
+	assert.NoError(t.T, t.Storage().Close())
 }
 
 // samplesAlmostEqual returns true if the two sample lines only differ by a
@@ -795,7 +795,7 @@ func (ll *LazyLoader) parse(input string) error {
 func (ll *LazyLoader) clear() {
 	if ll.storage != nil {
 		err := ll.storage.Close()
-		require.NoError(ll.T, err, "Unexpected error while closing test storage.")
+		assert.NoError(ll.T, err, "Unexpected error while closing test storage.")
 	}
 	if ll.cancelCtx != nil {
 		ll.cancelCtx()
@@ -870,5 +870,5 @@ func (ll *LazyLoader) Storage() storage.Storage {
 func (ll *LazyLoader) Close() {
 	ll.cancelCtx()
 	err := ll.storage.Close()
-	require.NoError(ll.T, err, "Unexpected error while closing test storage.")
+	assert.NoError(ll.T, err, "Unexpected error while closing test storage.")
 }


### PR DESCRIPTION
testify `require` functions have to run on the same thread as test function.
Otherwise in case of failure go routines
might be left hanging and blocking test completion. This is because `require`
is using FailNow() test function. So we switch to use `assert` for cases where
we run checks from different go routines.