### PR TITLE
Adds support to run and compare benchmarks on CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,8 @@
 
 *Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.*
 
+*Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.*
+
 ## Merge requirements
 
 Please take into account the following non-code changes that you may need to make with your PR:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -1,0 +1,100 @@
+name: Benchmarks
+
+on:
+  pull_request:
+    branches: [ '**' ]
+
+env:
+  PROMSCALE_LOGGING: false
+  PROMSCALE_BENCHMARK: true
+  golang-version: 1.18.4
+
+jobs:
+  benchmark_current:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v3
+
+      - name: Set up Go ${{ env.golang-version }}
+        uses: actions/setup-go@v3.2.1
+        with:
+          go-version: ${{ env.golang-version }}
+        id: go
+
+      - name: Benchmark
+        run: go test -bench=. -run=^$ -benchmem -cpu=1 ./... | tee current.txt
+
+      - name: Upload result
+        uses: actions/upload-artifact@v3
+        with:
+          name: current
+          path: current.txt
+
+  benchmark_master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master branch
+        uses: actions/checkout@v3
+        with:
+          ref: 'master'
+
+      - name: Set up Go ${{ env.golang-version }}
+        uses: actions/setup-go@v3.2.1
+        with:
+          go-version: ${{ env.golang-version }}
+        id: go
+
+      - name: Benchmark
+        run: go test -bench=. -run=^$ -benchmem -cpu=1 ./... | tee master.txt
+
+      - name: Upload result
+        uses: actions/upload-artifact@v3
+        with:
+          name: master
+          path: master.txt
+
+  compare_and_publish_results:
+    runs-on: ubuntu-latest
+    needs: [benchmark_current, benchmark_master]
+    steps:
+      - name: Set up Go ${{ env.golang-version }}
+        uses: actions/setup-go@v3.2.1
+        with:
+          go-version: ${{ env.golang-version }}
+        id: go
+
+      - name: Download result for benchmark_current
+        uses: actions/download-artifact@v3
+        with:
+          name: current
+
+      - name: Download result for benchmark_master
+        uses: actions/download-artifact@v3
+        with:
+          name: master
+
+      - name: Install benchstat
+        run: go install -a golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Compare
+        id: compare
+        run: |
+          OUTPUT=$(benchstat -delta-test=none master.txt current.txt)
+          echo "${OUTPUT}"
+          OUTPUT="${OUTPUT//$'\n'/'%0A'}"
+          OUTPUT="${OUTPUT//$'\r'/'%0D'}"
+          echo "::set-output name=result::$OUTPUT"
+
+      - name: Publish results as comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          header: compare
+          message: |
+            @${{ github.event.pull_request.user.login }}
+            ## Benchmark Result for **${{ github.sha }}**
+            ### Master vs PR
+            ```
+            ${{ steps.compare.outputs.result }}
+            ```

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,14 +3,16 @@ name: Benchmarks
 on:
   pull_request:
     branches: [ '**' ]
+    types: [opened, synchronize, reopened, labeled]
 
 env:
   PROMSCALE_LOGGING: false
-  PROMSCALE_BENCHMARK: true
+  SKIP_PROMQL_BENCHMARKS: true
   golang-version: 1.18.4
 
 jobs:
-  benchmark_current:
+  benchmark:
+    if: contains( github.event.pull_request.labels.*.name, 'action:benchmarks')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch
@@ -22,57 +24,27 @@ jobs:
           go-version: ${{ env.golang-version }}
         id: go
 
-      - name: Benchmark
-        run: go test -bench=. -run=^$ -benchmem -cpu=1 ./... | tee current.txt
+      - name: Benchmark current PR
+        run: go test -bench=. -run=^$ -benchmem -cpu=1 -count=10 -timeout=6h ./... | tee current.txt
 
-      - name: Upload result
+      - name: Upload results
         uses: actions/upload-artifact@v3
         with:
           name: current
           path: current.txt
 
-  benchmark_master:
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout master branch
         uses: actions/checkout@v3
         with:
           ref: 'master'
 
-      - name: Set up Go ${{ env.golang-version }}
-        uses: actions/setup-go@v3.2.1
-        with:
-          go-version: ${{ env.golang-version }}
-        id: go
+      - name: Benchmark Master
+        run: go test -bench=. -run=^$ -benchmem -cpu=1 -count=10 -timeout=6h ./... | tee master.txt
 
-      - name: Benchmark
-        run: go test -bench=. -run=^$ -benchmem -cpu=1 ./... | tee master.txt
-
-      - name: Upload result
-        uses: actions/upload-artifact@v3
-        with:
-          name: master
-          path: master.txt
-
-  compare_and_publish_results:
-    runs-on: ubuntu-latest
-    needs: [benchmark_current, benchmark_master]
-    steps:
-      - name: Set up Go ${{ env.golang-version }}
-        uses: actions/setup-go@v3.2.1
-        with:
-          go-version: ${{ env.golang-version }}
-        id: go
-
-      - name: Download result for benchmark_current
+      - name: Download results of "Benchmark current PR"
         uses: actions/download-artifact@v3
         with:
           name: current
-
-      - name: Download result for benchmark_master
-        uses: actions/download-artifact@v3
-        with:
-          name: master
 
       - name: Install benchstat
         run: go install -a golang.org/x/perf/cmd/benchstat@latest
@@ -80,7 +52,7 @@ jobs:
       - name: Compare
         id: compare
         run: |
-          OUTPUT=$(benchstat -delta-test=none master.txt current.txt)
+          OUTPUT=$(benchstat master.txt current.txt)
           echo "${OUTPUT}"
           OUTPUT="${OUTPUT//$'\n'/'%0A'}"
           OUTPUT="${OUTPUT//$'\r'/'%0D'}"

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -43,10 +44,24 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	return cfg
 }
 
+func shouldLog() bool {
+	value := os.Getenv("PROMSCALE_LOGGING")
+	enabled, err := strconv.ParseBool(value)
+	if err != nil {
+		// If we cannot parse, then assume to continue logging.
+		return true
+	}
+	return enabled
+}
+
 // InitDefault is used to start the logger with sane defaults before we can configure it.
 // It's useful in instances where we want to log stuff before the configuration
 // has been successfully parsed. Calling Init function later on overrides this.
 func InitDefault() {
+	if !shouldLog() {
+		logger = log.NewNopLogger()
+		return
+	}
 	l := level.NewFilter(
 		log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr)),
 		level.AllowInfo(),
@@ -57,6 +72,10 @@ func InitDefault() {
 // Init starts logging given the configuration. By default, it uses logfmt format
 // and minimum logging level.
 func Init(cfg Config) error {
+	if !shouldLog() {
+		logger = log.NewNopLogger()
+		return nil
+	}
 	var l log.Logger
 	switch cfg.Format {
 	case "logfmt", "":

--- a/pkg/promql/bench_test.go
+++ b/pkg/promql/bench_test.go
@@ -28,13 +28,13 @@ import (
 )
 
 func ignore() bool {
-	value := os.Getenv("PROMSCALE_BENCHMARK")
+	value := os.Getenv("SKIP_PROMQL_BENCHMARKS")
 	return value != ""
 }
 
 func BenchmarkRangeQuery(b *testing.B) {
 	if ignore() {
-		return
+		b.Skip("skipping promql package benchmarks because we rely on upstream promql")
 	}
 	teststorage := NewTestStorage(b)
 	defer teststorage.Close()
@@ -243,7 +243,7 @@ func BenchmarkRangeQuery(b *testing.B) {
 
 func BenchmarkParser(b *testing.B) {
 	if ignore() {
-		return
+		b.Skip("skipping promql package benchmarks because we rely on upstream promql")
 	}
 	cases := []string{
 		"a",

--- a/pkg/promql/bench_test.go
+++ b/pkg/promql/bench_test.go
@@ -16,6 +16,7 @@ package promql
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -26,7 +27,15 @@ import (
 	"github.com/prometheus/prometheus/storage"
 )
 
+func ignore() bool {
+	value := os.Getenv("PROMSCALE_BENCHMARK")
+	return value != ""
+}
+
 func BenchmarkRangeQuery(b *testing.B) {
+	if ignore() {
+		return
+	}
 	teststorage := NewTestStorage(b)
 	defer teststorage.Close()
 	opts := EngineOpts{
@@ -233,6 +242,9 @@ func BenchmarkRangeQuery(b *testing.B) {
 }
 
 func BenchmarkParser(b *testing.B) {
+	if ignore() {
+		return
+	}
 	cases := []string{
 		"a",
 		"metric",


### PR DESCRIPTION
## Description

This PR adds the support for running benchmarks in Promscale on CI. It also compares with the benchmark results of the master branch.

By default, benchmarks will not be active when a PR (or draft PR) is opened. A dev has to assign `action:benchmarks` label, which will automatically trigger the benchmark workflow.

In order to restart the benchmarks, just remove and reassign the label, and it will trigger the benchmark workflow again.

Note:
1. After the benchmark comparison with benchstat is done, the results will be pasted as a PR comment, tagging the author. Each PR comment with a result contains the code hash corresponding to which the benchmark was executed.2. 
2. The commenting on PR will happen only if the PR is opened from a branch in Promscale repo, not from your fork. This is due to some permission reason.

You can refer to https://github.com/timescale/promscale/pull/1505 to see the testing in verbose level.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation