### PR TITLE
Reset inverted labels cache on epoch change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use the following categories for changes:
 
 ### Fixed
 - Make Jaeger Event queryable using name and tags [#1553]
+- Reset inverted labels cache on epoch change [#1561]
 
 ## [0.13.0] - 2022-07-20
 

--- a/pkg/pgmodel/Readme.md
+++ b/pkg/pgmodel/Readme.md
@@ -15,7 +15,7 @@ TODO (@ante do you want to write this?)
 
 ## Write Path
 
-A `WriteRequest` is made out of a `[]TimeSeries` each of which contains a set of lables, each a `{string, string}`, and a set of samples, each a `{Timestamp, Value}`. Logically, the write path deals with this write request multiple stages. In Go notation, this can be thought of as follows
+A `WriteRequest` is made out of a `[]TimeSeries` each of which contains a set of labels, each a `{string, string}`, and a set of samples, each a `{Timestamp, Value}`. Logically, the write path deals with this write request multiple stages. In Go notation, this can be thought of as follows
 
 ```go
 type WriteRequest = []TimeSeries

--- a/pkg/pgmodel/cache/inverted_labels_cache.go
+++ b/pkg/pgmodel/cache/inverted_labels_cache.go
@@ -42,7 +42,7 @@ type InvertedLabelsCache struct {
 }
 
 // Cache is thread-safe
-func NewInvertedLablesCache(size uint64) (*InvertedLabelsCache, error) {
+func NewInvertedLabelsCache(size uint64) (*InvertedLabelsCache, error) {
 	if size <= 0 {
 		return nil, fmt.Errorf("labels cache size must be > 0")
 	}
@@ -61,4 +61,8 @@ func (c *InvertedLabelsCache) GetLabelsId(key LabelKey) (LabelInfo, bool) {
 func (c *InvertedLabelsCache) Put(key LabelKey, val LabelInfo) bool {
 	_, added := c.cache.Insert(key, val, uint64(key.len())+uint64(val.len())+17)
 	return added
+}
+
+func (c *InvertedLabelsCache) Reset() {
+	c.cache.Reset()
 }


### PR DESCRIPTION
## Description

The database cache epoch advances when series are deleted from the
database. When connector detects a cache epoch change, it invalidates
the series cache, as it may contain values which reference the deleted
rows in the series table.

During the database series deletion, unused labels may also be deleted.
This means that we must also invalidate the inverted label cache, as it
could also reference deleted rows in the `_prom_catalog.label` table.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] ~~Updated the relevant documentation~~
