### PR TITLE
Fix path to quick start docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ TimescaleDB and Promscale extensions).
 
 ```bash
 git clone https://github.com/timescale/promscale.git
-cd promscale/docker-compose/
+cd promscale/docker-compose/promscale-demo
 docker compose up -d
 ```
 Explore your metrics and traces in Grafana (http://localhost:3000, username: admin, password: admin) and


### PR DESCRIPTION
## Description

Somehow in the last PR the path to the docker-compose file is wrong

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
