### PR TITLE
Adds support for benchmarking new series creation.

### DIFF
--- a/pkg/tests/end_to_end_tests/metric_ingest_bench_test.go
+++ b/pkg/tests/end_to_end_tests/metric_ingest_bench_test.go
@@ -5,16 +5,19 @@
 package end_to_end_tests
 
 import (
+	"context"
 	"fmt"
 	"testing"
+
+	"github.com/walle/targz"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stretchr/testify/require"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/pgmodel/ingestor"
 	"github.com/timescale/promscale/pkg/pgxconn"
+	"github.com/timescale/promscale/pkg/prompb"
 	"github.com/timescale/promscale/pkg/tests/testsupport"
-	"github.com/walle/targz"
 )
 
 var prometheusDataGzip = "../testdata/prometheus-data.tar.gz"
@@ -72,5 +75,29 @@ func BenchmarkMetricIngest(b *testing.B) {
 		b.StartTimer()
 		sampleLoader.Run(metricsIngestor.Ingest)
 		b.StopTimer()
+	})
+}
+
+func BenchmarkNewSeriesIngestion(b *testing.B) {
+	seriesGen, err := testsupport.NewSeriesGenerator(10, 100, 4)
+	require.NoError(b, err)
+
+	ts := seriesGen.GetTimeseries()
+
+	withDB(b, "bench_e2e_new_series_ingest", func(db *pgxpool.Pool, t testing.TB) {
+		metricsIngestor, err := ingestor.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), &ingestor.Cfg{
+			NumCopiers:              8,
+			InvertedLabelsCacheSize: cache.DefaultConfig.InvertedLabelsCacheSize,
+		})
+		require.NoError(b, err)
+		defer metricsIngestor.Close()
+
+		b.ResetTimer()
+		b.ReportAllocs()
+		_, _, _ = metricsIngestor.Ingest(context.Background(), &prompb.WriteRequest{Timeseries: ts})
+
+		numSeries := 0
+		require.NoError(b, db.QueryRow(context.Background(), "SELECT count(*) FROM _prom_catalog.series").Scan(&numSeries))
+		require.Equal(b, 1000, numSeries)
 	})
 }

--- a/pkg/tests/testsupport/series_gen.go
+++ b/pkg/tests/testsupport/series_gen.go
@@ -1,0 +1,69 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package testsupport
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/timescale/promscale/pkg/prompb"
+)
+
+type seriesGen struct {
+	ts []prompb.TimeSeries
+}
+
+const (
+	labelKeyPrefix   = "test_k_"
+	labelValuePrefix = "test_v_"
+	metricNamePrefix = "test_metric_"
+)
+
+var samples = []prompb.Sample{{Timestamp: 1, Value: 1}}
+
+// NewSeriesGenerator generates distinct timeseries equal to numMetrics * numSeriesPerMetric, such that
+// each timeseries has `labels` count of labels. The label keys are common across the series, but their
+// values are random, thereby creating a new series.
+func NewSeriesGenerator(numMetrics, numSeriesPerMetric, labels int) (*seriesGen, error) {
+	if labels < 2 {
+		return nil, fmt.Errorf("minLabels cannot be less than 2")
+	}
+	totalSeries := numMetrics * numSeriesPerMetric
+	ts := make([]prompb.TimeSeries, 0, totalSeries)
+
+	labels -= 1 // Since 1 label will be occupied by __name__
+	labelKeys := make([]string, labels)
+	for i := 0; i < labels; i++ {
+		labelKeys[i] = fmt.Sprintf("%s%d", labelKeyPrefix, i)
+	}
+
+	for i := 0; i < numMetrics; i++ {
+		metricName := randomText(metricNamePrefix)
+		metric := prompb.Label{Name: "__name__", Value: metricName}
+
+		for j := 0; j < numSeriesPerMetric; j++ {
+			serie := []prompb.Label{metric}
+
+			for k := 0; k < labels; k++ {
+				// The keys remain the same across the series, but the values change, everytime creating a new series.
+				serie = append(serie, prompb.Label{Name: labelKeys[k], Value: randomText(labelValuePrefix)})
+			}
+			ts = append(ts, prompb.TimeSeries{
+				Labels:  serie,
+				Samples: samples,
+			})
+		}
+	}
+	return &seriesGen{ts}, nil
+}
+
+func (s *seriesGen) GetTimeseries() []prompb.TimeSeries {
+	return s.ts
+}
+
+func randomText(prefix string) string {
+	suffix := rand.Int() // #nosec
+	return fmt.Sprintf("%s%d", prefix, suffix)
+}


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

## Description

This PR adds benchmarks for new series creation case. This happens when Promscale sees a new series for the first time, like in case of a startup.

The `NewSeriesGenerator` creates batches of distinct series based on the given `numMetrics` and `numSeries`, with each series containing labels equal to `labels` arg of the function. The label key in the series remain constant, and the value always changes to create a new series.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
