### PR TITLE
VictoriaMetrics doesn't support remote read

### DIFF
--- a/migration-tool/cmd/prom-migrator/README.md
+++ b/migration-tool/cmd/prom-migrator/README.md
@@ -58,7 +58,7 @@ Key:
 3. Prometheus tsdb (TODO)
 4. Thanos (read, write)
 5. Cortex (only blocks storage, chunks storage in later versions) (read, write)
-6. VictoriaMetrics (read, write, not sure about backfill)
+6. VictoriaMetrics (write, not sure about backfill)
 7. M3DB (read, write, not sure about backfill)
 8. Others (any remote storage systems with remote read (for reading) and write (for writing) endpoints)
 


### PR DESCRIPTION
## Description
Because VictoriaMetrics doesn't support remote read, it doesn't allow users to use prom-migrator to migrate data from it to another Prometheus compatible-backend. The README wrongly stated that VictoriaMetrics supported remote read.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
