### PR TITLE
Fix broken cache eviction in clockcache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ We use the following categories for changes:
 ## [Unreleased]
 
 ### Added
-
 - prom-migrator: Support for passing custom HTTP headers via command line arguments for both
   reader and writer [#1020].
 - Run timescaledb-tune with the promscale profile [#1615]
+
+### Fixed
+- Fix broken cache eviction in clockcache [#1603]
 
 ## [0.14.0] - 2022-08-30
 

--- a/pkg/clockcache/cache.go
+++ b/pkg/clockcache/cache.go
@@ -174,7 +174,7 @@ func (self *Cache) evict() (insertPtr *element) {
 			}
 
 			if insertPtr != nil {
-				self.next = next + 1
+				self.next = (startLoc + next + 1) % self.Len()
 				return
 			}
 		}


### PR DESCRIPTION
## Description

The clockcache is a simple approximation of an LRU cache. Instead of
maintaining an exact ordering of which elements were least recently
used, the cache simply keeps track of whether each element is "used".

When an item is inserted into the cache, it is counted as unused. When
an item is fetched from the cache, it is counted as used.

The eviction algorithm looks through the elements of the cache one by
one, trying to find one to evict. If the item is used, it marks it as
unused. If it is unused, it can evict the item. The next time an
eviction is required, it can continue with the next element.

Through a bug in index manipulation, if the next item to be evicted was
at index 1 of the storage array, the next eviction would not continue to
index 2. Instead, after successfully evicting an item from index 1, it
would attempt (on the next eviction) to evict the item at index 1
(again).

The above, combined with the fact that items just inserted are marked as
unused, meant that it was possible to end up in a situation where each
insert evicted the _previously inserted_ item.

This caused much woe, and thrashing.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
