### PR TITLE
Skip context.Canceled error in grpc logging interceptors

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -9,6 +9,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -57,7 +58,7 @@ func init() {
 
 func loggingUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	m, err := handler(ctx, req)
-	if err != nil {
+	if err != nil && !errors.As(err, &context.Canceled) {
 		log.Error("msg", "error in GRPC call", "err", err)
 	}
 	return m, err
@@ -65,7 +66,7 @@ func loggingUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.Un
 
 func loggingStreamInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	err := handler(srv, ss)
-	if err != nil {
+	if err != nil && !errors.As(err, &context.Canceled) {
 		log.Error("msg", "error in GRPC call", "err", err)
 	}
 	return err


### PR DESCRIPTION
context.Canceled is returned by grpc stream.Recv when you stop promscale with Ctrl-C.Skip logging the above error as the behavior is expected.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
