### PR TITLE
Fix: Exemplar ingestion due to conflicting temporary tables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ We use the following categories for changes:
 ### Fixed
 - Make Jaeger Event queryable using name and tags [#1553]
 - Reset inverted labels cache on epoch change [#1561]
+- Error `column "exemplar_label_values" does not exist (SQLSTATE 42703)` on ingesting exemplars [#1574]
 
 ## [0.13.0] - 2022-07-20
 

--- a/pkg/pgmodel/ingestor/copier.go
+++ b/pkg/pgmodel/ingestor/copier.go
@@ -428,7 +428,7 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, onConflict bool, re
 			rows := sampleRows
 			if isExemplar {
 				columns = schema.PromExemplarColumns
-				tempTablePrefix = fmt.Sprintf("s%d_", r)
+				tempTablePrefix = fmt.Sprintf("e%d_", r)
 				rows = exemplarRows
 			}
 			table := pgx.Identifier{schemaName, tableName}
@@ -464,7 +464,7 @@ func insertSeries(ctx context.Context, conn pgxconn.PgxConn, onConflict bool, re
 			}
 		}
 		if hasExemplars {
-			numRowsPerInsert = append(numRowsPerInsert, numSamples)
+			numRowsPerInsert = append(numRowsPerInsert, numExemplars)
 			if err = copyFromFunc(req.info.TableName, schema.PromDataExemplar, true); err != nil {
 				return err, lowestMinTime
 			}


### PR DESCRIPTION
Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

Fixes: #1567 

This PR fixes the `ERROR: column \"exemplar_label_values\" does not exist (SQLSTATE 42703)` error seen in exemplar ingestion. Based on what I studied, the error occurred due to temporary tables created for samples being used for exemplars as well. Exemplars have a different column requirements and hence the error.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
