### PR TITLE
Remove multinode e2e tests from the e2e target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ e2e: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):hea
 e2e: pkg/tests/testdata/traces-dataset.sz generate
 	go test -v ./pkg/tests/end_to_end_tests/ -timescale-docker-image=$(DOCKER_IMAGE)
 	go test -v ./pkg/tests/end_to_end_tests/ -use-timescaledb=false -timescale-docker-image=$(DOCKER_IMAGE)
-	go test -v ./pkg/tests/end_to_end_tests/ -use-multinode -timescale-docker-image=$(DOCKER_IMAGE)
+	# TODO: Skipping multinode because tests are broken for now
+	# go test -v ./pkg/tests/end_to_end_tests/ -use-multinode -timescale-docker-image=$(DOCKER_IMAGE)
 
 .PHONY: upgrade-test
 upgrade-test: CURRENT_BRANCH?=$(shell git branch --show-current | sed 's#/#-#')


### PR DESCRIPTION
## Description

Multinode is not supported and running the e2e tests with the flag
causes the following error when creating the extension:

```
CREATE EXTENSION IF NOT EXISTS promscale VERSION '0.5.4';

ERROR:  [dn0]: schema "ps_trace" does not exist
```
## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
