### PR TITLE
Helm pin version

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -71,6 +71,7 @@ jobs:
           helm repo update
           helm install \
             --set replicaCount=1 \
+            --set image.tag=pg14.4-ts2.7.2-p0 \
             timescaledb timescale/timescaledb-single
           kubectl rollout status statefulset timescaledb
 
@@ -110,7 +111,7 @@ jobs:
         run: |
             mkdir -p chart_release
             helm package deploy/helm-chart -d chart_release/
-            helm plugin install https://github.com/hypnoglow/helm-s3.git          
+            helm plugin install https://github.com/hypnoglow/helm-s3.git
             helm repo add tscharts s3://charts.timescale.com
             helm s3 push chart_release/* tscharts --acl public-read --relative --dry-run
 

--- a/deploy/helm-chart/templates/deployment-promscale.yaml
+++ b/deploy/helm-chart/templates/deployment-promscale.yaml
@@ -33,8 +33,8 @@ spec:
         {{- end }}
     spec:
       containers:
-        - image: {{ .Values.image }}
-          imagePullPolicy: {{ .Values.imagePullPolicy }}
+        - image: {{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: promscale
           args:
           - "-config=/etc/promscale/config.yaml"

--- a/deploy/helm-chart/values.yaml
+++ b/deploy/helm-chart/values.yaml
@@ -1,5 +1,10 @@
-image: timescale/promscale
-imagePullPolicy: IfNotPresent
+image:
+  repository: timescale/promscale
+  # The default will come from appVersion in Chart.yaml, if you wish to
+  # override that value then set the tag version here.
+  tag:
+  pullPolicy: IfNotPresent
+
 # number of connector pods to spawn
 replicaCount: 1
 

--- a/deploy/static/deploy.yaml
+++ b/deploy/static/deploy.yaml
@@ -106,7 +106,7 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       containers:
-        - image: timescale/promscale
+        - image: timescale/promscale:0.13.0
           imagePullPolicy: IfNotPresent
           name: promscale
           args:


### PR DESCRIPTION
## Description

In the Helm chart we are not forcibly setting a container image version, which will always pull the `latest` tag.  The changes here will set the image tag from `Chart.yaml` but allow override from `values.yaml` if the end user wants to use a different tag.

- Change how the container image information is structures in
  values.yaml
- Take the default container image tag from Chart.yaml, but allow
  override.
