### PR TITLE
Fix possible goroutine leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ We use the following categories for changes:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
-## [Unreleased]
-
 ### Added
 - prom-migrator: Support for passing custom HTTP headers via command line arguments for both
   reader and writer [#1020].
@@ -22,6 +20,7 @@ We use the following categories for changes:
 
 ### Fixed
 - Fix broken cache eviction in clockcache [#1603]
+- Possible goroutine leak due to unbuffered channel in select block [#1604]
 
 ## [0.14.0] - 2022-08-30
 

--- a/pkg/jaeger/proxy/proxy.go
+++ b/pkg/jaeger/proxy/proxy.go
@@ -79,7 +79,7 @@ func New(config ProxyConfig, logger hclog.Logger) (*Proxy, error) {
 }
 
 func (p *Proxy) Close(ctx context.Context, _ *storage_v1.CloseWriterRequest) (*storage_v1.CloseWriterResponse, error) {
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		errChan <- p.conn.Close()
 		close(errChan)


### PR DESCRIPTION
## Description

Using unbuffered channels to receive in a select block might lead to a
goroutine leak if another branch of the select is selected instead.

By using a buffered channel the writer doesn't have to wait for another
goroutine to unblock it with a read. Instead it just uses the buffered
space to send the message and continue its execution.

fixes #1604 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
