### PR TITLE
Fix upgrade test by cleanly stopping test containers

### DIFF
--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -93,8 +94,8 @@ func StopContainer(ctx context.Context, container testcontainers.Container, prin
 			fmt.Fprintln(os.Stderr, "couldn't stop log producer", err)
 		}
 	}
-
-	err := container.Terminate(ctx)
+	timeout := 10 * time.Second
+	err := container.Stop(ctx, &timeout)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "couldn't terminate container", err)
 	}

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -87,6 +87,11 @@ func getDBImages(extensionState testhelpers.TestOptions, prevPromscaleVersion *s
 		panic("Only use pg12 for upgrade tests")
 	}
 
+	// From Promscale 0.14.0 onwards the minimum extension version is 0.6.0
+	if prevPromscaleVersion != nil && prevPromscaleVersion.GE(semver.MustParse("0.14.0")) {
+		return "timescale/timescaledb-ha:pg" + pgVersion + ".12-ts2.7.2-latest", dockerImageName, nil
+	}
+
 	// From Promscale 0.13.0 onwards the minimum extension version is 0.5.4
 	if prevPromscaleVersion != nil && prevPromscaleVersion.GE(semver.MustParse("0.13.0")) {
 		return "timescale/timescaledb-ha:pg" + pgVersion + ".11-ts2.7.1-latest", dockerImageName, nil


### PR DESCRIPTION
## Description

For some reason, we have never allowed the database container to cleanly shutdown.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
