### PR TITLE
Prometheus metrics has to be registered after all services are added

### DIFF
--- a/pkg/pgmodel/ingestor/trace/cache.go
+++ b/pkg/pgmodel/ingestor/trace/cache.go
@@ -6,7 +6,7 @@ const (
 	urlCacheSize       = 10000
 	operationCacheSize = 10000
 	instLibCacheSize   = 10000
-	tagCacheSize       = 10000
+	tagCacheSize       = 100000
 )
 
 func newSchemaCache() *clockcache.Cache {

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -224,10 +224,6 @@ func Run(cfg *Config) error {
 	}
 	grpcServer := grpc.NewServer(options...)
 	ptraceotlp.RegisterServer(grpcServer, api.NewTraceServer(client))
-	grpc_prometheus.Register(grpcServer)
-	grpc_prometheus.EnableHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
-	)
 
 	queryPlugin := shared.StorageGRPCPlugin{
 		Impl: jaegerQuery,
@@ -236,6 +232,11 @@ func Run(cfg *Config) error {
 		log.Error("msg", "Creating jaeger query GRPC server failed", "err", err)
 		return err
 	}
+
+	grpc_prometheus.EnableHandlingTimeHistogram(
+		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20, 30, 60, 90, 120}),
+	)
+	grpc_prometheus.Register(grpcServer)
 
 	group.Add(
 		func() error {


### PR DESCRIPTION
Prometheus metrics has to be registered after all services are added

Enabling server histograms should be done before registering metrics.

Bumping tag cache size since 10K seems pretty low.
