### PR TITLE
Compare for context.Canceled error with `Is`

### DIFF
--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -58,7 +58,7 @@ func init() {
 
 func loggingUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 	m, err := handler(ctx, req)
-	if err != nil && !errors.As(err, &context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		log.Error("msg", "error in GRPC call", "err", err)
 	}
 	return m, err
@@ -66,7 +66,7 @@ func loggingUnaryInterceptor(ctx context.Context, req interface{}, info *grpc.Un
 
 func loggingStreamInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	err := handler(srv, ss)
-	if err != nil && !errors.As(err, &context.Canceled) {
+	if err != nil && !errors.Is(err, context.Canceled) {
 		log.Error("msg", "error in GRPC call", "err", err)
 	}
 	return err


### PR DESCRIPTION
Since `context.Caceled` is declared as:

```
var Canceled = errors.New("context canceled")
```

We should use `errors.Is` instead of `errors.As` because we are
comparing against and error value instead of the type of the error.

golangci-lint reports the current usage of `errors.As` with the
following error:

```
golangci-lint run
pkg/runner/runner.go:61:20: errorsas: second argument to errors.As should not be *error (govet)
        if err != nil && !errors.As(err, &context.Canceled) {
                          ^
pkg/runner/runner.go:69:20: errorsas: second argument to errors.As should not be *error (govet)
        if err != nil && !errors.As(err, &context.Canceled) {
```

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
