### PR TITLE
Update the docker-compose

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -36,7 +36,6 @@ services:
       - ${PWD}/rules.yml:/rules.yml
       - ${PWD}/alerts.yml:/alerts.yml
     environment:
-      PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
       PROMSCALE_TRACING_OTLP_SERVER_ADDRESS: ":9202"
       PROMSCALE_TELEMETRY_TRACE_OTEL_ENDPOINT: "otel-collector:4317"

--- a/docker-compose/high-availability/docker-compose.yaml
+++ b/docker-compose/high-availability/docker-compose.yaml
@@ -43,7 +43,6 @@ services:
     environment:
       PROMSCALE_METRICS_HIGH_AVAILABILITY: true
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
-      PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
 
   promscale-connector2:
@@ -61,7 +60,6 @@ services:
     environment:
       PROMSCALE_METRICS_HIGH_AVAILABILITY: true
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
-      PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
 
   node_exporter:

--- a/docker-compose/high-availability/prometheus1.yml
+++ b/docker-compose/high-availability/prometheus1.yml
@@ -34,7 +34,6 @@ scrape_configs:
     static_configs:
       - targets: ['node_exporter:9100']
   - job_name: promscale
-    metrics_path: '/metrics-text'
     static_configs:
       - targets: 
           - 'promscale-connector1:9201'

--- a/docker-compose/high-availability/prometheus2.yml
+++ b/docker-compose/high-availability/prometheus2.yml
@@ -32,7 +32,6 @@ scrape_configs:
     static_configs:
       - targets: ['node_exporter:9100']
   - job_name: promscale
-    metrics_path: '/metrics-text'
     static_configs:
       - targets: 
           - 'promscale-connector1:9201'

--- a/docker-compose/high-availability/test.sh
+++ b/docker-compose/high-availability/test.sh
@@ -34,7 +34,7 @@ cleanup() {
 trap cleanup EXIT
 
 leader_name() {
-    LEADER=`docker exec $1 wget -O - localhost:9201/metrics-text 2>&1 | grep -i "promscale_ha_cluster_leader_info.*1$" | sed 's/^.*replica=\"\(.*\)\".*$/\1/'`
+    LEADER=`docker exec $1 wget -O - localhost:9201/metrics 2>&1 | grep -i "promscale_ha_cluster_leader_info.*1$" | sed 's/^.*replica=\"\(.*\)\".*$/\1/'`
     echo "$LEADER"
 }
 
@@ -60,7 +60,7 @@ wait_for() {
     echo "waiting for $1"
 
     for i in `seq 10` ; do
-        if [ ! -z "$(docker exec $1 wget -O - localhost:9201/metrics-text)" ] ; then
+        if [ ! -z "$(docker exec $1 wget -O - localhost:9201/metrics)" ] ; then
           echo "connector up"
           return 0
         fi

--- a/docker-compose/prometheus.yml
+++ b/docker-compose/prometheus.yml
@@ -9,7 +9,6 @@ scrape_configs:
     static_configs:
       - targets: ['node_exporter:9100']
   - job_name: promscale
-    metrics_path: '/metrics-text'
     static_configs:
       - targets: ['promscale:9201']
 

--- a/docker-compose/promscale-demo/docker-compose.yaml
+++ b/docker-compose/promscale-demo/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_USER: postgres
-      POSTGRES_DB: otel_demo
+      POSTGRES_DB: tsdb
       POSTGRES_HOST_AUTH_METHOD: trust
 
   prometheus:
@@ -40,12 +40,9 @@ services:
       - ${PWD}/../rules.yml:/rules.yml
       - ${PWD}/../alerts.yml:/alerts.yml
     environment:
-      PROMSCALE_WEB_TELEMETRY_PATH: /metrics-text
-      PROMSCALE_DB_URI: postgres://postgres:password@timescaledb:5432/otel_demo?sslmode=allow
-      PROMSCALE_TELEMETRY_TRACE_OTEL_ENDPOINT: "collector:4317"
-      PROMSCALE_TELEMETRY_TRACE_SAMPLING_RATIO: "0.1"
+      PROMSCALE_DB_URI: postgres://postgres:password@timescaledb:5432/tsdb?sslmode=allow
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
-      TOBS_PROMSCALE_QUICK_START: "true"
+      PROMSCALE_PKG: "docker-quick-start"
 
   collector:
     image: "otel/opentelemetry-collector:0.55.0"
@@ -143,9 +140,6 @@ services:
     restart: on-failure
     depends_on:
       - generator
-    deploy:
-      mode: replicated
-      replicas: 3
 
 volumes:
   timescaledb-data:

--- a/docker-compose/promscale-demo/docker-compose.yaml
+++ b/docker-compose/promscale-demo/docker-compose.yaml
@@ -3,6 +3,7 @@ version: '3.0'
 services:
   timescaledb:
     image: timescale/timescaledb-ha:pg14-latest
+    restart: on-failure
     ports:
       - 5432:5432/tcp
     volumes:
@@ -15,6 +16,7 @@ services:
 
   prometheus:
     image: prom/prometheus:latest
+    restart: on-failure
     depends_on:
      - promscale
     ports:
@@ -24,15 +26,16 @@ services:
 
   alertmanager:
     image: prom/alertmanager:latest
+    restart: on-failure
     ports:
       - 9093:9093/tcp
 
   promscale:
     image: timescale/promscale:latest
+    restart: on-failure
     ports:
       - 9201:9201/tcp
       - 9202:9202/tcp
-    restart: on-failure
     depends_on:
       - timescaledb
     volumes:
@@ -46,6 +49,7 @@ services:
 
   collector:
     image: "otel/opentelemetry-collector:0.55.0"
+    restart: on-failure
     command: [ "--config=/etc/otel-collector-config.yml" ]
     depends_on:
       - promscale
@@ -58,27 +62,32 @@ services:
 
   jaeger:
     image: jaegertracing/jaeger-query:1.36.0
+    restart: on-failure
     environment:
       SPAN_STORAGE_TYPE: grpc-plugin
     command: [
       "--grpc-storage.server=promscale:9202",
     ]
+    depends_on:
+    - timescaledb
+    - promscale
     ports:
       - "16686:16686"
 
   grafana:
     image: vineeth97/promscale-demo-grafana
+    restart: on-failure
     volumes:
       - grafana-data:/var/lib/grafana
     ports:
       - 3000:3000/tcp
-    restart: on-failure
     depends_on:
       - timescaledb
       - jaeger
 
   node_exporter:
     image: quay.io/prometheus/node-exporter
+    restart: on-failure
     ports:
       - "9100:9100"
 


### PR DESCRIPTION
## Description

Update the docker-compose to make it simple, The quick start guide specifically had a few unnecessary configs and heavy-weight configurations on the quick guide. In this I'm modifying the below list of configurations:
1. Change the load generator replicas from 3 to 1.
2. Updated default database name from `otel_demo` to `tsdb`.
3. Drop metrics path configuration to default i.e. from `/metrics-text` to `/metrics`.
4. Add telemetry env for Promscale to `docker-quick-start`. This helps to gauge user engagement. 
