### PR TITLE
Allow configuring HA replica and cluster label names

### DIFF
--- a/pkg/api/read.go
+++ b/pkg/api/read.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
-	"github.com/timescale/promscale/pkg/ha"
 	"github.com/timescale/promscale/pkg/log"
 	"github.com/timescale/promscale/pkg/pgmodel/querier"
 	"github.com/timescale/promscale/pkg/prompb"
@@ -56,10 +55,10 @@ func Read(config *Config, reader querier.Reader, metrics *Metrics, updateMetrics
 		// Drop __replica__ labelSet when
 		// Promscale is running in HA mode
 		// as the same lebelSet is dropped during ingestion.
-		if config.HighAvailability {
+		if config.HighAvailability.Enabled {
 			for _, q := range req.Queries {
 				for ind, l := range q.Matchers {
-					if l.Name == ha.ReplicaNameLabel {
+					if l.Name == config.HighAvailability.ReplicaLabelName {
 						q.Matchers = append(q.Matchers[:ind], q.Matchers[ind+1:]...)
 					}
 				}

--- a/pkg/api/read_test.go
+++ b/pkg/api/read_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/timescale/promscale/pkg/ha"
 	"github.com/timescale/promscale/pkg/prompb"
 )
 
@@ -79,7 +80,7 @@ func TestRead(t *testing.T) {
 				response: c.readerResponse,
 				err:      c.readerErr,
 			}
-			config := &Config{}
+			config := &Config{HighAvailability: &ha.Config{}}
 			receivedQueriesCounter := &mockMetric{}
 
 			metrics = &Metrics{

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -31,9 +31,9 @@ import (
 // TODO: Refactor this function to reduce number of paramaters.
 func GenerateRouter(apiConf *Config, promqlConf *query.Config, client *pgclient.Client, store *jaegerStore.Store, authWrapper mux.MiddlewareFunc, reload func() error) (*mux.Router, error) {
 	var writePreprocessors []parser.Preprocessor
-	if apiConf.HighAvailability {
+	if apiConf.HighAvailability.Enabled {
 		service := ha.NewService(haClient.NewLeaseClient(client.ReadOnlyConnection()))
-		writePreprocessors = append(writePreprocessors, ha.NewFilter(service))
+		writePreprocessors = append(writePreprocessors, ha.NewFilter(service, apiConf.HighAvailability.ReplicaLabelName, apiConf.HighAvailability.ClusterLabelName))
 	}
 	if apiConf.MultiTenancy != nil {
 		writePreprocessors = append(writePreprocessors, apiConf.MultiTenancy.WriteAuthorizer())

--- a/pkg/ha/config.go
+++ b/pkg/ha/config.go
@@ -1,0 +1,50 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package ha
+
+import (
+	"flag"
+	"fmt"
+)
+
+const DefaultReplicaLabelName = "__replica__"
+const DefaultClusterLabelName = "cluster"
+
+var DefaultConfig = Config{
+	Enabled:          false,
+	ReplicaLabelName: DefaultReplicaLabelName,
+	ClusterLabelName: DefaultClusterLabelName,
+}
+
+type Config struct {
+	Enabled          bool
+	ReplicaLabelName string
+	ClusterLabelName string
+}
+
+func ParseFlags(fs *flag.FlagSet) *Config {
+	cfg := Config{}
+
+	fs.BoolVar(&cfg.Enabled, "metrics.high-availability", DefaultConfig.Enabled, "Enable external_labels based HA.")
+	fs.StringVar(&cfg.ReplicaLabelName, "metrics.high-availability.replica-label-name", DefaultConfig.ReplicaLabelName,
+		"Name of the label that provides a unique identifier for a Prometheus replica in HA mode.")
+	fs.StringVar(&cfg.ClusterLabelName, "metrics.high-availability.cluster-label-name", DefaultConfig.ClusterLabelName,
+		"Name of the label that uniquely identifies a cluster of Prometheus instances running in HA.")
+
+	return &cfg
+}
+
+func (cfg *Config) Validate() error {
+	// Do not validate other flags if HA is not enabled.
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if cfg.ReplicaLabelName == cfg.ClusterLabelName {
+		return fmt.Errorf("replica label name and cluster label name cannot be same")
+	}
+
+	return nil
+}

--- a/pkg/ha/config_test.go
+++ b/pkg/ha/config_test.go
@@ -1,0 +1,26 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package ha
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultFlags(t *testing.T) {
+	var cfg *Config
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+
+	cfg = ParseFlags(fs)
+
+	err := fs.Parse([]string{})
+	require.Nil(t, err)
+
+	require.Equal(t, DefaultConfig.Enabled, cfg.Enabled)
+	require.Equal(t, DefaultConfig.ReplicaLabelName, cfg.ReplicaLabelName)
+	require.Equal(t, DefaultConfig.ClusterLabelName, cfg.ClusterLabelName)
+}

--- a/pkg/ha/filter_test.go
+++ b/pkg/ha/filter_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/timescale/promscale/pkg/ha/client"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
 	"github.com/timescale/promscale/pkg/prompb"
@@ -69,7 +71,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster1"},
+							{Name: DefaultClusterLabelName, Value: "cluster1"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -88,7 +90,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -106,8 +108,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
-							{Name: ClusterNameLabel, Value: "cluster1"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
+							{Name: DefaultClusterLabelName, Value: "cluster1"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -121,7 +123,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster1"},
+							{Name: DefaultClusterLabelName, Value: "cluster1"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -146,8 +148,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica2"},
-							{Name: ClusterNameLabel, Value: "cluster2"},
+							{Name: DefaultReplicaLabelName, Value: "replica2"},
+							{Name: DefaultClusterLabelName, Value: "cluster2"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -176,8 +178,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
-							{Name: ClusterNameLabel, Value: "cluster3"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
+							{Name: DefaultClusterLabelName, Value: "cluster3"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -191,7 +193,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster3"},
+							{Name: DefaultClusterLabelName, Value: "cluster3"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -216,8 +218,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
-							{Name: ClusterNameLabel, Value: "cluster3"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
+							{Name: DefaultClusterLabelName, Value: "cluster3"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: behindLeaseTimestamp, Value: 0.1},
@@ -232,7 +234,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster3"},
+							{Name: DefaultClusterLabelName, Value: "cluster3"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.2},
@@ -257,8 +259,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
-							{Name: ClusterNameLabel, Value: "cluster3"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
+							{Name: DefaultClusterLabelName, Value: "cluster3"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: aheadLeaseTimestamp, Value: 0.1},
@@ -272,7 +274,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster3"},
+							{Name: DefaultClusterLabelName, Value: "cluster3"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: aheadLeaseTimestamp, Value: 0.1},
@@ -297,8 +299,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica2"},
-							{Name: ClusterNameLabel, Value: "cluster4"},
+							{Name: DefaultReplicaLabelName, Value: "replica2"},
+							{Name: DefaultClusterLabelName, Value: "cluster4"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -312,7 +314,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster4"},
+							{Name: DefaultClusterLabelName, Value: "cluster4"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.1},
@@ -337,8 +339,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica2"},
-							{Name: ClusterNameLabel, Value: "cluster5"},
+							{Name: DefaultReplicaLabelName, Value: "replica2"},
+							{Name: DefaultClusterLabelName, Value: "cluster5"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: behindLeaseTimestamp, Value: 0.1},
@@ -367,8 +369,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
-							{Name: ClusterNameLabel, Value: "cluster5"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
+							{Name: DefaultClusterLabelName, Value: "cluster5"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: behindLeaseTimestamp, Value: 0.1},
@@ -383,7 +385,7 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ClusterNameLabel, Value: "cluster5"},
+							{Name: DefaultClusterLabelName, Value: "cluster5"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: behindLeaseTimestamp, Value: 0.1},
@@ -414,8 +416,8 @@ func TestHaParserParseData(t *testing.T) {
 					{
 						Labels: []prompb.Label{
 							{Name: model.MetricNameLabelName, Value: "test"},
-							{Name: ReplicaNameLabel, Value: "replica1"},
-							{Name: ClusterNameLabel, Value: "cluster5"},
+							{Name: DefaultReplicaLabelName, Value: "replica1"},
+							{Name: DefaultClusterLabelName, Value: "cluster5"},
 						},
 						Samples: []prompb.Sample{
 							{Timestamp: inLeaseTimestamp, Value: 0.3},
@@ -446,7 +448,7 @@ func TestHaParserParseData(t *testing.T) {
 			if c.setClusterStates != nil {
 				SetLeaderInMockService(service, c.setClusterStates)
 			}
-			h := NewFilter(service)
+			h := NewFilter(service, DefaultReplicaLabelName, DefaultClusterLabelName)
 			err := h.Process(nil, c.args)
 			if err != nil {
 				if !c.wantErr {
@@ -561,4 +563,53 @@ func TestFilterSamples(t *testing.T) {
 		}
 	}
 
+}
+
+func TestFilterValidateLabels(t *testing.T) {
+	testCases := []struct {
+		description string
+		cluster     string
+		replica     string
+		errExpected bool
+	}{
+		{
+			description: "both cluster and replica label values are empty",
+			cluster:     "",
+			replica:     "",
+			errExpected: true,
+		},
+		{
+			description: "cluster label value is set but replica label value is empty",
+			cluster:     "test",
+			replica:     "",
+			errExpected: true,
+		},
+		{
+			description: "replica label value is set but cluster label value is empty",
+			cluster:     "",
+			replica:     "test-0",
+			errExpected: true,
+		},
+		{
+			description: "both cluster and replica label values are set",
+			cluster:     "test",
+			replica:     "test-0",
+			errExpected: false,
+		},
+	}
+
+	f := NewFilter(nil, DefaultReplicaLabelName, DefaultClusterLabelName)
+
+	for _, testcase := range testCases {
+		tc := testcase
+
+		t.Run(tc.description, func(t *testing.T) {
+			err := f.validateClusterLabels(tc.cluster, tc.replica)
+			if tc.errExpected {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
 }

--- a/pkg/runner/client.go
+++ b/pkg/runner/client.go
@@ -143,7 +143,7 @@ func CreateClient(r prometheus.Registerer, cfg *Config) (*pgclient.Client, error
 			"compression and thus performance and disk usage will be significantly negatively effected.")
 	}
 
-	if !cfg.APICfg.HighAvailability && !cfg.APICfg.ReadOnly {
+	if !cfg.APICfg.HighAvailability.Enabled && !cfg.APICfg.ReadOnly {
 		log.Info("msg", "Prometheus HA is not enabled")
 	}
 

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -225,7 +225,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 		if flagset["install-extensions"] && cfg.InstallExtensions {
 			return nil, fmt.Errorf("Cannot install or update TimescaleDB extension in read-only mode")
 		}
-		if flagset["metrics.high-availability"] && cfg.APICfg.HighAvailability {
+		if flagset["metrics.high-availability"] && cfg.APICfg.HighAvailability.Enabled {
 			return nil, fmt.Errorf("cannot run Promscale in both HA and read-only mode")
 		}
 		cfg.Migrate = false
@@ -235,7 +235,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 		cfg.UpgradeExtensions = false
 	}
 
-	if cfg.APICfg.HighAvailability {
+	if cfg.APICfg.HighAvailability.Enabled {
 		cfg.PgmodelCfg.UsesHA = true
 	}
 	return cfg, nil

--- a/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
+++ b/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
@@ -121,7 +121,7 @@ func prepareWriterWithHa(db *pgxpool.Pool, t testing.TB) (*util.ManualTicker, ht
 	sigClose := make(chan struct{})
 	sCache := cache.NewSeriesCache(cache.DefaultConfig, sigClose)
 	dataParser := parser.NewParser()
-	dataParser.AddPreprocessor(ha.NewFilter(haService))
+	dataParser.AddPreprocessor(ha.NewFilter(haService, ha.DefaultReplicaLabelName, ha.DefaultClusterLabelName))
 	mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
 
 	ing, err := ingestor.NewPgxIngestor(pgxconn.NewPgxConn(db), mCache, sCache, nil, &ingestor.Cfg{
@@ -542,8 +542,8 @@ func generateHASamplesRequest(input haTestInput) *http.Request {
 		sample := prompb.TimeSeries{
 			Labels: []prompb.Label{
 				{Name: model.MetricNameLabelName, Value: "metric"},
-				{Name: ha.ClusterNameLabel, Value: "cluster"},
-				{Name: ha.ReplicaNameLabel, Value: input.replica},
+				{Name: ha.DefaultClusterLabelName, Value: "cluster"},
+				{Name: ha.DefaultReplicaLabelName, Value: input.replica},
 			},
 			Samples: []prompb.Sample{{
 				Value: rand.Float64(), Timestamp: ts,

--- a/pkg/tests/end_to_end_tests/migrate_test.go
+++ b/pkg/tests/end_to_end_tests/migrate_test.go
@@ -80,6 +80,7 @@ func TestMigrateLock(t *testing.T) {
 				ReaderPoolSize: pgclient.MinPoolSize,
 				MaintPoolSize:  pgclient.MinPoolSize,
 			},
+			APICfg: *defaultAPIConfig(),
 		}
 		conn.Release()
 		reader, err := runner.CreateClient(prometheus.NewRegistry(), &cfg)
@@ -171,6 +172,7 @@ func TestInstallFlagPromscaleExtension(t *testing.T) {
 				SslMode:        "allow",
 				MaxConnections: -1,
 			},
+			APICfg: *defaultAPIConfig(),
 		}
 		conn.Release()
 		_, err = db.Exec(context.Background(), "DROP EXTENSION IF EXISTS promscale")

--- a/pkg/tests/end_to_end_tests/no_timescaledb_test.go
+++ b/pkg/tests/end_to_end_tests/no_timescaledb_test.go
@@ -5,6 +5,8 @@ package end_to_end_tests
 
 import (
 	"context"
+	"testing"
+
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
@@ -12,7 +14,6 @@ import (
 	"github.com/timescale/promscale/pkg/pgclient"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/runner"
-	"testing"
 )
 
 func TestMigrationFailsIfNoTimescaleDBAvailable(t *testing.T) {
@@ -49,6 +50,7 @@ func TestMigrationFailsIfNoTimescaleDBAvailable(t *testing.T) {
 				WriterPoolSize: pgclient.MinPoolSize,
 				ReaderPoolSize: pgclient.MinPoolSize,
 			},
+			APICfg: *defaultAPIConfig(),
 		}
 
 		_, err = runner.CreateClient(prometheus.NewRegistry(), &cfg)

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/timescale/promscale/pkg/api"
+	"github.com/timescale/promscale/pkg/ha"
 	"github.com/timescale/promscale/pkg/pgclient"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/query"
@@ -280,8 +281,9 @@ func dateHeadersMatch(expected, actual []string) bool {
 
 func defaultAPIConfig() *api.Config {
 	return &api.Config{
-		AllowedOrigin: regexp.MustCompile(".*"),
-		TelemetryPath: "/metrics",
+		AllowedOrigin:    regexp.MustCompile(".*"),
+		TelemetryPath:    "/metrics",
+		HighAvailability: &ha.Config{},
 	}
 }
 

--- a/pkg/tests/end_to_end_tests/router_test.go
+++ b/pkg/tests/end_to_end_tests/router_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/timescale/promscale/pkg/api"
 	"github.com/timescale/promscale/pkg/auth"
+	"github.com/timescale/promscale/pkg/ha"
 )
 
 var (
@@ -52,8 +53,9 @@ func TestRouterAuth(t *testing.T) {
 		}
 
 		apiConfig := &api.Config{
-			AllowedOrigin: regexp.MustCompile(".*"),
-			TelemetryPath: "/metrics",
+			AllowedOrigin:    regexp.MustCompile(".*"),
+			TelemetryPath:    "/metrics",
+			HighAvailability: &ha.Config{},
 		}
 
 		router, pgClient, err := buildRouterWithAPIConfig(db, apiConfig, nil)
@@ -87,8 +89,9 @@ func TestRouterAuth(t *testing.T) {
 		}
 
 		apiConfig = &api.Config{
-			AllowedOrigin: regexp.MustCompile(".*"),
-			TelemetryPath: "/metrics",
+			AllowedOrigin:    regexp.MustCompile(".*"),
+			TelemetryPath:    "/metrics",
+			HighAvailability: &ha.Config{},
 		}
 
 		authWrapper := func(h http.Handler) http.Handler {

--- a/pkg/tests/end_to_end_tests/telemetry_test.go
+++ b/pkg/tests/end_to_end_tests/telemetry_test.go
@@ -332,6 +332,7 @@ func TestPromQLBasedTelemetry(t *testing.T) {
 				ReaderPoolSize: pgclient.MinPoolSize,
 				MaintPoolSize:  pgclient.MinPoolSize,
 			},
+			APICfg: *defaultAPIConfig(),
 		}
 		defer conn.Release()
 


### PR DESCRIPTION
## Description
Fixes #1578 .

This PR adds two new flags to allow configuring the replica and cluster label names. Currently both of the label names are not configurable but are required for HA to work.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
