### PR TITLE
Fix upgrade test by pinning to timescaledb 2.7.1

### DIFF
--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -89,7 +89,7 @@ func getDBImages(extensionState testhelpers.TestOptions, prevPromscaleVersion *s
 
 	// From Promscale 0.13.0 onwards the minimum extension version is 0.5.4
 	if prevPromscaleVersion != nil && prevPromscaleVersion.GE(semver.MustParse("0.13.0")) {
-		return "timescale/timescaledb-ha:pg" + pgVersion + "-ts2.7-latest", dockerImageName, nil
+		return "timescale/timescaledb-ha:pg" + pgVersion + ".11-ts2.7.1-latest", dockerImageName, nil
 	}
 
 	// From Promscale 0.11.0 onwards the minimum extension version is 0.5.0


### PR DESCRIPTION
## Description

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
