### PR TITLE
copier: Skip err log if tx is closed after successful commit

### DIFF
--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -356,8 +356,8 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, onConflict bool, re
 	}
 	defer func() {
 		if tx != nil {
-			if err := tx.Rollback(ctx); err != nil {
-				log.Error(err)
+			if err := tx.Rollback(ctx); err != nil && err != pgx.ErrTxClosed {
+				log.Error("rollback err", err)
 			}
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Description

This fixes an incorrect log statement.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
