### PR TITLE
fix pass []any as any in `logQueryStats`

### DIFF
--- a/pkg/pgxconn/pgx_conn.go
+++ b/pkg/pgxconn/pgx_conn.go
@@ -116,7 +116,7 @@ func (p *loggingPgxRows) Next() bool {
 	if !p.logged {
 		p.logged = true
 		res := p.Rows.Next()
-		logQueryStats(p.sqlQuery, p.startTime, p.args)()
+		logQueryStats(p.sqlQuery, p.startTime, p.args...)()
 		return res
 	}
 	return p.Rows.Next()
@@ -139,7 +139,7 @@ func logQueryStats(sql string, startTime time.Time, args ...interface{}) func() 
 		startTime = time.Now()
 	}
 	return func() {
-		log.Debug("msg", "SQL query timing", "query", filterIndentChars(sql), "args", fmt.Sprintf("%v", args...), "time", time.Since(startTime))
+		log.Debug("msg", "SQL query timing", "query", filterIndentChars(sql), "args", fmt.Sprintf("%v", args), "time", time.Since(startTime))
 	}
 }
 


### PR DESCRIPTION
## Description

fix pass []any as any in `Next`, call `logQueryStats` need with `args...`

and fix logQueryStats `fmt.Sprintf("%v", args...)` if args has many this will not format as expected.

see github actions result here https://github.com/alingse/asasalint/runs/7270916179?check_suite_focus=true

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
