### PR TITLE
Use correct data types in otel span attributes

### DIFF
--- a/pkg/pgmodel/ingestor/dispatcher.go
+++ b/pkg/pgmodel/ingestor/dispatcher.go
@@ -237,7 +237,7 @@ func (p *pgxDispatcher) InsertTs(ctx context.Context, dataTS model.Data) (uint64
 		}
 		p.getMetricBatcher(metricName) <- &insertDataRequest{spanCtx: span.SpanContext(), metric: metricName, data: data, finished: workFinished, errChan: errChan}
 	}
-	span.SetAttributes(attribute.String("num_rows", fmt.Sprintf("%d", numRows)))
+	span.SetAttributes(attribute.Int64("num_rows", int64(numRows)))
 	span.SetAttributes(attribute.Int("num_metrics", len(rows)))
 	reportIncomingBatch(numRows)
 	reportOutgoing := func() {

--- a/pkg/pgmodel/ingestor/metric_batcher.go
+++ b/pkg/pgmodel/ingestor/metric_batcher.go
@@ -202,7 +202,7 @@ func sendBatches(firstReq *insertDataRequest, input chan *insertDataRequest, con
 					SpanContext: req.spanCtx,
 				},
 			),
-			trace.WithAttributes(attribute.String("insertable_count", fmt.Sprintf("%d", len(req.data)))),
+			trace.WithAttributes(attribute.Int("insertable_count", len(req.data))),
 		)
 		buf.addReq(req)
 		addSpan.End()


### PR DESCRIPTION
## Description

In few instances, string data type has been forced on int data. This commit just fixes those.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
