### PR TITLE
Propagate context from query requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,12 @@ We use the following categories for changes:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased]
-
 ### Added
-
 - prom-migrator: Support for passing custom HTTP headers via command line arguments for both
   reader and writer [#1020].
 - Run timescaledb-tune with the promscale profile [#1615]
+- Propagate the context from received HTTP read requests downstream to database
+  requests [#1205]. 
 
 ## [0.14.0] - 2022-08-30
 
@@ -29,7 +28,6 @@ We use the following categories for changes:
 - Helm chart now ships a JSON Schema for imposing a structure of the values.yaml file [#1551]
 
 ### Changed
-
 - Helm chart code was migrated to https://github.com/timescale/helm-charts [#1562]
 - Deprecate flag `tracing.otlp.server-address` in favour of `tracing.grpc.server-address` [#1588]
 

--- a/pkg/api/delete.go
+++ b/pkg/api/delete.go
@@ -72,7 +72,7 @@ func deleteHandler(config *Config, client *pgclient.Client) http.HandlerFunc {
 				continue
 			}
 			pgDelete := deletePkg.PgDelete{Conn: client.ReadOnlyConnection()}
-			touchedMetrics, deletedSeriesIDs, rowsDeleted, err := pgDelete.DeleteSeries(matchers, start, end)
+			touchedMetrics, deletedSeriesIDs, rowsDeleted, err := pgDelete.DeleteSeries(r.Context(), matchers, start, end)
 			if err != nil {
 				respondErrorWithMessage(w, http.StatusInternalServerError, err, "deleting_series",
 					fmt.Sprintf("partial delete: deleted %v series IDs from %v metrics, affecting %d rows in total.",

--- a/pkg/api/label_values.go
+++ b/pkg/api/label_values.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -28,7 +27,7 @@ func labelValues(queryable promql.Queryable) http.HandlerFunc {
 			respondError(w, http.StatusBadRequest, fmt.Errorf("invalid label name: %s", name), "bad_data")
 			return
 		}
-		querier, err := queryable.SamplesQuerier(context.Background(), math.MinInt64, math.MaxInt64)
+		querier, err := queryable.SamplesQuerier(r.Context(), math.MinInt64, math.MaxInt64)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return

--- a/pkg/api/labels.go
+++ b/pkg/api/labels.go
@@ -5,7 +5,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"math"
 	"net/http"
@@ -34,7 +33,7 @@ func Labels(conf *Config, queryable promql.Queryable) http.Handler {
 
 func labelsHandler(queryable promql.Queryable) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		querier, err := queryable.SamplesQuerier(context.Background(), math.MinInt64, math.MaxInt64)
+		querier, err := queryable.SamplesQuerier(r.Context(), math.MinInt64, math.MaxInt64)
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "internal")
 			return

--- a/pkg/api/metadata.go
+++ b/pkg/api/metadata.go
@@ -38,7 +38,7 @@ func metricMetadataHandler(client *pgclient.Client) http.HandlerFunc {
 				return
 			}
 		}
-		data, err := metadata.MetricQuery(client.ReadOnlyConnection(), metric, int(limit))
+		data, err := metadata.MetricQuery(r.Context(), client.ReadOnlyConnection(), metric, int(limit))
 		if err != nil {
 			respondError(w, http.StatusInternalServerError, err, "fetching metric metadata")
 			return

--- a/pkg/api/query_test.go
+++ b/pkg/api/query_test.go
@@ -60,7 +60,7 @@ func (m mockQuerier) Query(*prompb.Query) ([]*prompb.TimeSeries, error) {
 	panic("implement me")
 }
 
-func (m mockQuerier) SamplesQuerier() querier.SamplesQuerier {
+func (m mockQuerier) SamplesQuerier(_ context.Context) querier.SamplesQuerier {
 	return m
 }
 
@@ -70,7 +70,7 @@ func (ms mockQuerier) Select(int64, int64, bool, *storage.SelectHints, *querier.
 	return &mockSeriesSet{err: ms.selectErr}, nil
 }
 
-func (m mockQuerier) RemoteReadQuerier() querier.RemoteReadQuerier {
+func (m mockQuerier) RemoteReadQuerier(_ context.Context) querier.RemoteReadQuerier {
 	return nil
 }
 

--- a/pkg/api/read.go
+++ b/pkg/api/read.go
@@ -54,7 +54,7 @@ func Read(config *Config, reader querier.Reader, metrics *Metrics, updateMetrics
 		metrics.RemoteReadReceivedQueries.Add(float64(len(req.Queries)))
 
 		// Drop __replica__ labelSet when
-		// Promscale is running is HA mode
+		// Promscale is running in HA mode
 		// as the same lebelSet is dropped during ingestion.
 		if config.HighAvailability {
 			for _, q := range req.Queries {
@@ -67,7 +67,7 @@ func Read(config *Config, reader querier.Reader, metrics *Metrics, updateMetrics
 		}
 
 		var resp *prompb.ReadResponse
-		resp, err = reader.Read(&req)
+		resp, err = reader.Read(r.Context(), &req)
 		if err != nil {
 			statusCode = "500"
 			log.Warn("msg", "Error executing query", "query", req, "storage", "PostgreSQL", "err", err)

--- a/pkg/api/read_test.go
+++ b/pkg/api/read_test.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -121,7 +122,7 @@ type mockReader struct {
 	err      error
 }
 
-func (m *mockReader) Read(r *prompb.ReadRequest) (*prompb.ReadResponse, error) {
+func (m *mockReader) Read(_ context.Context, r *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 	m.request = r
 	return m.response, m.err
 }

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -296,7 +296,7 @@ func (c *Client) IngestTraces(ctx context.Context, tr ptrace.Traces) error {
 }
 
 // Read returns the promQL query results
-func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
+func (c *Client) Read(ctx context.Context, req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 	if req == nil {
 		return nil, nil
 	}
@@ -305,7 +305,7 @@ func (c *Client) Read(req *prompb.ReadRequest) (*prompb.ReadResponse, error) {
 		Results: make([]*prompb.QueryResult, len(req.Queries)),
 	}
 
-	qr := c.querier.RemoteReadQuerier()
+	qr := c.querier.RemoteReadQuerier(ctx)
 
 	for i, q := range req.Queries {
 		tts, err := qr.Query(q)

--- a/pkg/pgclient/client_test.go
+++ b/pkg/pgclient/client_test.go
@@ -26,7 +26,7 @@ type mockQuerier struct {
 
 var _ querier.Querier = (*mockQuerier)(nil)
 
-func (q *mockQuerier) SamplesQuerier() querier.SamplesQuerier {
+func (q *mockQuerier) SamplesQuerier(_ context.Context) querier.SamplesQuerier {
 	return mockSamplesQuerier{}
 }
 
@@ -36,7 +36,7 @@ func (q mockSamplesQuerier) Select(mint int64, maxt int64, sortSeries bool, hint
 	return nil, nil
 }
 
-func (q *mockQuerier) RemoteReadQuerier() querier.RemoteReadQuerier {
+func (q *mockQuerier) RemoteReadQuerier(_ context.Context) querier.RemoteReadQuerier {
 	return mockRemoteReadQuerier{
 		tts: q.tts,
 		err: q.err,
@@ -151,7 +151,7 @@ func TestDBReaderRead(t *testing.T) {
 
 			r := Client{querier: mq}
 
-			res, err := r.Read(c.req)
+			res, err := r.Read(context.Background(), c.req)
 
 			if err != nil {
 				if c.err == nil || err != c.err {

--- a/pkg/pgmodel/metadata/metadata.go
+++ b/pkg/pgmodel/metadata/metadata.go
@@ -13,15 +13,15 @@ import (
 )
 
 // MetricQuery returns metadata corresponding to metric or metric_family.
-func MetricQuery(conn pgxconn.PgxConn, metric string, limit int) (map[string][]model.Metadata, error) {
+func MetricQuery(ctx context.Context, conn pgxconn.PgxConn, metric string, limit int) (map[string][]model.Metadata, error) {
 	var (
 		rows pgxconn.PgxRows
 		err  error
 	)
 	if metric != "" {
-		rows, err = conn.Query(context.Background(), "SELECT * from prom_api.get_metric_metadata($1)", metric)
+		rows, err = conn.Query(ctx, "SELECT * from prom_api.get_metric_metadata($1)", metric)
 	} else {
-		rows, err = conn.Query(context.Background(), "SELECT metric_family, type, unit, help from _prom_catalog.metadata ORDER BY metric_family, last_seen DESC")
+		rows, err = conn.Query(ctx, "SELECT metric_family, type, unit, help from _prom_catalog.metadata ORDER BY metric_family, last_seen DESC")
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query metric metadata: %w", err)

--- a/pkg/pgmodel/querier/common.go
+++ b/pkg/pgmodel/querier/common.go
@@ -49,9 +49,9 @@ type QueryHints struct {
 	Lookback    time.Duration
 }
 
-func GetMetricNameSeriesIds(conn pgxconn.PgxConn, metadata *evalMetadata) (metrics, schemas []string, correspondingSeriesIDs [][]model.SeriesID, err error) {
+func GetMetricNameSeriesIds(ctx context.Context, conn pgxconn.PgxConn, metadata *evalMetadata) (metrics, schemas []string, correspondingSeriesIDs [][]model.SeriesID, err error) {
 	sqlQuery := buildMetricNameSeriesIDQuery(metadata.clauses)
-	rows, err := conn.Query(context.Background(), sqlQuery, metadata.values...)
+	rows, err := conn.Query(ctx, sqlQuery, metadata.values...)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/pgmodel/querier/interface.go
+++ b/pkg/pgmodel/querier/interface.go
@@ -13,7 +13,7 @@ import (
 
 // Reader reads the data based on the provided read request.
 type Reader interface {
-	Read(*prompb.ReadRequest) (*prompb.ReadResponse, error)
+	Read(context.Context, *prompb.ReadRequest) (*prompb.ReadResponse, error)
 }
 
 // SeriesSet adds a Close method to storage.SeriesSet to provide a way to free memory/
@@ -26,9 +26,9 @@ type SeriesSet interface {
 // and exemplars.
 type Querier interface {
 	// RemoteReadQuerier returns a remote storage querier
-	RemoteReadQuerier() RemoteReadQuerier
+	RemoteReadQuerier(ctx context.Context) RemoteReadQuerier
 	// SamplesQuerier returns a sample querier.
-	SamplesQuerier() SamplesQuerier
+	SamplesQuerier(ctx context.Context) SamplesQuerier
 	// ExemplarsQuerier returns an exemplar querier.
 	ExemplarsQuerier(ctx context.Context) ExemplarQuerier
 }

--- a/pkg/pgmodel/querier/querier.go
+++ b/pkg/pgmodel/querier/querier.go
@@ -42,16 +42,16 @@ func NewQuerier(
 	return querier
 }
 
-func (q *pgxQuerier) RemoteReadQuerier() RemoteReadQuerier {
-	return newQueryRemoteRead(q)
+func (q *pgxQuerier) RemoteReadQuerier(ctx context.Context) RemoteReadQuerier {
+	return newQueryRemoteRead(ctx, q)
 }
 
-func (q *pgxQuerier) SamplesQuerier() SamplesQuerier {
-	return newQuerySamples(q)
+func (q *pgxQuerier) SamplesQuerier(ctx context.Context) SamplesQuerier {
+	return newQuerySamples(ctx, q)
 }
 
 func (q *pgxQuerier) ExemplarsQuerier(ctx context.Context) ExemplarQuerier {
-	return newQueryExemplars(q)
+	return newQueryExemplars(ctx, q)
 }
 
 // errorSeriesSet represents an error result in a form of a series set.

--- a/pkg/pgmodel/querier/querier_sql_test.go
+++ b/pkg/pgmodel/querier/querier_sql_test.go
@@ -5,6 +5,7 @@
 package querier
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -723,7 +724,7 @@ func TestPGXQuerierQuery(t *testing.T) {
 			}
 			querier := pgxQuerier{&queryTools{conn: mock, metricTableNames: mockMetrics, labelsReader: lreader.NewLabelsReader(mock, clockcache.WithMax(0), tenancy.NewNoopAuthorizer().ReadAuthorizer())}}
 
-			result, err := querier.RemoteReadQuerier().Query(c.query)
+			result, err := querier.RemoteReadQuerier(context.Background()).Query(c.query)
 
 			if err != nil {
 				switch {

--- a/pkg/pgmodel/querier/query_remote_read.go
+++ b/pkg/pgmodel/querier/query_remote_read.go
@@ -1,6 +1,7 @@
 package querier
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/timescale/promscale/pkg/prompb"
@@ -8,10 +9,11 @@ import (
 
 type queryRemoteRead struct {
 	*pgxQuerier
+	ctx context.Context
 }
 
-func newQueryRemoteRead(qr *pgxQuerier) *queryRemoteRead {
-	return &queryRemoteRead{qr}
+func newQueryRemoteRead(ctx context.Context, qr *pgxQuerier) *queryRemoteRead {
+	return &queryRemoteRead{qr, ctx}
 }
 
 // Query implements the RemoteReadQuerier interface. It is the entrypoint for
@@ -26,7 +28,7 @@ func (q *queryRemoteRead) Query(query *prompb.Query) ([]*prompb.TimeSeries, erro
 		return nil, err
 	}
 
-	qrySamples := newQuerySamples(q.pgxQuerier)
+	qrySamples := newQuerySamples(q.ctx, q.pgxQuerier)
 	sampleRows, _, err := qrySamples.fetchSamplesRows(query.StartTimestampMs, query.EndTimestampMs, nil, nil, nil, matchers)
 	if err != nil {
 		return nil, err

--- a/pkg/query/queryable.go
+++ b/pkg/query/queryable.go
@@ -66,7 +66,7 @@ func (q *samplesQuerier) Close() {
 }
 
 func (q *samplesQuerier) Select(sortSeries bool, hints *storage.SelectHints, qh *pgQuerier.QueryHints, path []parser.Node, matchers ...*labels.Matcher) (storage.SeriesSet, parser.Node) {
-	qry := q.metricsReader.SamplesQuerier()
+	qry := q.metricsReader.SamplesQuerier(q.ctx)
 	ss, n := qry.Select(q.mint, q.maxt, sortSeries, hints, qh, path, matchers...)
 	q.seriesSets = append(q.seriesSets, ss)
 	return ss, n

--- a/pkg/tests/end_to_end_tests/db_connections_test.go
+++ b/pkg/tests/end_to_end_tests/db_connections_test.go
@@ -49,7 +49,8 @@ func TestDBConnectionHandling(t *testing.T) {
 		for _, m := range metrics[:2] {
 			count += len(m.Samples)
 		}
-		ingested, _, err := pgClient.IngestMetrics(context.Background(), newWriteRequestWithTs(copyMetrics(metrics[:2])))
+		ctx := context.Background()
+		ingested, _, err := pgClient.IngestMetrics(ctx, newWriteRequestWithTs(copyMetrics(metrics[:2])))
 		if err != nil {
 			t.Fatalf("got an unexpected error %v", err)
 		}
@@ -58,7 +59,7 @@ func TestDBConnectionHandling(t *testing.T) {
 		}
 
 		// Check for Read response.
-		resp, err := pgClient.Read(readRequest)
+		resp, err := pgClient.Read(ctx, readRequest)
 		if err != nil {
 			t.Fatalf("got an unexpected error %v", err)
 		}
@@ -67,7 +68,7 @@ func TestDBConnectionHandling(t *testing.T) {
 		}
 
 		var user string
-		err = db.QueryRow(context.Background(), "SELECT current_user").Scan(&user)
+		err = db.QueryRow(ctx, "SELECT current_user").Scan(&user)
 		if err != nil {
 			t.Fatalf("got an unexpected error while getting DB user: %v", err)
 		}
@@ -79,11 +80,11 @@ func TestDBConnectionHandling(t *testing.T) {
 		}
 
 		// Try ingesting and reading from DB, expect to error.
-		_, _, err = pgClient.IngestMetrics(context.Background(), newWriteRequestWithTs(copyMetrics(metrics[2:])))
+		_, _, err = pgClient.IngestMetrics(ctx, newWriteRequestWithTs(copyMetrics(metrics[2:])))
 		if ignoreBlockedConnectionError(err) != nil {
 			t.Fatalf("got an unexpected error: %v", err)
 		}
-		_, err = pgClient.Read(readRequest)
+		_, err = pgClient.Read(ctx, readRequest)
 		if ignoreBlockedConnectionError(err) != nil {
 			t.Fatalf("expected an error to occur: %+v", resp)
 		}
@@ -99,7 +100,7 @@ func TestDBConnectionHandling(t *testing.T) {
 		for _, m := range metrics[2:] {
 			count += len(m.Samples)
 		}
-		ingested, _, err = pgClient.IngestMetrics(context.Background(), newWriteRequestWithTs(copyMetrics(metrics[2:])))
+		ingested, _, err = pgClient.IngestMetrics(ctx, newWriteRequestWithTs(copyMetrics(metrics[2:])))
 		if err != nil {
 			t.Fatalf("got an unexpected error: %v", err)
 		}
@@ -108,7 +109,7 @@ func TestDBConnectionHandling(t *testing.T) {
 		}
 
 		// Check for Read response.
-		resp, err = pgClient.Read(readRequest)
+		resp, err = pgClient.Read(ctx, readRequest)
 		if err != nil {
 			t.Fatalf("got an unexpected error %v", err)
 		}

--- a/pkg/tests/end_to_end_tests/metadata_test.go
+++ b/pkg/tests/end_to_end_tests/metadata_test.go
@@ -76,7 +76,8 @@ func TestFetchMetricMetadataAPI(t *testing.T) {
 		wr.Timeseries = copyMetrics(ts)
 		wr.Metadata = copyMetadata(metadata)
 
-		numSamples, numMetadata, err := ingestor.IngestMetrics(context.Background(), wr)
+		ctx := context.Background()
+		numSamples, numMetadata, err := ingestor.IngestMetrics(ctx, wr)
 		require.NoError(t, err)
 		require.Equal(t, 10, int(numSamples))
 		require.Equal(t, 20, int(numMetadata))
@@ -86,7 +87,7 @@ func TestFetchMetricMetadataAPI(t *testing.T) {
 		db = testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_reader")
 		defer db.Close()
 
-		result, err := metadataAPI.MetricQuery(pgxconn.NewPgxConn(db), "", 0)
+		result, err := metadataAPI.MetricQuery(ctx, pgxconn.NewPgxConn(db), "", 0)
 		require.NoError(t, err)
 		expected := getExpectedMap(metadata)
 		for metric, md := range result {
@@ -96,7 +97,7 @@ func TestFetchMetricMetadataAPI(t *testing.T) {
 		}
 
 		// -- fetch metadata with metric_name --
-		result, err = metadataAPI.MetricQuery(pgxconn.NewPgxConn(db), metadata[0].MetricFamilyName, 0)
+		result, err = metadataAPI.MetricQuery(ctx, pgxconn.NewPgxConn(db), metadata[0].MetricFamilyName, 0)
 		require.NoError(t, err)
 		expected = getExpectedMap(metadata[:1])
 		for metric, md := range result {
@@ -106,12 +107,12 @@ func TestFetchMetricMetadataAPI(t *testing.T) {
 		}
 
 		// -- fetch metadata with limit --
-		result, err = metadataAPI.MetricQuery(pgxconn.NewPgxConn(db), "", 5)
+		result, err = metadataAPI.MetricQuery(ctx, pgxconn.NewPgxConn(db), "", 5)
 		require.NoError(t, err)
 		require.Equal(t, 5, len(result))
 
 		// -- fetch metadata with both limit and metric_name --
-		result, err = metadataAPI.MetricQuery(pgxconn.NewPgxConn(db), metadata[0].MetricFamilyName, 1)
+		result, err = metadataAPI.MetricQuery(ctx, pgxconn.NewPgxConn(db), metadata[0].MetricFamilyName, 1)
 		require.NoError(t, err)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(result))

--- a/pkg/tests/end_to_end_tests/multi_tenancy_test.go
+++ b/pkg/tests/end_to_end_tests/multi_tenancy_test.go
@@ -40,13 +40,14 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 		require.NoError(t, err)
 		defer client.Close()
 
+		ctx := context.Background()
 		for _, tenant := range tenants {
 			request := newWriteRequestWithTs(copyMetrics(ts))
 			// Pre-processing.
 			wauth := mt.WriteAuthorizer()
 			err = wauth.Process(requestWithHeaderTenant(tenant), request)
 			require.NoError(t, err)
-			_, _, err = client.IngestMetrics(context.Background(), request)
+			_, _, err = client.IngestMetrics(ctx, request)
 			require.NoError(t, err)
 		}
 
@@ -76,7 +77,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -129,7 +130,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -196,7 +197,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -232,14 +233,15 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 		request := newWriteRequestWithTs(copyMetrics(ts))
 		err = wauth.Process(requestWithHeaderTenant(tenants[0]), request)
 		require.NoError(t, err)
-		_, _, err = client.IngestMetrics(context.Background(), request)
+		ctx := context.Background()
+		_, _, err = client.IngestMetrics(ctx, request)
 		require.NoError(t, err)
 
 		// Ingest tenant-b.
 		request = newWriteRequestWithTs(copyMetrics(ts))
 		err = wauth.Process(requestWithHeaderTenant(tenants[1]), request)
 		require.NoError(t, err)
-		_, _, err = client.IngestMetrics(context.Background(), request)
+		_, _, err = client.IngestMetrics(ctx, request)
 		require.NoError(t, err)
 		require.NoError(t, err)
 
@@ -273,7 +275,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 				},
 			},
 		}
-		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -297,7 +299,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 		// ----- query-test: querying an invalid tenant (tenant-c) -----
 		expectedResult = []prompb.TimeSeries{}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -350,7 +352,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 			},
 		}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -384,7 +386,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 
 		expectedResult = []prompb.TimeSeries{}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_RE,
@@ -420,7 +422,8 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 		request := newWriteRequestWithTs(copyMetrics(ts))
 		err = wauth.Process(requestWithHeaderTenant(tenants[0]), request)
 		require.NoError(t, err)
-		_, _, err = client.IngestMetrics(context.Background(), request)
+		ctx := context.Background()
+		_, _, err = client.IngestMetrics(ctx, request)
 		require.NoError(t, err)
 
 		// Ingest tenant-b.
@@ -476,7 +479,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 			},
 		}
 
-		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -524,7 +527,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 			},
 		}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -580,7 +583,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 			},
 		}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -597,7 +600,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 		verifyResults(t, expectedResult, result)
 
 		expectedResult = []prompb.TimeSeries{}
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -633,14 +636,15 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 		request := newWriteRequestWithTs(applyTenantAsExternalLabel(tenants[0], copyMetrics(ts)))
 		err = wauth.Process(&http.Request{}, request)
 		require.NoError(t, err)
-		_, _, err = client.IngestMetrics(context.Background(), request)
+		ctx := context.Background()
+		_, _, err = client.IngestMetrics(ctx, request)
 		require.NoError(t, err)
 
 		// Ingest tenant-b.
 		request = newWriteRequestWithTs(applyTenantAsExternalLabel(tenants[1], copyMetrics(ts)))
 		err = wauth.Process(&http.Request{}, request)
 		require.NoError(t, err)
-		_, _, err = client.IngestMetrics(context.Background(), request)
+		_, _, err = client.IngestMetrics(ctx, request)
 		require.NoError(t, err)
 		require.NoError(t, err)
 
@@ -675,7 +679,7 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 			},
 		}
 
-		result, err := qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err := qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,
@@ -728,7 +732,7 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 			},
 		}
 
-		result, err = qr.RemoteReadQuerier().Query(&prompb.Query{
+		result, err = qr.RemoteReadQuerier(ctx).Query(&prompb.Query{
 			Matchers: []*prompb.LabelMatcher{
 				{
 					Type:  prompb.LabelMatcher_EQ,

--- a/pkg/tests/end_to_end_tests/nan_test.go
+++ b/pkg/tests/end_to_end_tests/nan_test.go
@@ -79,7 +79,8 @@ func TestSQLStaleNaN(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ingestor.Close()
-		_, _, err = ingestor.IngestMetrics(context.Background(), newWriteRequestWithTs(copyMetrics(metrics)))
+		ctx := context.Background()
+		_, _, err = ingestor.IngestMetrics(ctx, newWriteRequestWithTs(copyMetrics(metrics)))
 
 		if err != nil {
 			t.Fatalf("unexpected error while ingesting test dataset: %s", err)
@@ -129,7 +130,7 @@ func TestSQLStaleNaN(t *testing.T) {
 			dbConn := pgxconn.NewPgxConn(db)
 			labelsReader := lreader.NewLabelsReader(dbConn, lCache, noopReadAuthorizer)
 			r := querier.NewQuerier(dbConn, mCache, labelsReader, nil, nil)
-			resp, err := r.RemoteReadQuerier().Query(c.query)
+			resp, err := r.RemoteReadQuerier(ctx).Query(c.query)
 			if err != nil {
 				t.Fatalf("unexpected error while ingesting test dataset: %s", err)
 			}


### PR DESCRIPTION
## Description

### Propagate context from query requests 
 
 Each http.Request comes with its own context, in the case the client
connection closes this context is cancelled.

Propagating the request context prevents the request handler from doing
extra work in situations when the client is not going to be able to
receive the response.

For supporting context propagation, the same approach from the
Prometheus codebase was followed. Every `Queryable` method that returns
a `Querier` accepts a context, it's the `Querier` responsibility to
propagate it downstream.

- Prometheus `Queryable` interface definition:
https://github.com/prometheus/prometheus/blob/15fa34936b6f1febe896ecee0f49889a56347762/storage/interface.go#L79-L84

- Prometheus `Querier` propagating the ctx in the `Select` method:
https://github.com/prometheus/prometheus/blob/15fa34936b6f1febe896ecee0f49889a56347762/storage/remote/read.go#L170

Even though endpoints like `/api/v1/query` and `/api/v1/query_range`
already propagated the context to downstream functions to the
`SamplesQuerier` to handle the `timeout` parameter of the request, the
`Querier` was not using the given context in the calls to the `PgxConn`
methods, it was using `context.Background()` instead.

An important consideration to keep in mind: cancelling the
context on a request for a running query will abort the connection to the
database but not the query. To cancel the query we might have to use
something like `statement_timeout` as proposed by
https://github.com/timescale/promscale/issues/1232 .

closes #1205

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
