### PR TITLE
Add benchmark to test varying ingestion load

### DIFF
--- a/pkg/tests/testsupport/series_gen.go
+++ b/pkg/tests/testsupport/series_gen.go
@@ -59,8 +59,15 @@ func NewSeriesGenerator(numMetrics, numSeriesPerMetric, labels int) (*seriesGen,
 	return &seriesGen{ts}, nil
 }
 
-func (s *seriesGen) GetTimeseries() []prompb.TimeSeries {
-	return s.ts
+func (s *seriesGen) GetTimeseriesInBatch(batchSize int) [][]prompb.TimeSeries {
+	ts := s.ts
+	batches := make([][]prompb.TimeSeries, 0, (len(ts)+batchSize-1)/batchSize)
+
+	for batchSize < len(ts) {
+		ts, batches = ts[batchSize:], append(batches, ts[0:batchSize:batchSize])
+	}
+	batches = append(batches, ts)
+	return batches
 }
 
 func randomText(prefix string) string {


### PR DESCRIPTION


## Description

This commit adds benchmark to test ingestion performance with varying series count and batches.

Related to https://github.com/timescale/promscale/issues/1530

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

*Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.*

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
