### PR TITLE
Move from deprecated ioutil to io and os

### DIFF
--- a/migration-tool/pkg/integration_tests/remote_reader_test.go
+++ b/migration-tool/pkg/integration_tests/remote_reader_test.go
@@ -5,7 +5,7 @@
 package integration_tests
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -63,7 +63,7 @@ func getReadHandler(t *testing.T, series []prompb.TimeSeries, testRetry bool) ht
 			t.Fatal("invalid read headers")
 		}
 
-		compressed, err := ioutil.ReadAll(r.Body)
+		compressed, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal("msg", "read header validation error", "err", err.Error())
 		}

--- a/migration-tool/pkg/integration_tests/remote_writer_test.go
+++ b/migration-tool/pkg/integration_tests/remote_writer_test.go
@@ -7,7 +7,6 @@ package integration_tests
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
 	"net/http/httptest"
@@ -199,7 +198,7 @@ func getProgressHandler(t *testing.T, rws *remoteWriteServer, labels string) htt
 			t.Fatal("invalid read headers")
 		}
 
-		compressed, err := ioutil.ReadAll(r.Body)
+		compressed, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Fatal("msg", "read header validation error", "err", err.Error())
 		}
@@ -279,7 +278,7 @@ func FinishWriteRequest(wr *prompb.WriteRequest) {
 }
 
 func decodeSnappyBody(r io.Reader) ([]byte, error, string) {
-	compressed, err := ioutil.ReadAll(r)
+	compressed, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err, "Read error"
 	}

--- a/migration-tool/pkg/utils/client.go
+++ b/migration-tool/pkg/utils/client.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -243,7 +242,7 @@ retry:
 		return nil, 0, 0, err
 	}
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, httpResp.Body)
+		_, _ = io.Copy(io.Discard, httpResp.Body)
 		_ = httpResp.Body.Close()
 	}()
 
@@ -258,7 +257,7 @@ retry:
 		// This case belongs to when the client is used to fetch the progress metric from progress-metric url.
 		_, _ = io.Copy(&reader, httpResp.Body)
 	}
-	compressed, err = ioutil.ReadAll(bytes.NewReader(reader.Bytes()))
+	compressed, err = io.ReadAll(bytes.NewReader(reader.Bytes()))
 	if err != nil {
 		err = errors.Wrap(err, fmt.Sprintf("error reading response. HTTP status code: %s", httpResp.Status))
 		if c.clientConfig.shouldRetry(onError, numAttempts, fmt.Sprintf("error:\n%s\n", err.Error())) {
@@ -358,7 +357,7 @@ func (c *Client) Store(ctx context.Context, req []byte) error {
 		return RecoverableError{err}
 	}
 	defer func() {
-		_, _ = io.Copy(ioutil.Discard, httpResp.Body)
+		_, _ = io.Copy(io.Discard, httpResp.Body)
 		_ = httpResp.Body.Close()
 	}()
 

--- a/pkg/api/common.go
+++ b/pkg/api/common.go
@@ -9,9 +9,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -120,7 +120,7 @@ func readFromFile(path string, defaultValue string) (string, error) {
 	if path == "" {
 		return defaultValue, nil
 	}
-	bs, err := ioutil.ReadFile(path) // #nosec G304
+	bs, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return "", fmt.Errorf("unable to read file %s: %w", path, err)
 	}

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -7,7 +7,6 @@ package api
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -123,7 +122,7 @@ func doCORSWrapperRequest(t *testing.T, queryHandler http.Handler, url, origin s
 }
 
 func TestValidateConfig(t *testing.T) {
-	fileContents, err := ioutil.ReadFile("common_test.go")
+	fileContents, err := os.ReadFile("common_test.go")
 	if err != nil {
 		t.Fatal("error reading file contents common_test.go")
 	}

--- a/pkg/api/delete_test.go
+++ b/pkg/api/delete_test.go
@@ -6,7 +6,7 @@ package api
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -92,7 +92,7 @@ func TestDelete(t *testing.T) {
 				return
 			}
 			if tc.fails {
-				bstream, err := ioutil.ReadAll(wPost.Body)
+				bstream, err := io.ReadAll(wPost.Body)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -112,7 +112,7 @@ func TestDelete(t *testing.T) {
 				return
 			}
 			if tc.fails {
-				bstream, err := ioutil.ReadAll(wPut.Body)
+				bstream, err := io.ReadAll(wPut.Body)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/pkg/api/parser/json/json_test.go
+++ b/pkg/api/parser/json/json_test.go
@@ -5,7 +5,7 @@
 package json
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -164,7 +164,7 @@ func TestParseRequest(t *testing.T) {
 	for _, c := range testCases {
 		t.Run(c.name, func(t *testing.T) {
 			req := &http.Request{
-				Body: ioutil.NopCloser(strings.NewReader(c.body)),
+				Body: io.NopCloser(strings.NewReader(c.body)),
 			}
 			response := ingestor.NewWriteRequest()
 			defer ingestor.FinishWriteRequest(response)

--- a/pkg/api/parser/parser_test.go
+++ b/pkg/api/parser/parser_test.go
@@ -6,7 +6,7 @@ package parser
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -137,7 +137,7 @@ func TestParseRequest(t *testing.T) {
 				Header: map[string][]string{
 					"Content-Type": {contentType},
 				},
-				Body: ioutil.NopCloser(strings.NewReader(c.body)),
+				Body: io.NopCloser(strings.NewReader(c.body)),
 			}
 
 			parser := NewParser()

--- a/pkg/api/parser/text/text.go
+++ b/pkg/api/parser/text/text.go
@@ -3,7 +3,6 @@ package text
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -18,7 +17,7 @@ var timeProvider = time.Now
 
 // ParseRequest parses an incoming HTTP request as a Prometheus text format.
 func ParseRequest(r *http.Request, wr *prompb.WriteRequest) error {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		return fmt.Errorf("error reading request body: %w", err)
 	}

--- a/pkg/api/query_exemplar_test.go
+++ b/pkg/api/query_exemplar_test.go
@@ -6,7 +6,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -99,7 +99,7 @@ func TestQueryExemplar(t *testing.T) {
 		r := doExemplarQuery(t, "GET", preparedURL, handler)
 		require.Equal(t, tc.statusCode, r.Code, fmt.Sprintf("received code %d, expected %d", r.Code, tc.statusCode), tc.name)
 		if tc.shouldErr {
-			b, err := ioutil.ReadAll(r.Body)
+			b, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, tc.err, string(b), tc.name)
 		}

--- a/pkg/api/read.go
+++ b/pkg/api/read.go
@@ -6,7 +6,7 @@ package api
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -30,7 +30,7 @@ func Read(config *Config, reader querier.Reader, metrics *Metrics, updateMetrics
 			return
 		}
 
-		compressed, err := ioutil.ReadAll(r.Body)
+		compressed, err := io.ReadAll(r.Body)
 		if err != nil {
 			log.Error("msg", "Read header validation error", "err", err.Error())
 			http.Error(w, err.Error(), http.StatusBadRequest)

--- a/pkg/internal/testhelpers/containers.go
+++ b/pkg/internal/testhelpers/containers.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"time"
@@ -110,5 +109,5 @@ func TempDir(name string) (string, error) {
 		// so switch to cross-user tmp dir
 		tmpDir = "/tmp"
 	}
-	return ioutil.TempDir(tmpDir, name)
+	return os.MkdirTemp(tmpDir, name)
 }

--- a/pkg/internal/testhelpers/containers_test.go
+++ b/pkg/internal/testhelpers/containers_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	constants "github.com/timescale/promscale/pkg/tests"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	constants "github.com/timescale/promscale/pkg/tests"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -77,7 +77,7 @@ func runMain(m *testing.M) int {
 			// so switch to cross-user tmp dir
 			tmpDir = "/tmp"
 		}
-		path, err := ioutil.TempDir(tmpDir, "prom_test")
+		path, err := os.MkdirTemp(tmpDir, "prom_test")
 		if err != nil {
 			fmt.Println("Error getting temp dir for Prometheus storage", err)
 			os.Exit(1)

--- a/pkg/limits/flags_test.go
+++ b/pkg/limits/flags_test.go
@@ -6,7 +6,7 @@ package limits
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -85,7 +85,7 @@ func TestString(t *testing.T) {
 
 func fullyParse(t *testing.T, args []string, expectError bool) Config {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 	config := &Config{}
 	ParseFlags(fs, config)
 	err := ff.Parse(fs, args)

--- a/pkg/pgmodel/cache/flags_test.go
+++ b/pkg/pgmodel/cache/flags_test.go
@@ -6,7 +6,7 @@ package cache
 
 import (
 	"flag"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -17,7 +17,7 @@ import (
 
 func fullyParse(t *testing.T, args []string, lcfg *limits.Config, expectError bool) Config {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 	config := &Config{}
 	ParseFlags(fs, config)
 	err := ff.Parse(fs, args)

--- a/pkg/promql/engine_test.go
+++ b/pkg/promql/engine_test.go
@@ -16,7 +16,6 @@ package promql
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -44,7 +43,7 @@ func TestMain(m *testing.M) {
 func TestQueryConcurrency(t *testing.T) {
 	maxConcurrency := 10
 
-	dir, err := ioutil.TempDir("", "test_concurrency")
+	dir, err := os.MkdirTemp("", "test_concurrency")
 	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 	queryTracker := NewActiveQueryTracker(dir, maxConcurrency, nil)

--- a/pkg/promql/query_logger_test.go
+++ b/pkg/promql/query_logger_test.go
@@ -15,7 +15,6 @@ package promql
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -105,7 +104,7 @@ func TestIndexReuse(t *testing.T) {
 }
 
 func TestMMapFile(t *testing.T) {
-	file, err := ioutil.TempFile("", "mmapedFile")
+	file, err := os.CreateTemp("", "mmapedFile")
 	require.NoError(t, err)
 
 	filename := file.Name()

--- a/pkg/promql/test.go
+++ b/pkg/promql/test.go
@@ -16,7 +16,6 @@ package promql
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"strconv"
@@ -61,7 +60,7 @@ type TestStorage struct {
 // New returns a new TestStorage for testing purposes
 // that removes all associated files on closing.
 func NewTestStorage(t testutil.T) *TestStorage {
-	dir, err := ioutil.TempDir("", "test_storage")
+	dir, err := os.MkdirTemp("", "test_storage")
 	assert.NoError(t, err, "opening test dir failed")
 
 	// Tests just load data for a series sequentially. Thus we
@@ -150,7 +149,7 @@ func NewTest(t testutil.T, input string) (*Test, error) {
 }
 
 func newTestFromFile(t testutil.T, filename string) (*Test, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -7,7 +7,6 @@ package runner
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -276,7 +275,7 @@ func TestParseFlagsConfigPrecedence(t *testing.T) {
 
 			var configFilePath string
 			if c.configFileContents != "" {
-				f, err := ioutil.TempFile("", "promscale.yml")
+				f, err := os.CreateTemp("", "promscale.yml")
 				if err != nil {
 					t.Fatalf("unexpected error when creating config file: %s", err)
 				}
@@ -389,7 +388,7 @@ func TestRemovedFlagUsage(t *testing.T) {
 			}
 
 			if c.configFileContents != "" {
-				f, err := ioutil.TempFile("", "promscale.yml")
+				f, err := os.CreateTemp("", "promscale.yml")
 				if err != nil {
 					t.Fatalf("unexpected error when creating config file: %s", err)
 				}

--- a/pkg/tenancy/flags_test.go
+++ b/pkg/tenancy/flags_test.go
@@ -3,7 +3,7 @@ package tenancy
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -27,7 +27,7 @@ func TestParseFlags(t *testing.T) {
 
 func fullyParse(t *testing.T, args []string) Config {
 	fs := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
-	fs.SetOutput(ioutil.Discard)
+	fs.SetOutput(io.Discard)
 	config := &Config{}
 	ParseFlags(fs, config)
 	require.NoError(t, ff.Parse(fs, args))

--- a/pkg/tests/end_to_end_tests/alerts_test.go
+++ b/pkg/tests/end_to_end_tests/alerts_test.go
@@ -7,7 +7,6 @@ package end_to_end_tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"sync"
@@ -121,7 +120,7 @@ func waitForAlertWithName(expected string) error {
 // The aim of this function is to abstract out the code of setting up alertmanager that is copied from alertmanager repo
 // from the actual test.
 func setupAM(expected string) (*api.API, *sync.WaitGroup, *fakeAlerts, error) {
-	f, err := ioutil.TempFile(os.TempDir(), "*.alerts.test")
+	f, err := os.CreateTemp(os.TempDir(), "*.alerts.test")
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/tests/end_to_end_tests/datasets_metrics_test.go
+++ b/pkg/tests/end_to_end_tests/datasets_metrics_test.go
@@ -5,7 +5,7 @@
 package end_to_end_tests
 
 import (
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"time"
@@ -327,7 +327,7 @@ func generateRealTimeseries() []prompb.TimeSeries {
 			panic(err)
 		}
 
-		compressed, err := ioutil.ReadAll(f)
+		compressed, err := io.ReadAll(f)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/tests/end_to_end_tests/golden_files_test.go
+++ b/pkg/tests/end_to_end_tests/golden_files_test.go
@@ -5,7 +5,8 @@ package end_to_end_tests
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -53,7 +54,7 @@ func TestSQLGoldenFiles(t *testing.T) {
 
 			actualFile := filepath.Join(pgContainerTestDataDir, "out", base+".out")
 
-			actual, err := ioutil.ReadFile(actualFile)
+			actual, err := os.ReadFile(actualFile)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -69,7 +70,7 @@ func TestSQLGoldenFiles(t *testing.T) {
 				}
 				defer rc.Close()
 
-				msg, err := ioutil.ReadAll(rc)
+				msg, err := io.ReadAll(rc)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -96,7 +97,7 @@ func TestSQLGoldenFiles(t *testing.T) {
 				}
 			}
 
-			expected, err := ioutil.ReadFile(expectedFile)
+			expected, err := os.ReadFile(expectedFile)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/tests/end_to_end_tests/prometheus_wal_test.go
+++ b/pkg/tests/end_to_end_tests/prometheus_wal_test.go
@@ -3,7 +3,6 @@ package end_to_end_tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -30,7 +29,7 @@ func generatePrometheusWAL(withExemplars bool) ([]prompb.TimeSeries, string, err
 	if withExemplars {
 		dbStoragePath = dbStoragePath + "_with_exemplars"
 	}
-	dbPath, err := ioutil.TempDir(tmpDir, dbStoragePath)
+	dbPath, err := os.MkdirTemp(tmpDir, dbStoragePath)
 	if err != nil {
 		return nil, "", err
 	}
@@ -38,7 +37,7 @@ func generatePrometheusWAL(withExemplars bool) ([]prompb.TimeSeries, string, err
 	if !withExemplars {
 		// Take snapshots only when exemplars are not to be inserted.
 		// Otherwise, snapshots will remove them.
-		snapPath, err = ioutil.TempDir(tmpDir, "prom_snaptest_storage")
+		snapPath, err = os.MkdirTemp(tmpDir, "prom_snaptest_storage")
 		if err != nil {
 			return nil, "", err
 		}

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -7,7 +7,7 @@ package end_to_end_tests
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"math/rand"
 	"net/http"
@@ -139,13 +139,13 @@ func testRequest(tsReq, promReq *http.Request, client *http.Client, comparator r
 
 		compareHTTPHeaders(t, promResp.Header, tsResp.Header)
 
-		promContent, err := ioutil.ReadAll(promResp.Body)
+		promContent, err := io.ReadAll(promResp.Body)
 		if err != nil {
 			t.Fatalf("unexpected error returned when reading Prometheus response body:\n%s\n", err.Error())
 		}
 		defer promResp.Body.Close()
 
-		tsContent, err := ioutil.ReadAll(tsResp.Body)
+		tsContent, err := io.ReadAll(tsResp.Body)
 
 		if err != nil {
 			t.Fatalf("unexpected error returned when reading connector response body:\n%s\n", err.Error())
@@ -212,7 +212,7 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 
 				compareHTTPHeaders(t, promResp.Header, tsResp.Header)
 
-				promContent, err := ioutil.ReadAll(promResp.Body)
+				promContent, err := io.ReadAll(promResp.Body)
 
 				if err != nil {
 					t.Errorf("unexpected error returned when reading Prometheus response body:\n%s\n", err.Error())
@@ -220,7 +220,7 @@ func testRequestConcurrent(requestCases []requestCase, client *http.Client, comp
 				}
 				defer promResp.Body.Close()
 
-				tsContent, err := ioutil.ReadAll(tsResp.Body)
+				tsContent, err := io.ReadAll(tsResp.Body)
 
 				if err != nil {
 					t.Errorf("unexpected error returned when reading connector response body:\n%s\n", err.Error())

--- a/pkg/tests/end_to_end_tests/promql_write_endpoint_test.go
+++ b/pkg/tests/end_to_end_tests/promql_write_endpoint_test.go
@@ -7,7 +7,7 @@ package end_to_end_tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
@@ -122,7 +122,7 @@ func sendWriteRequest(t testing.TB, router http.Handler, ts []prompb.TimeSeries)
 		return
 	}
 
-	_, err = ioutil.ReadAll(tsResp.Body)
+	_, err = io.ReadAll(tsResp.Body)
 	if err != nil {
 		t.Errorf("unexpected error returned when reading connector response body:\n%s\n", err.Error())
 		return

--- a/pkg/tests/end_to_end_tests/query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/query_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"net/url"
@@ -79,7 +79,7 @@ func (c *PromClient) Read(rr *prompb.ReadRequest) (*prompb.ReadResponse, error) 
 		return nil, fmt.Errorf("Prometheus returned status: %s", httpResp.Status)
 	}
 
-	compressed, err = ioutil.ReadAll(httpResp.Body)
+	compressed, err = io.ReadAll(httpResp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tests/end_to_end_tests/trace_query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/trace_query_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"sort"
@@ -348,7 +348,7 @@ func do(url string) (*structuredResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("http get: %w", err)
 	}
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read all: %w", err)
 	}

--- a/pkg/tests/upgrade_tests/shapshot.go
+++ b/pkg/tests/upgrade_tests/shapshot.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -335,7 +334,7 @@ func getPsqlInfo(t *testing.T, container testcontainers.Container, dbName string
 
 func readOutput(t *testing.T, outputDir string) string {
 	outputFile := outputDir + "/output.out"
-	output, err := ioutil.ReadFile(filepath.Clean(outputFile))
+	output, err := os.ReadFile(filepath.Clean(outputFile))
 	if err != nil {
 		t.Errorf("error reading psql output: %v", err)
 	}

--- a/pkg/tests/upgrade_tests/upgrade_test.go
+++ b/pkg/tests/upgrade_tests/upgrade_test.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -107,7 +106,7 @@ func getDBImages(extensionState testhelpers.TestOptions, prevPromscaleVersion *s
 }
 
 func writeToFiles(t *testing.T, upgradedDbInfo, pristineDbInfo dbSnapshot) error {
-	dir, err := ioutil.TempDir("", "upgrade_test")
+	dir, err := os.MkdirTemp("", "upgrade_test")
 	if err != nil {
 		return err
 	}
@@ -571,7 +570,7 @@ func doWrite(t *testing.T, client *http.Client, url string, data ...[]prompb.Tim
 			t.Fatal("non-ok status:", resp.Status)
 		}
 
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 	}
 }


### PR DESCRIPTION
## Description

From the docs https://pkg.go.dev/io/ioutil as of Go 1.19 the package has
been deprecated.

> Deprecated: As of Go 1.16, the same functionality is now provided by
> package io or package os, and those implementations should be preferred
> in new code. See the specific function documentation for details.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
