### PR TITLE
Adjust Promscale extension version range

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ var (
 	TimescaleVersionRange       = semver.MustParseRange(TimescaleVersionRangeString)
 
 	// ExtVersionRangeString is a range of required promscale extension versions
-	ExtVersionRangeString = ">=0.5.4 <0.6.99"
+	ExtVersionRangeString = ">=0.6.0 <0.6.99"
 	ExtVersionRange       = semver.MustParseRange(ExtVersionRangeString)
 
 	// Expose build info through Prometheus metric


### PR DESCRIPTION
 Promscale requires `_ps_trace.text_matches` function introduced in Promscale extension
 version 0.6.0