### PR TITLE
Allow using version 0.6.0 of the Promscale extension

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,8 +51,7 @@ var (
 	TimescaleVersionRange       = semver.MustParseRange(TimescaleVersionRangeString)
 
 	// ExtVersionRangeString is a range of required promscale extension versions
-	// support 0.5.x
-	ExtVersionRangeString = ">=0.5.4 <0.5.99"
+	ExtVersionRangeString = ">=0.5.4 <0.6.99"
 	ExtVersionRange       = semver.MustParseRange(ExtVersionRangeString)
 
 	// Expose build info through Prometheus metric


### PR DESCRIPTION
## Description

We must relax the extension version constraints in order for the
extension's release tests to pass. The constraints can be tightened
once the new version of the extension is release.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
