### PR TITLE
Fix: Do not collect telemetry if set to `off`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We use the following categories for changes:
   requests [#1205]. 
 
 ### Fixed
+- Do not collect telemetry if `timescaledb.telemetry_level=off` [#1612]
 - Fix broken cache eviction in clockcache [#1603]
 - Possible goroutine leak due to unbuffered channel in select block [#1604]
 


### PR DESCRIPTION
Fixes: #1413 

Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

This commits updates the telemetry engine to start, irrespective of
whether `timescaledb.telemetry_level` is `on` or `off`. However,
collection of telemetry happens only when the `telemetry_level` is `on`.

This allows the telemetry engine to either start telemetry collection
if it was disabled in the starting, but enabled later on, or stop
telemetry collection if it was enabled in the starting but disabled
later on.

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
