### PR TITLE
Manually Vacuum Freeze Compressed Chunks

### DIFF
--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -101,6 +101,7 @@ func NewClient(r prometheus.Registerer, cfg *Config, mt tenancy.Authorizer, sche
 			return nil, fmt.Errorf("err creating writer connection pool: %w", err)
 		}
 
+		/* jgp debug
 		maintPoolSize = cfg.MaintenancePoolSize
 		if maintPoolSize < MinPoolSize {
 			return nil, fmt.Errorf("maintenance pool size canot be less than %d: received %d", MinPoolSize, maintPoolSize)
@@ -114,6 +115,7 @@ func NewClient(r prometheus.Registerer, cfg *Config, mt tenancy.Authorizer, sche
 		if err != nil {
 			return nil, fmt.Errorf("err creating maintenance connection pool: %w", err)
 		}
+		*/
 	}
 
 	readerPoolSize, err := cfg.GetPoolSize("reader", readerFraction, cfg.ReaderPoolSize)

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -275,6 +275,10 @@ func (c *Client) ReadOnlyConnection() pgxconn.PgxConn {
 	return c.readerPool
 }
 
+func (c *Client) ReadWriteConnection() pgxconn.PgxConn {
+	return c.writerPool
+}
+
 func (c *Client) MaintenanceConnection() pgxconn.PgxConn {
 	return c.maintPool
 }

--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -79,7 +79,6 @@ func NewClient(r prometheus.Registerer, cfg *Config, mt tenancy.Authorizer, sche
 		if err != nil {
 			return nil, fmt.Errorf("get writer pool size: %w", err)
 		}
-		writerPoolSize = writerPoolSize
 		totalConns += writerPoolSize
 
 		numCopiers, err = cfg.GetNumCopiers()
@@ -275,10 +274,14 @@ func (c *Client) ReadOnlyConnection() pgxconn.PgxConn {
 	return c.readerPool
 }
 
-func (c *Client) ReadWriteConnection() pgxconn.PgxConn {
+// WriterConnection returns a connection from the writer pool
+// Will return nil if promscale is running in read only mode
+func (c *Client) WriterConnection() pgxconn.PgxConn {
 	return c.writerPool
 }
 
+// MaintenanceConnection returns a connection from the maintenance pool
+// Will return nil if promscale is running in read only mode
 func (c *Client) MaintenanceConnection() pgxconn.PgxConn {
 	return c.maintPool
 }

--- a/pkg/pgclient/config.go
+++ b/pkg/pgclient/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	IgnoreCompressedChunks  bool
 	MetricsAsyncAcks        bool
 	TracesAsyncAcks         bool
+	MaintenancePoolSize     int
 	WriteConnections        int
 	WriterPoolSize          int
 	WriterSynchronousCommit bool
@@ -58,6 +59,7 @@ const (
 	defaultConnectionTime          = time.Minute
 	defaultDbStatementsCache       = true
 	MinPoolSize                    = 2
+	defaultMaintenancePoolSize     = 10
 	defaultPoolSize                = -1
 	defaultMaxConns                = -1
 	defaultWriterSynchronousCommit = false
@@ -84,6 +86,7 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.BoolVar(&cfg.IgnoreCompressedChunks, "metrics.ignore-samples-written-to-compressed-chunks", false, "Ignore/drop samples that are being written to compressed chunks. "+
 		"Setting this to false allows Promscale to ingest older data by decompressing chunks that were earlier compressed. "+
 		"However, setting this to true will save your resources that may be required during decompression. ")
+	fs.IntVar(&cfg.MaintenancePoolSize, "db.connections.maint-pool.size", defaultMaintenancePoolSize, "Maximum size of the maintenance pool of database connections.")
 	fs.IntVar(&cfg.WriteConnections, "db.connections.num-writers", 0, "Number of database connections for writing metrics/traces to database. "+
 		"By default, this will be set based on the number of CPUs available to the DB Promscale is connected to.")
 	fs.IntVar(&cfg.WriterPoolSize, "db.connections.writer-pool.size", defaultPoolSize, "Maximum size of the writer pool of database connections. This defaults to 50% of max_connections "+

--- a/pkg/runner/flags.go
+++ b/pkg/runner/flags.go
@@ -23,6 +23,7 @@ import (
 	"github.com/timescale/promscale/pkg/tenancy"
 	"github.com/timescale/promscale/pkg/tracer"
 	"github.com/timescale/promscale/pkg/util"
+	"github.com/timescale/promscale/pkg/vacuum"
 )
 
 type Config struct {
@@ -38,6 +39,7 @@ type Config struct {
 	PromQLCfg                   query.Config
 	RulesCfg                    rules.Config
 	TracingCfg                  jaegerStore.Config
+	VacuumCfg                   vacuum.Config
 	ConfigFile                  string
 	DatasetConfig               string
 	TLSCertFile                 string
@@ -132,6 +134,7 @@ func ParseFlags(cfg *Config, args []string) (*Config, error) {
 	query.ParseFlags(fs, &cfg.PromQLCfg)
 	jaegerStore.ParseFlags(fs, &cfg.TracingCfg)
 	rules.ParseFlags(fs, &cfg.RulesCfg)
+	vacuum.ParseFlags(fs, &cfg.VacuumCfg)
 
 	fs.StringVar(&cfg.ConfigFile, "config", "config.yml", "YAML configuration file path for Promscale.")
 	fs.StringVar(&cfg.ListenAddr, "web.listen-address", ":9201", "Address to listen on for web endpoints.")
@@ -245,6 +248,9 @@ func validate(cfg *Config) error {
 	}
 	if err := rules.Validate(&cfg.RulesCfg); err != nil {
 		return fmt.Errorf("error validating rules configuration: %w", err)
+	}
+	if err := vacuum.Validate(&cfg.VacuumCfg); err != nil {
+		return fmt.Errorf("error validating vacuum configuration: %w", err)
 	}
 	return nil
 }

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -170,6 +171,27 @@ func TestParseFlags(t *testing.T) {
 			name:        "test deprecated CLI flag",
 			args:        []string{"-db-writer-connection-concurrency", "10"},
 			shouldError: true,
+		},
+		{
+			name:        "test vacuum.disable",
+			args:        []string{"-vacuum.disable", "true"},
+			shouldError: false,
+			result: func(c Config) Config {
+				c.VacuumCfg.Disable = true
+				c.VacuumCfg.RunFrequency = 10 * time.Minute
+				c.VacuumCfg.Parallelism = 4
+				return c
+			},
+		},
+		{
+			name:        "test vacuum",
+			args:        []string{"-vacuum.parallelism", "5", "-vacuum.run-frequency", "30m"},
+			shouldError: false,
+			result: func(c Config) Config {
+				c.VacuumCfg.RunFrequency = 30 * time.Minute
+				c.VacuumCfg.Parallelism = 5
+				return c
+			},
 		},
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -256,8 +256,8 @@ func Run(cfg *Config) error {
 		},
 	)
 
-	if !cfg.VacuumCfg.Disable {
-		ve := vacuum.NewEngine(client.ReadWriteConnection(), cfg.VacuumCfg.RunFrequency, cfg.VacuumCfg.Parallelism)
+	if !cfg.VacuumCfg.Disable && !cfg.APICfg.ReadOnly {
+		ve := vacuum.NewEngine(client.MaintenanceConnection(), cfg.VacuumCfg.RunFrequency, cfg.VacuumCfg.Parallelism)
 		group.Add(
 			func() error {
 				log.Info("msg", "Starting vacuum engine")

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -20,6 +20,7 @@ import (
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 	"github.com/oklog/run"
+	"github.com/timescale/promscale/pkg/vacuum"
 	"go.opentelemetry.io/collector/pdata/ptrace/ptraceotlp"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
@@ -254,6 +255,20 @@ func Run(cfg *Config) error {
 			grpcServer.Stop()
 		},
 	)
+
+	if !cfg.VacuumCfg.Disable {
+		ve := vacuum.NewEngine(client.ReadWriteConnection(), cfg.VacuumCfg.RunFrequency, cfg.VacuumCfg.Parallelism)
+		group.Add(
+			func() error {
+				log.Info("msg", "Starting vacuum engine")
+				ve.Start()
+				return nil
+			}, func(err error) {
+				log.Info("msg", "Stopping vacuum engine")
+				ve.Stop()
+			},
+		)
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("/", router)

--- a/pkg/tests/end_to_end_tests/alerts_test.go
+++ b/pkg/tests/end_to_end_tests/alerts_test.go
@@ -47,7 +47,7 @@ func TestAlerts(t *testing.T) {
 			MaxConnections: -1,
 		}
 
-		pgClient, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), conf, 1, db, db, tenancy.NewNoopAuthorizer(), false)
+		pgClient, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), conf, 1, db, db, db, tenancy.NewNoopAuthorizer(), false)
 		require.NoError(t, err)
 		defer pgClient.Close()
 		err = pgClient.InitPromQLEngine(&query.Config{

--- a/pkg/tests/end_to_end_tests/multi_tenancy_test.go
+++ b/pkg/tests/end_to_end_tests/multi_tenancy_test.go
@@ -36,7 +36,7 @@ func TestMultiTenancyWithoutValidTenants(t *testing.T) {
 		require.NoError(t, err)
 
 		// Ingestion.
-		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, mt, false)
+		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, db, mt, false)
 		require.NoError(t, err)
 		defer client.Close()
 
@@ -224,7 +224,7 @@ func TestMultiTenancyWithValidTenants(t *testing.T) {
 		require.NoError(t, err)
 
 		// Ingestion.
-		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, mt, false)
+		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, db, mt, false)
 		require.NoError(t, err)
 		defer client.Close()
 
@@ -413,7 +413,7 @@ func TestMultiTenancyWithValidTenantsAndNonTenantOps(t *testing.T) {
 		require.NoError(t, err)
 
 		// Ingestion.
-		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, mt, false)
+		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, db, mt, false)
 		require.NoError(t, err)
 		defer client.Close()
 
@@ -627,7 +627,7 @@ func TestMultiTenancyWithValidTenantsAsLabels(t *testing.T) {
 		require.NoError(t, err)
 
 		// Ingestion.
-		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, mt, false)
+		client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, db, mt, false)
 		require.NoError(t, err)
 		defer client.Close()
 
@@ -759,7 +759,7 @@ func TestMultiTenancyLabelNamesValues(t *testing.T) {
 	ts, _ := generateSmallMultiTenantTimeseries()
 	withDB(t, *testDatabase, func(db *pgxpool.Pool, tb testing.TB) {
 		getClient := func(auth tenancy.Authorizer) *pgclient.Client {
-			client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, auth, false)
+			client, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), &testConfig, 1, db, db, db, auth, false)
 			require.NoError(t, err)
 			return client
 		}

--- a/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
+++ b/pkg/tests/end_to_end_tests/promql_endpoint_integration_test.go
@@ -311,7 +311,7 @@ func buildRouterWithAPIConfig(pool *pgxpool.Pool, cfg *api.Config) (*mux.Router,
 		MaxConnections: -1,
 	}
 
-	pgClient, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), conf, 1, pool, pool, tenancy.NewNoopAuthorizer(), cfg.ReadOnly)
+	pgClient, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), conf, 1, pool, pool, pool, tenancy.NewNoopAuthorizer(), cfg.ReadOnly)
 	if err != nil {
 		return nil, pgClient, fmt.Errorf("cannot run test, cannot instantiate pgClient: %w", err)
 	}

--- a/pkg/tests/end_to_end_tests/rules_test.go
+++ b/pkg/tests/end_to_end_tests/rules_test.go
@@ -35,7 +35,7 @@ func TestRecordingRulesEval(t *testing.T) {
 			MaxConnections: -1,
 		}
 
-		pgClient, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), conf, 1, db, db, tenancy.NewNoopAuthorizer(), false)
+		pgClient, err := pgclient.NewClientWithPool(prometheus.NewRegistry(), conf, 1, db, db, db, tenancy.NewNoopAuthorizer(), false)
 		require.NoError(t, err)
 		defer pgClient.Close()
 		err = pgClient.InitPromQLEngine(&query.Config{

--- a/pkg/tests/end_to_end_tests/vacuum_test.go
+++ b/pkg/tests/end_to_end_tests/vacuum_test.go
@@ -1,0 +1,181 @@
+package end_to_end_tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/require"
+	"github.com/timescale/promscale/pkg/pgxconn"
+	"github.com/timescale/promscale/pkg/vacuum"
+)
+
+type uncompressedChunk struct {
+	id     int
+	schema string
+	table  string
+}
+
+type compressedChunk struct {
+	id int
+}
+
+func TestVacuumBlocking(t *testing.T) {
+	if !*useTimescaleDB {
+		t.Skip("vacuum engine needs TimescaleDB support")
+	}
+	testVacuum(t, func(e *vacuum.Engine) {
+		e.RunOnce()
+	})
+}
+
+func TestVacuumNonBlocking(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	if !*useTimescaleDB {
+		t.Skip("vacuum engine needs TimescaleDB support")
+	}
+	testVacuum(t, func(e *vacuum.Engine) {
+		go e.Start()
+		time.Sleep(20 * time.Second)
+		e.Stop()
+	})
+}
+
+func testVacuum(t *testing.T, do func(e *vacuum.Engine)) {
+	/*
+		create two hypertables with compression enabled but the policy set that it doesn't compress automatically
+		load enough samples to create a bunch of chunks
+		choose some chunks, compress them, and see if the show up in the view
+		run the vacuum engine
+		make sure the chunks disappear from the view
+	*/
+	var ctx = context.Background()
+	databaseName := fmt.Sprintf("%s_vacuum", *testDatabase)
+	withDB(t, databaseName, func(db *pgxpool.Pool, tb testing.TB) {
+		createMetric(t, ctx, db, "metric1")
+		createMetric(t, ctx, db, "metric2")
+		loadSamples(t, ctx, db, "metric1")
+		loadSamples(t, ctx, db, "metric2")
+		chunksExist(t, ctx, db)
+		viewEmpty(t, ctx, db)
+		const count = 5
+		uncompressed := chooseUncompressedChunks(t, ctx, db, count)
+		compressChunks(t, ctx, db, uncompressed)
+		compressed := view(t, ctx, db)
+		require.Equal(t, count, len(compressed), "Expected to find %d compressed chunks but got %d", count, len(compressed))
+		engine := vacuum.NewEngine(pgxconn.NewPgxConn(db), time.Second, count)
+		do(engine)
+		viewEmpty(t, ctx, db)
+	})
+}
+
+func createMetric(t *testing.T, ctx context.Context, db *pgxpool.Pool, name string) {
+	_, err := db.Exec(ctx, fmt.Sprintf("create table %s(id int, t timestamptz not null, val double precision)", name))
+	if err != nil {
+		t.Fatalf("Failed to create hypertable %s: %v", name, err)
+	}
+	_, err = db.Exec(ctx, "select create_hypertable($1::regclass, 't', chunk_time_interval=>'5 minutes'::interval)", name)
+	if err != nil {
+		t.Fatalf("Failed to create hypertable %s: %v", name, err)
+	}
+	_, err = db.Exec(ctx, fmt.Sprintf("alter table %s set (timescaledb.compress, timescaledb.compress_segmentby = 'id')", name))
+	if err != nil {
+		t.Fatalf("Failed to create hypertable %s: %v", name, err)
+	}
+	_, err = db.Exec(ctx, "select add_compression_policy($1, INTERVAL '7 days')", name)
+	if err != nil {
+		t.Fatalf("Failed to set compression policy on hypertable %s: %v", name, err)
+	}
+}
+
+func loadSamples(t *testing.T, ctx context.Context, db *pgxpool.Pool, name string) {
+	d := time.Now().Truncate(time.Minute)
+	for i := 0; i < 25; i++ {
+		_, err := db.Exec(ctx, fmt.Sprintf(`
+			insert into %s (id, t, val)
+			select x, $1, random()
+			from generate_series(1, 5) x
+			`, name), d)
+		if err != nil {
+			t.Fatalf("Failed to load samples into hypertable %s: %v", name, err)
+		}
+		d = d.Add(time.Minute * 5)
+	}
+}
+
+func chunksExist(t *testing.T, ctx context.Context, db *pgxpool.Pool) {
+	var nbr int64
+	err := db.QueryRow(ctx, "select count(*) from _timescaledb_catalog.chunk").Scan(&nbr)
+	if err != nil {
+		t.Fatalf("failed to count chunks: %v", err)
+	}
+	require.GreaterOrEqual(t, nbr, int64(10), "Expected a bunch of chunks but got %d", nbr)
+}
+
+func viewEmpty(t *testing.T, ctx context.Context, db *pgxpool.Pool) {
+	var nbr int64
+	err := db.QueryRow(ctx, "select count(*) from _ps_catalog.chunks_to_vacuum_freeze").Scan(&nbr)
+	if err != nil {
+		t.Fatalf("Failed to count chunks: %v", err)
+	}
+	require.Equal(t, int64(0), nbr, "Expected view to return zero results but got %d", nbr)
+}
+
+func chooseUncompressedChunks(t *testing.T, ctx context.Context, db *pgxpool.Pool, count int) []uncompressedChunk {
+	rows, err := db.Query(ctx, `
+		select id, schema_name, table_name
+		from _timescaledb_catalog.chunk
+		where compressed_chunk_id is null
+		order by random()
+		limit $1
+	`, count)
+	if err != nil {
+		t.Fatalf("Failed to select random uncompressed chunks: %v", err)
+	}
+	defer rows.Close()
+	chunks := make([]uncompressedChunk, 0)
+	for rows.Next() {
+		var chunk uncompressedChunk
+		err := rows.Scan(&chunk.id, &chunk.schema, &chunk.table)
+		if err != nil {
+			t.Fatalf("Failed to scan uncompressed chunk: %v", err)
+		}
+		chunks = append(chunks, chunk)
+	}
+	require.Equal(t, count, len(chunks), "Expected %d uncompresed chunks but got %d", count, len(chunks))
+	return chunks
+}
+
+func compressChunks(t *testing.T, ctx context.Context, db *pgxpool.Pool, chunks []uncompressedChunk) {
+	for _, chunk := range chunks {
+		_, err := db.Exec(ctx, "select compress_chunk(format('%I.%I', $1::text, $2::text)::regclass)", chunk.schema, chunk.table)
+		if err != nil {
+			t.Fatalf("Failed to compress chunk %s.%s: %v", chunk.schema, chunk.table, err)
+		}
+	}
+}
+
+func view(t *testing.T, ctx context.Context, db *pgxpool.Pool) []compressedChunk {
+	rows, err := db.Query(ctx, `
+		select compressed_chunk_id
+		from _ps_catalog.chunks_to_vacuum_freeze
+	`)
+	if err != nil {
+		t.Fatalf("Failed to select from _ps_catalog.chunks_to_vacuum_freeze: %v", err)
+	}
+	defer rows.Close()
+	chunks := make([]compressedChunk, 0)
+	for rows.Next() {
+		var chunk compressedChunk
+		err := rows.Scan(&chunk.id)
+		if err != nil {
+			t.Fatalf("Failed to scan uncompressed chunk: %v", err)
+		}
+		chunks = append(chunks, chunk)
+	}
+	return chunks
+}

--- a/pkg/vacuum/vacuum.go
+++ b/pkg/vacuum/vacuum.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	sqlStart            = "SELECT pg_try_advisory_lock(1982010619820106)"
-	sqlListChunks       = "SELECT format('%I.%I', schema_name, table_name) from _ps_catalog.chunks_to_vacuum_freeze LIMIT 1000"
+	sqlListChunks       = "SELECT format('%I.%I', schema_name, table_name) from _ps_catalog.chunks_to_freeze LIMIT 1000"
 	sqlVacuumFmt        = "VACUUM (FREEZE, ANALYZE) %s"
 	sqlStop             = "SELECT pg_advisory_unlock(1982010619820106)"
 	delay               = 10 * time.Second
@@ -101,7 +101,6 @@ func every(every time.Duration, task func()) (execute, kill func()) {
 	kill = func() {
 		once.Do(func() {
 			ticker.Stop()
-			die <- struct{}{}
 			close(die)
 		})
 	}

--- a/pkg/vacuum/vacuum.go
+++ b/pkg/vacuum/vacuum.go
@@ -1,0 +1,223 @@
+package vacuum
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/timescale/promscale/pkg/log"
+	"github.com/timescale/promscale/pkg/pgxconn"
+)
+
+const (
+	sqlStart            = "SELECT pg_try_advisory_lock(1982010619820106)"
+	sqlListChunks       = "SELECT format('%I.%I', schema_name, table_name) from _ps_catalog.chunks_to_vacuum_freeze LIMIT 1000"
+	sqlVacuumFmt        = "VACUUM (FREEZE, ANALYZE) %s"
+	sqlStop             = "SELECT pg_advisory_unlock(1982010619820106)"
+	delay               = 10 * time.Second
+	defaultDisable      = false
+	defaultRunFrequency = 10 * time.Minute
+	defaultParallelism  = 4
+	minParallelism      = 1
+)
+
+type Config struct {
+	Disable      bool
+	RunFrequency time.Duration
+	Parallelism  int
+}
+
+func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
+	fs.BoolVar(&cfg.Disable, "vacuum.disable", defaultDisable, "disables the vacuum engine")
+	fs.DurationVar(&cfg.RunFrequency, "vacuum.run-frequency", defaultRunFrequency, "how often should the vacuum engine run")
+	fs.IntVar(&cfg.Parallelism, "vacuum.parallelism", defaultParallelism, "how many goroutines/connections should be used to vacuum")
+	return cfg
+}
+
+func Validate(cfg *Config) error {
+	if cfg.Disable {
+		return nil
+	}
+	if cfg.Parallelism < minParallelism {
+		return fmt.Errorf("vacuum.parallelism must be at least %d: %d", minParallelism, cfg.Parallelism)
+	}
+	if cfg.RunFrequency <= 0 {
+		return fmt.Errorf("vacuum.run-frequency must be positive: %d", cfg.RunFrequency)
+	}
+	return nil
+}
+
+// Engine periodically vacuums compressed chunks
+type Engine struct {
+	runFreq     time.Duration
+	pool        pgxconn.PgxConn
+	parallelism int
+	mu          sync.Mutex
+	kill        func()
+}
+
+// NewEngine creates a new Engine
+func NewEngine(pool pgxconn.PgxConn, runFreq time.Duration, parallelism int) *Engine {
+	return &Engine{
+		runFreq:     runFreq,
+		pool:        pool,
+		parallelism: parallelism,
+	}
+}
+
+// Start starts the Engine
+// Blocks forever unless Stop is called
+func (e *Engine) Start() {
+	var execute, kill = every(e.runFreq, e.RunOnce)
+	func() {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		e.kill = kill
+	}()
+	execute() // blocks forever unless kill is called
+}
+
+// Stop stops the engine if it is running
+func (e *Engine) Stop() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.kill != nil {
+		e.kill()
+	}
+}
+
+// every executes a task periodically
+// returns an execute function which when called will block
+// and execute task periodically, and a kill function which will
+// terminate the execution function if called
+func every(every time.Duration, task func()) (execute, kill func()) {
+	var ticker = time.NewTicker(every)
+	var once sync.Once
+	var die = make(chan struct{}, 1)
+
+	kill = func() {
+		once.Do(func() {
+			ticker.Stop()
+			die <- struct{}{}
+			close(die)
+		})
+	}
+
+	execute = func() {
+		defer kill() // be sure to clean up our ticker and channel
+		// loop forever, or until the die signal is received
+		for {
+			select {
+			case <-ticker.C:
+				task()
+			case <-die:
+				return
+			}
+		}
+	}
+	return
+}
+
+// RunOnce attempts vacuum a batch of compressed chunks
+func (e *Engine) RunOnce() {
+	con, err := e.pool.Acquire(context.Background())
+	if err != nil {
+		log.Error("msg", "failed to acquire a db connection", "error", err)
+		return
+	}
+	defer con.Release() // return the connection to the pool when finished with it
+	acquired := false
+	err = con.QueryRow(context.Background(), sqlStart).Scan(&acquired)
+	if err != nil {
+		log.Error("msg", "failed to attempt to acquire advisory lock", "error", err)
+		return
+	}
+	if !acquired {
+		log.Info("msg", "vacuum engine did not acquire advisory lock")
+		return
+	}
+	// release the advisory lock when we're done
+	defer func() {
+		_, err := con.Exec(context.Background(), sqlStop)
+		if err != nil {
+			log.Error("msg", "vacuum engine failed to release advisory lock", "error", err)
+		}
+	}()
+	// we limit ourselves to batches of 1000 chunks
+	// since we already have the advisory lock, continue to vacuum batches as needed until none left
+	for {
+		chunks, err := e.listChunks(con)
+		if err != nil {
+			log.Error("msg", "failed to list chunks for vacuuming", "error", err)
+			return
+		}
+		if len(chunks) == 0 {
+			log.Info("msg", "zero compressed chunks need to be vacuumed")
+			return
+		}
+		log.Info("msg", "compressed chunks need to be vacuumed", "count", len(chunks))
+		p := e.parallelism
+		if len(chunks) < p {
+			// don't spin up more workers than we could possibly use
+			// if parallelism is 6, but we only have 5 chunks to work on, use 5 workers
+			p = len(chunks)
+		}
+		runWorkers(p, chunks, e.worker)
+		// in some cases, have seen it take up to 10 seconds for the stats to be updated post vacuum
+		time.Sleep(delay)
+	}
+}
+
+// listChunks identifies chunks which need to be vacuumed
+func (e *Engine) listChunks(con *pgxpool.Conn) ([]string, error) {
+	rows, err := con.Query(context.Background(), sqlListChunks)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tables := make([]string, 0)
+	for rows.Next() {
+		var table string
+		err := rows.Scan(&table)
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, table)
+	}
+	return tables, nil
+}
+
+// runWorkers kicks off a number of goroutines to work on the chunks in parallel
+// blocks until the workers complete
+func runWorkers(parallelism int, chunks []string, worker func(int, <-chan string)) {
+	todo := make(chan string, len(chunks))
+	var wg sync.WaitGroup
+	wg.Add(parallelism)
+	for id := 0; id < parallelism; id++ {
+		go func(id int, todo <-chan string) {
+			defer wg.Done()
+			worker(id, todo)
+		}(id, todo)
+	}
+	for _, chunk := range chunks {
+		todo <- chunk
+	}
+	close(todo)
+	wg.Wait()
+}
+
+// worker pulls chunks from a channel and vacuums them
+func (e *Engine) worker(id int, todo <-chan string) {
+	for chunk := range todo {
+		log.Info("msg", "vacuuming a chunk", "worker", id, "chunk", chunk)
+		sql := fmt.Sprintf(sqlVacuumFmt, chunk)
+		_, err := e.pool.Exec(context.Background(), sql)
+		if err != nil {
+			log.Error("msg", "failed to vacuum chunk", "chunk", chunk, "worker", id, "error", err)
+			// don't return error here. attempt to vacuum other chunks. keep working
+		}
+	}
+}

--- a/pkg/vacuum/vacuum_test.go
+++ b/pkg/vacuum/vacuum_test.go
@@ -1,0 +1,135 @@
+package vacuum
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_runWorkers(t *testing.T) {
+	tests := []struct {
+		parallelism int
+		work        string
+	}{
+		{1, "abcdef"},
+		{2, "helloworld"},
+		{3, "foobarbaz12"},
+		{4, "1"},
+		{5, "buzz"},
+		{6, "buzzbuzz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.work, func(t *testing.T) {
+			var mu sync.Mutex
+			// each individual char is a unit of "work"
+			// the work will consist of adding the char to worked slice
+			chunks := strings.Split(tt.work, "")
+			worked := make([]string, 0)
+			runWorkers(tt.parallelism, chunks, func(id int, todo <-chan string) {
+				for chunk := range todo {
+					func(id int, chunk string) {
+						mu.Lock()
+						defer mu.Unlock()
+						worked = append(worked, chunk)
+					}(id, chunk)
+				}
+			})
+			sort.Strings(chunks)
+			sort.Strings(worked)
+			require.Equal(t, strings.Join(chunks, ""), strings.Join(worked, ""))
+		})
+	}
+}
+
+func Test_every(t *testing.T) {
+	// add 1 to count every 100 milliseconds
+	// stop after 450 milliseconds
+	// expect count to be 4
+	var count = 0
+	var mu sync.Mutex
+	timer := time.NewTimer(time.Millisecond * 450)
+	execute, kill := every(time.Millisecond*100, func() {
+		mu.Lock()
+		defer mu.Unlock()
+		count = count + 1
+	})
+	go func() {
+		execute()
+	}()
+	<-timer.C
+	kill()
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 4, count)
+}
+
+func TestValidate(t *testing.T) {
+	type fields struct {
+		disable      bool
+		runFrequency time.Duration
+		parallelism  int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "ok",
+			fields: fields{
+				runFrequency: time.Minute,
+				parallelism:  6,
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad runFrequency",
+			fields: fields{
+				runFrequency: -1 * time.Minute,
+				parallelism:  6,
+			},
+			wantErr: true,
+		},
+		{
+			name: "bad parallelism",
+			fields: fields{
+				runFrequency: time.Minute,
+				parallelism:  0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "both bad",
+			fields: fields{
+				runFrequency: -1 * time.Minute,
+				parallelism:  -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "disable both bad",
+			fields: fields{
+				disable:      true,
+				runFrequency: -1 * time.Minute,
+				parallelism:  -1,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Disable:      tt.fields.disable,
+				RunFrequency: tt.fields.runFrequency,
+				Parallelism:  tt.fields.parallelism,
+			}
+			if err := Validate(cfg); (err != nil) != tt.wantErr {
+				t.Errorf("Validate(cfg) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adding an "engine" to the connector that will periodically look for compressed chunks that have not been vacuumed and frozen. The engine will grab a batch of them and manually `vacuum (freeze, analyze)` them. A configurable amount of parallelism will be employed in working through the batch.

The goal of this engine is to help prevent txid wraparound.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
