### PR TITLE
Hide PR template instructions from published PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,10 @@
 ## Description
 
-*Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created.*
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 
 
-*Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.*
+Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
+-->
 
 ## Merge requirements
 


### PR DESCRIPTION

## Description

The instructions are meant to be seen when editing the PR description,
but serve no purpose once the description has been created. Putting them
in a HTML comment hides them.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
