### PR TITLE
Fix double counting while populating `promscale_sql_database_chunks_count` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We use the following categories for changes:
 ### Fixed
 - Refine check for existence of `prom_schema_migrations` table [#1452]
 - Do not run rules-manager in `-db.read-only` mode [#1451]
+- Fix underlying metric(`promscale_sql_database_chunks_count`) which leads to false positive firing of PromscaleCompressionLow alert [#1494]
 
 ## [0.12.1] - 2022-06-29
 

--- a/docs/runbooks/PromscaleCompressionLow.md
+++ b/docs/runbooks/PromscaleCompressionLow.md
@@ -14,7 +14,7 @@ High disk usage by Promscale database
 3. Open psql
 4. Check total number of chunks: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false and compressed_chunk_id is null;`
 5. Check total number of compressed chunks: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false and compressed_chunk_id is not null;`
-6. Check number of maintenancec jobs: `select count(*) from timescaledb_information.jobs where proc_name = 'execute_maintenance_job'`
+6. Check number of maintenance jobs: `select count(*) from timescaledb_information.jobs where proc_name = 'execute_maintenance_job'`
 7. Run the following debugging query:
 
 ```postgresql

--- a/docs/runbooks/PromscaleCompressionLow.md
+++ b/docs/runbooks/PromscaleCompressionLow.md
@@ -12,9 +12,10 @@ High disk usage by Promscale database
 1. Open Grafana and navigate to Promscale dashboard
 2. Go to Database section and see `Compressesd chunks ratio`. If you see a ratio of < 10% then compression is not adequate in your system
 3. Open psql
-4. Check number of uncompressed chunks: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false and compressed_chunk_id=null;`
-5. Check number of maintenancec jobs: `select count(*) from timescaledb_information.jobs where proc_name = 'execute_maintenance_job'`
-6. Run the following debugging query:
+4. Check total number of chunks: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false and compressed_chunk_id is null;`
+5. Check total number of compressed chunks: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false and compressed_chunk_id is not null;`
+6. Check number of maintenancec jobs: `select count(*) from timescaledb_information.jobs where proc_name = 'execute_maintenance_job'`
+7. Run the following debugging query:
 
 ```postgresql
 SELECT 

--- a/pkg/pgmodel/metrics/database/metrics.go
+++ b/pkg/pgmodel/metrics/database/metrics.go
@@ -67,7 +67,8 @@ var metrics = []metricQueryWrap{
 				Help:      "Total number of chunks in TimescaleDB currently.",
 			},
 		),
-		query: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false`,
+		// Compressed_chunk_id is null for both yet to be compressed and already compressed chunks.
+		query: `select count(*)::bigint from _timescaledb_catalog.chunk where dropped=false and compressed_chunk_id is null`,
 	},
 	{
 		metric: prometheus.NewGauge(
@@ -78,7 +79,8 @@ var metrics = []metricQueryWrap{
 				Help:      "Total number of chunks created since creation of database.",
 			},
 		),
-		query: `select count(*)::bigint from _timescaledb_catalog.chunk`,
+		// Compressed_chunk_id is null for both yet to be compressed and already compressed chunks.
+		query: `select count(*)::bigint from _timescaledb_catalog.chunk where compressed_chunk_id is null`,
 	},
 	{
 		metric: prometheus.NewGauge(


### PR DESCRIPTION

## Description

### Problem statment
`PromscaleCompressionLow` alert fires regardless of a good compression ratio.

### Root cause

SQL query which populates `promscale_sql_database_chunks_count` is a sum of the below metrics,
1) Uncompressed Chunks
2) Proxy Chunks which points to Compressed Chunks
3) Compressed Chunks

However the total chunk count should be just (1) + (3), because (2) is already pointing to (3) and which leads to double counting.

### Solution

Fix the SQL query to consider entries which has `compressed_chunk_id` as null and this will be true for both (1) and (3).

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
