### PR TITLE
Import jaeger storage integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ We use the following categories for changes:
 - Fix broken cache eviction in clockcache [#1603]
 - Possible goroutine leak due to unbuffered channel in select block [#1604]
 - Wrap extension upgrades in an explicit transaction [#1665]
+- Fix incorrect population of span kind field in jaeger getOperations response [#1627]
 
 ## [0.14.0] - 2022-08-30
 

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/jackc/pgtype v1.12.0
 	github.com/jackc/pgx/v4 v4.17.0
 	github.com/jaegertracing/jaeger v1.38.0
+	github.com/kr/pretty v0.3.0
 	github.com/oklog/run v1.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.57.2
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
@@ -127,6 +128,7 @@ require (
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
@@ -156,6 +158,7 @@ require (
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/exporter-toolkit v0.7.1 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/rogpeppe/go-internal v1.6.2 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect

--- a/go.sum
+++ b/go.sum
@@ -754,6 +754,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
@@ -989,7 +990,9 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.6.2 h1:aIihoIOHCiLZHxyoNQ+ABL4NKhFTgKLBdMLyEAh98m0=
+github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=

--- a/pkg/jaeger/store/get_operations.go
+++ b/pkg/jaeger/store/get_operations.go
@@ -59,7 +59,7 @@ func getOperations(ctx context.Context, conn pgxconn.PgxConn, query spanstore.Op
 	if err != nil {
 		return operationsResp, fmt.Errorf("operation names: text-array-to-string-array: %w", err)
 	}
-	spanKinds, err := textArraytoStringArr(pgOperationNames)
+	spanKinds, err := textArraytoStringArr(pgSpanKinds)
 	if err != nil {
 		return operationsResp, fmt.Errorf("span kinds: text-array-to-string-array: %w", err)
 	}
@@ -71,10 +71,7 @@ func getOperations(ctx context.Context, conn pgxconn.PgxConn, query spanstore.Op
 	operationsResp = make([]spanstore.Operation, len(spanKinds))
 
 	for i := 0; i < len(operationNames); i++ {
-		operationsResp[i] = spanstore.Operation{
-			Name:     operationNames[i],
-			SpanKind: spanKinds[i],
-		}
+		operationsResp[i] = internalToJaegerOperation(operationNames[i], spanKinds[i])
 	}
 	return operationsResp, nil
 }

--- a/pkg/jaeger/store/translation.go
+++ b/pkg/jaeger/store/translation.go
@@ -6,6 +6,7 @@ package store
 import (
 	"fmt"
 
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -34,6 +35,15 @@ var (
 		"consumer": "consumer",
 		"producer": "producer",
 	}
+	// Map of internal span kind to Jaeger.
+	internalToJaegerSpanKind = map[string]string{
+		"client":      "client",
+		"server":      "server",
+		"internal":    "internal",
+		"consumer":    "consumer",
+		"producer":    "producer",
+		"unspecified": "",
+	}
 )
 
 func internalToStatusCode(s string) ptrace.StatusCode {
@@ -51,6 +61,17 @@ func statusCodeToInternal(sc ptrace.StatusCode) string {
 		}
 	}
 	panic(fmt.Sprintf("status code %s does not have internal representation", sc.String()))
+}
+
+func internalToJaegerOperation(name, kind string) spanstore.Operation {
+	spanKind, ok := internalToJaegerSpanKind[kind]
+	if !ok {
+		return spanstore.Operation{}
+	}
+	return spanstore.Operation{
+		Name:     name,
+		SpanKind: spanKind,
+	}
 }
 
 func internalToSpanKind(s string) ptrace.SpanKind {

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
 	"github.com/stretchr/testify/require"
 
 	"github.com/timescale/promscale/pkg/jaeger/store"
@@ -17,6 +19,25 @@ import (
 	"github.com/timescale/promscale/pkg/pgxconn"
 	jaeger_integration_tests "github.com/timescale/promscale/pkg/tests/end_to_end_tests/jaeger_store_integration_tests"
 )
+
+type spanCopyingWriter struct {
+	w spanstore.Writer
+}
+
+// Copies Tags to avoid altering test expectation.
+func (f spanCopyingWriter) WriteSpan(ctx context.Context, span *model.Span) error {
+	spanCopy := *span
+	spanCopy.Tags = append([]model.KeyValue{}, span.Tags...)
+	spanCopy.References = append([]model.SpanRef{}, span.References...)
+	process := *span.Process
+	spanCopy.Process = &process
+	spanCopy.Process.Tags = append([]model.KeyValue{}, span.Process.Tags...)
+	spanCopy.Logs = append([]model.Log{}, span.Logs...)
+	for i := range span.Logs {
+		spanCopy.Logs[i].Fields = append([]model.KeyValue{}, span.Logs[i].Fields...)
+	}
+	return f.w.WriteSpan(ctx, &spanCopy)
+}
 
 // Similar to TestQueryTraces, but uses Jaeger span ingestion interface.
 func TestJaegerStorageIntegration(t *testing.T) {
@@ -54,27 +75,14 @@ func TestJaegerStorageIntegration(t *testing.T) {
 				}
 				si := jaeger_integration_tests.StorageIntegration{
 					SpanReader: jaegerStore.SpanReader(),
-					SpanWriter: writer,
+					SpanWriter: spanCopyingWriter{writer},
 					CleanUp: func() error {
 						_, err := db.Exec(context.Background(), `TRUNCATE TABLE _ps_trace.span`)
 						return err
 					},
 					Refresh: func() error { return nil },
 					SkipList: []string{
-						"FindTraces/Tags_in_one_spot_-_Tags",
-						"FindTraces/Tags_in_one_spot_-_Logs",
-						"FindTraces/Tags_in_one_spot_-_Process",
-						"FindTraces/default",
 						"FindTraces/Tags_\\+_Operation_name$",
-						"FindTraces/Tags_\\+_Operation_name_\\+_max_Duration$",
-						"FindTraces/Tags_\\+_Operation_name_\\+_Duration_range$",
-						"FindTraces/Tags_\\+_Duration_range$",
-						"FindTraces/Tags_\\+_max_Duration$",
-						"FindTraces/Multi-spot_Tags_\\+_Operation_name_\\+_max_Duration",
-						"FindTraces/Multi-spot_Tags_\\+_Operation_name_\\+_Duration_range",
-						"FindTraces/Multi-spot_Tags_\\+_Duration_range",
-						"FindTraces/Multi-spot_Tags_\\+_max_Duration",
-						"FindTraces/Multiple_Traces",
 					},
 				}
 				si.IntegrationTestAll(t.(*testing.T))

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
@@ -3,6 +3,7 @@ package end_to_end_tests
 import (
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -43,7 +44,9 @@ func TestJaegerStorageIntegration(t *testing.T) {
 				require.NoError(t, err)
 				defer ingestor.Close()
 
-				jaegerStore := jaegerstore.New(pgxconn.NewQueryLoggingPgxConn(db), ingestor, &store.DefaultConfig)
+				jaegerStore := jaegerstore.New(pgxconn.NewQueryLoggingPgxConn(db), ingestor, &store.Config{
+					MaxTraceDuration: 17 * time.Hour, // FindTraces/Trace_spans_over_multiple_indices test has events which has timestamp difference of ~17hrs when comparing to span.
+				})
 				writer := jaegerStore.SpanWriter()
 				if c.streaming {
 					writer = jaegerStore.StreamingSpanWriter()

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
@@ -1,6 +1,7 @@
 package end_to_end_tests
 
 import (
+	"context"
 	"runtime"
 	"testing"
 	"time"
@@ -54,10 +55,12 @@ func TestJaegerStorageIntegration(t *testing.T) {
 				si := jaeger_integration_tests.StorageIntegration{
 					SpanReader: jaegerStore.SpanReader(),
 					SpanWriter: writer,
-					CleanUp:    func() error { return nil },
-					Refresh:    func() error { return nil },
+					CleanUp: func() error {
+						_, err := db.Exec(context.Background(), `TRUNCATE TABLE _ps_trace.span`)
+						return err
+					},
+					Refresh: func() error { return nil },
 					SkipList: []string{
-						"GetLargeSpans",
 						"FindTraces/Tags_in_one_spot_-_Tags",
 						"FindTraces/Tags_in_one_spot_-_Logs",
 						"FindTraces/Tags_in_one_spot_-_Process",

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
@@ -37,7 +37,7 @@ func TestJaegerStorageIntegration(t *testing.T) {
 				cfg := &ingestor.Cfg{
 					InvertedLabelsCacheSize: cache.DefaultConfig.InvertedLabelsCacheSize,
 					NumCopiers:              runtime.NumCPU() / 2,
-					TracesAsyncAcks:         true,
+					TracesAsyncAcks:         true, // To make GetLargeSpans happy, otherwise it takes quite a few time to ingest.
 				}
 				ingestor, err := ingstr.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), cfg)
 				require.NoError(t, err)
@@ -53,6 +53,23 @@ func TestJaegerStorageIntegration(t *testing.T) {
 					SpanWriter: writer,
 					CleanUp:    func() error { return nil },
 					Refresh:    func() error { return nil },
+					SkipList: []string{
+						"GetLargeSpans",
+						"FindTraces/Tags_in_one_spot_-_Tags",
+						"FindTraces/Tags_in_one_spot_-_Logs",
+						"FindTraces/Tags_in_one_spot_-_Process",
+						"FindTraces/default",
+						"FindTraces/Tags_\\+_Operation_name$",
+						"FindTraces/Tags_\\+_Operation_name_\\+_max_Duration$",
+						"FindTraces/Tags_\\+_Operation_name_\\+_Duration_range$",
+						"FindTraces/Tags_\\+_Duration_range$",
+						"FindTraces/Tags_\\+_max_Duration$",
+						"FindTraces/Multi-spot_Tags_\\+_Operation_name_\\+_max_Duration",
+						"FindTraces/Multi-spot_Tags_\\+_Operation_name_\\+_Duration_range",
+						"FindTraces/Multi-spot_Tags_\\+_Duration_range",
+						"FindTraces/Multi-spot_Tags_\\+_max_Duration",
+						"FindTraces/Multiple_Traces",
+					},
 				}
 				si.IntegrationTestAll(t.(*testing.T))
 			})

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
@@ -1,0 +1,61 @@
+package end_to_end_tests
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/timescale/promscale/pkg/jaeger/store"
+	jaegerstore "github.com/timescale/promscale/pkg/jaeger/store"
+	"github.com/timescale/promscale/pkg/pgmodel/cache"
+	"github.com/timescale/promscale/pkg/pgmodel/ingestor"
+	ingstr "github.com/timescale/promscale/pkg/pgmodel/ingestor"
+	"github.com/timescale/promscale/pkg/pgxconn"
+	jaeger_integration_tests "github.com/timescale/promscale/pkg/tests/end_to_end_tests/jaeger_store_integration_tests"
+)
+
+// Similar to TestQueryTraces, but uses Jaeger span ingestion interface.
+func TestJaegerStorageIntegration(t *testing.T) {
+	cases := []struct {
+		name      string
+		streaming bool
+	}{
+		{
+			name:      "sequential",
+			streaming: false,
+		},
+		{
+			name:      "streaming",
+			streaming: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			withDB(t, "jaeger_storage_integration_tests", func(db *pgxpool.Pool, t testing.TB) {
+				cfg := &ingestor.Cfg{
+					InvertedLabelsCacheSize: cache.DefaultConfig.InvertedLabelsCacheSize,
+					NumCopiers:              runtime.NumCPU() / 2,
+					TracesAsyncAcks:         true,
+				}
+				ingestor, err := ingstr.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), cfg)
+				require.NoError(t, err)
+				defer ingestor.Close()
+
+				jaegerStore := jaegerstore.New(pgxconn.NewQueryLoggingPgxConn(db), ingestor, &store.DefaultConfig)
+				writer := jaegerStore.SpanWriter()
+				if c.streaming {
+					writer = jaegerStore.StreamingSpanWriter()
+				}
+				si := jaeger_integration_tests.StorageIntegration{
+					SpanReader: jaegerStore.SpanReader(),
+					SpanWriter: writer,
+					CleanUp:    func() error { return nil },
+					Refresh:    func() error { return nil },
+				}
+				si.IntegrationTestAll(t.(*testing.T))
+			})
+		})
+	}
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/grpc_plugin_conf.yaml
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/grpc_plugin_conf.yaml
@@ -1,0 +1,1 @@
+enable_streaming_writer: true

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/queries.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/queries.json
@@ -1,0 +1,380 @@
+[
+  {
+    "Caption": "Tags in one spot - Tags",
+    "Query": {
+      "ServiceName": "query01-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["span_tags_trace"]
+  },
+  {
+    "Caption": "Tags in one spot - Logs",
+    "Query": {
+      "ServiceName": "query02-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["log_tags_trace"]
+  },
+  {
+    "Caption": "Tags in one spot - Process",
+    "Query": {
+      "ServiceName": "query03-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["process_tags_trace"]
+  },
+  {
+    "Caption": "Tags in different spots",
+    "Query": {
+      "ServiceName": "query04-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multi_spot_tags_trace"]
+  },
+  {
+    "Caption": "Trace spans over multiple indices",
+    "Query": {
+      "ServiceName": "query05-service",
+      "OperationName": "",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T00:00:31.639875Z",
+      "StartTimeMax": "2017-01-26T00:07:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multi_index_trace"]
+  },
+  {
+    "Caption": "Operation name",
+    "Query": {
+      "ServiceName": "query06-service",
+      "OperationName": "query06-operation",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["opname_trace"]
+  },
+  {
+    "Caption": "Operation name + max Duration",
+    "Query": {
+      "ServiceName": "query07-service",
+      "OperationName": "query07-operation",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 2000,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["opname_maxdur_trace"]
+  },
+  {
+    "Caption": "Operation name + Duration range",
+    "Query": {
+      "ServiceName": "query08-service",
+      "OperationName": "query08-operation",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 4500,
+      "DurationMax": 5500,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["opname_dur_trace"]
+  },
+  {
+    "Caption": "Duration range",
+    "Query": {
+      "ServiceName": "query09-service",
+      "OperationName": "",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 4500,
+      "DurationMax": 5500,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["dur_trace"]
+  },
+  {
+    "Caption": "max Duration",
+    "Query": {
+      "ServiceName": "query10-service",
+      "OperationName": "",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 1000,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["max_dur_trace"]
+  },
+  {
+    "Caption": "default",
+    "Query": {
+      "ServiceName": "query11-service",
+      "OperationName": "",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["default"]
+  },
+  {
+    "Caption": "Tags + Operation name",
+    "Query": {
+      "ServiceName": "query12-service",
+      "OperationName": "query12-operation",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["tags_opname_trace"]
+  },
+  {
+    "Caption": "Tags + Operation name + max Duration",
+    "Query": {
+      "ServiceName": "query13-service",
+      "OperationName": "query13-operation",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 2000,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["tags_opname_maxdur_trace"]
+  },
+  {
+    "Caption": "Tags + Operation name + Duration range",
+    "Query": {
+      "ServiceName": "query14-service",
+      "OperationName": "query14-operation",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 4500,
+      "DurationMax": 5500,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["tags_opname_dur_trace"]
+  },
+  {
+    "Caption": "Tags + Duration range",
+    "Query": {
+      "ServiceName": "query15-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 4500,
+      "DurationMax": 5500,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["tags_dur_trace"]
+  },
+  {
+    "Caption": "Tags + max Duration",
+    "Query": {
+      "ServiceName": "query16-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 1000,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["tags_maxdur_trace"]
+  },
+  {
+    "Caption": "Multi-spot Tags + Operation name",
+    "Query": {
+      "ServiceName": "query17-service",
+      "OperationName": "query17-operation",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multispottag_opname_trace"]
+  },
+  {
+    "Caption": "Multi-spot Tags + Operation name + max Duration",
+    "Query": {
+      "ServiceName": "query18-service",
+      "OperationName": "query18-operation",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 2000,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multispottag_opname_maxdur_trace"]
+  },
+  {
+    "Caption": "Multi-spot Tags + Operation name + Duration range",
+    "Query": {
+      "ServiceName": "query19-service",
+      "OperationName": "query19-operation",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 4500,
+      "DurationMax": 5500,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multispottag_opname_dur_trace"]
+  },
+  {
+    "Caption": "Multi-spot Tags + Duration range",
+    "Query": {
+      "ServiceName": "query20-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 4500,
+      "DurationMax": 5500,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multispottag_dur_trace"]
+  },
+  {
+    "Caption": "Multi-spot Tags + max Duration",
+    "Query": {
+      "ServiceName": "query21-service",
+      "OperationName": "",
+      "Tags": {
+        "sameplacetag1":"sameplacevalue",
+        "sameplacetag2":"123",
+        "sameplacetag3":"72.5",
+        "sameplacetag4":"true"
+      },
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 1000,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multispottag_maxdur_trace"]
+  },
+  {
+    "Caption": "Multiple Traces",
+    "Query": {
+      "ServiceName": "query22-service",
+      "OperationName": "",
+      "Tags": null,
+      "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+      "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+      "DurationMin": 0,
+      "DurationMax": 0,
+      "NumTraces": 1000
+    },
+    "ExpectedFixtures": ["multiple1_trace", "multiple2_trace", "multiple3_trace"]
+  }
+]

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/queries_es.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/queries_es.json
@@ -1,0 +1,34 @@
+[
+    {
+        "Caption": "Tag escaped operator + Operation name + max Duration",
+        "Query": {
+        "ServiceName": "query23-service",
+        "OperationName": "query23-operation",
+        "Tags": {
+            "sameplacetag1":"same\\*"
+        },
+        "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+        "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+        "DurationMin": 0,
+        "DurationMax": 1000,
+        "NumTraces": 1000
+        },
+        "ExpectedFixtures": ["tags_escaped_operator_trace_1"]
+    },
+    {
+        "Caption": "Tag wildcard regex",
+        "Query": {
+        "ServiceName": "query24-service",
+        "OperationName": "",
+        "Tags": {
+            "sameplacetag1":"same.*"
+        },
+        "StartTimeMin": "2017-01-26T15:46:31.639875Z",
+        "StartTimeMax": "2017-01-26T17:46:31.639875Z",
+        "DurationMin": 0,
+        "DurationMax": 0,
+        "NumTraces": 1000
+        },
+        "ExpectedFixtures": ["tags_wildcard_regex_1", "tags_wildcard_regex_2"]
+    }
+]

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/default.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/default.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query11-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/dur_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAACQ==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query09-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/example_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/example_trace.json
@@ -1,0 +1,127 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "example-operation-1",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "example-service-1",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    },
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "example-operation-2",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "example-service-2",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    },
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+      "spanId": "AAAAAAAAAAU=",
+      "operationName": "example-operation-1",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "example-service-3",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    },
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+      "spanId": "AAAAAAAAAAY=",
+      "operationName": "example-operation-3",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [{
+        "key": "span.kind",
+        "vType": "STRING",
+        "vStr": "server"
+      }],
+      "process": {
+        "serviceName": "example-service-1",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    },
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEQ==",
+      "spanId": "AAAAAAAAAAc=",
+      "operationName": "example-operation-4",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [{
+        "key": "span.kind",
+        "vType": "STRING",
+        "vStr": "client"
+      }],
+      "process": {
+        "serviceName": "example-service-1",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/log_tags_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/log_tags_trace.json
@@ -1,0 +1,53 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAAg==",
+      "spanId": "AAAAAAAAAAE=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query02-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag1",
+              "vType": "STRING",
+              "vStr": "sameplacevalue"
+            },
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            },
+            {
+              "key": "sameplacetag4",
+              "vType": "BOOL",
+              "vBool": true
+            },
+            {
+              "key": "sameplacetag3",
+              "vType": "FLOAT64",
+              "vFloat64": 72.5
+            },
+            {
+              "key": "blob",
+              "vType": "BINARY",
+              "vBinary": "AAAwOQ=="
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/max_dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/max_dur_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEA==",
+      "spanId": "AAAAAAAAAAI=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query10-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multi_index_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multi_index_trace.json
@@ -1,0 +1,50 @@
+ {
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAABQ==",
+      "spanId": "AAAAAAAAAAE=",
+      "operationName": "operation-list-test2",
+      "references": [],
+      "startTime": "2017-01-26T00:03:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query05-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    },
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAABQ==",
+      "spanId": "AAAAAAAAAAI=",
+      "operationName": "operation-list-test3",
+      "references": [],
+      "startTime": "2017-01-25T23:56:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query05-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multi_spot_tags_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multi_spot_tags_trace.json
@@ -1,0 +1,50 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAABA==",
+      "spanId": "AAAAAAAAAAE=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [
+        {
+          "key": "sameplacetag4",
+          "vType": "BOOL",
+          "vBool": true
+        },
+        {
+          "key": "sameplacetag3",
+          "vType": "FLOAT64",
+          "vFloat64": 72.5
+        }
+      ],
+      "process": {
+        "serviceName": "query04-service",
+        "tags": [
+          {
+            "key": "sameplacetag1",
+            "vType": "STRING",
+            "vStr": "sameplacevalue"
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multiple1_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multiple1_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAACIQ==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query22-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multiple2_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multiple2_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAACIg==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query22-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multiple3_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multiple3_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAACIw==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "100000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query22-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_dur_trace.json
@@ -1,0 +1,55 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAIA==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [
+        {
+          "key": "sameplacetag2",
+          "vType": "INT64",
+          "vInt64": 123
+        },
+        {
+          "key": "sameplacetag4",
+          "vType": "BOOL",
+          "vBool": true
+        }
+      ],
+      "process": {
+        "serviceName": "query20-service",
+        "tags": [
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          },
+          {
+            "key": "blob",
+            "vType": "BINARY",
+            "vBinary": "AAAwOQ=="
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag1",
+              "vType": "STRING",
+              "vStr": "sameplacevalue"
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_maxdur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_maxdur_trace.json
@@ -1,0 +1,56 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAIQ==",
+      "spanId": "AAAAAAAAAAU=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue"
+        }
+      ],
+      "process": {
+        "serviceName": "query21-service",
+        "tags": [
+          {
+            "key": "sameplacetag4",
+            "vType": "BOOL",
+            "vBool": true
+          },
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "blob",
+              "vType": "BINARY",
+              "vBinary": "AAAwOQ=="
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_opname_dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_opname_dur_trace.json
@@ -1,0 +1,56 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAGQ==",
+      "spanId": "AAAAAAAAAAU=",
+      "operationName": "query19-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue"
+        }
+      ],
+      "process": {
+        "serviceName": "query19-service",
+        "tags": [
+          {
+            "key": "sameplacetag4",
+            "vType": "BOOL",
+            "vBool": true
+          },
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "blob",
+              "vType": "BINARY",
+              "vBinary": "AAAwOQ=="
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_opname_maxdur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_opname_maxdur_trace.json
@@ -1,0 +1,56 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAGA==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "query18-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue"
+        }
+      ],
+      "process": {
+        "serviceName": "query18-service",
+        "tags": [
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag4",
+              "vType": "BOOL",
+              "vBool": true
+            },
+            {
+              "key": "blob",
+              "vType": "BINARY",
+              "vBinary": "AAAwOQ=="
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_opname_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/multispottag_opname_trace.json
@@ -1,0 +1,51 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAFw==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "query17-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [
+        {
+          "key": "sameplacetag3",
+          "vType": "FLOAT64",
+          "vFloat64": 72.5
+        }
+      ],
+      "process": {
+        "serviceName": "query17-service",
+        "tags": [
+          {
+            "key": "sameplacetag1",
+            "vType": "STRING",
+            "vStr": "sameplacevalue"
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag4",
+              "vType": "BOOL",
+              "vBool": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/opname_dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/opname_dur_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAACA==",
+      "spanId": "AAAAAAAAAAI=",
+      "operationName": "query08-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query08-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/opname_maxdur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/opname_maxdur_trace.json
@@ -1,0 +1,47 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAABw==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "query07-operation",
+      "tags": [],
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceId": "AAAAAAAAAAAAAAAAAAAABw==",
+          "spanId": "AAAAAAAAAAI="
+        }
+      ],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "process": {
+        "serviceName": "query07-service",
+        "tags": []
+      },
+      "logs": []
+    },
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAABw==",
+      "spanId": "AAAAAAAAAAI=",
+      "operationName": "query07-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "2000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query07-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/opname_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/opname_trace.json
@@ -1,0 +1,27 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAABg==",
+      "spanId": "AAAAAAAAAAE=",
+      "operationName": "query06-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query06-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/process_tags_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/process_tags_trace.json
@@ -1,0 +1,53 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAAw==",
+      "spanId": "AAAAAAAAAAE=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query03-service",
+        "tags": [
+          {
+            "key": "sameplacetag1",
+            "vType": "STRING",
+            "vStr": "sameplacevalue"
+          },
+          {
+            "key": "sameplacetag2",
+            "vType": "INT64",
+            "vInt64": 123
+          },
+          {
+            "key": "sameplacetag4",
+            "vType": "BOOL",
+            "vBool": true
+          },
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          },
+          {
+            "key": "blob",
+            "vType": "BINARY",
+            "vBinary": "AAAwOQ=="
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/span_tags_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/span_tags_trace.json
@@ -1,0 +1,44 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
+      "spanId": "AAAAAAAAAAI=",
+      "operationName": "some-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "7000ns",
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue"
+        },
+        {
+          "key": "sameplacetag2",
+          "vType": "INT64",
+          "vInt64": 123
+        },
+        {
+          "key": "sameplacetag4",
+          "vType": "BOOL",
+          "vBool": true
+        },
+        {
+          "key": "sameplacetag3",
+          "vType": "FLOAT64",
+          "vFloat64": 72.5
+        },
+        {
+          "key": "blob",
+          "vType": "BINARY",
+          "vBinary": "AAAwOQ=="
+        }
+      ],
+      "process": {
+        "serviceName": "query01-service",
+        "tags": []
+      },
+      "logs": []
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_dur_trace.json
@@ -1,0 +1,53 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAFQ==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "placeholder",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue"
+        },
+        {
+          "key": "sameplacetag2",
+          "vType": "INT64",
+          "vInt64": 123
+        },
+        {
+          "key": "sameplacetag4",
+          "vType": "BOOL",
+          "vBool": true
+        },
+        {
+          "key": "sameplacetag3",
+          "vType": "FLOAT64",
+          "vFloat64": 72.5
+        },
+        {
+          "key": "blob",
+          "vType": "BINARY",
+          "vBinary": "AAAwOQ=="
+        }
+      ],
+      "process": {
+        "serviceName": "query15-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_escaped_operator_trace_1.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_escaped_operator_trace_1.json
@@ -1,0 +1,33 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAFEh==",
+      "spanId": "AAAAAAAAAAU=",
+      "operationName": "query23-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [          
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "same*"
+        }
+      ],
+      "process": {
+        "serviceName": "query23-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_escaped_operator_trace_2.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_escaped_operator_trace_2.json
@@ -1,0 +1,33 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAABZEh==",
+      "spanId": "AAAAAAAAAAU=",
+      "operationName": "query23-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [          
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacedifferentvalue"
+        }
+      ],
+      "process": {
+        "serviceName": "query23-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_maxdur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_maxdur_trace.json
@@ -1,0 +1,53 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAFg==",
+      "spanId": "AAAAAAAAAAU=",
+      "operationName": "",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query16-service",
+        "tags": [
+          {
+            "key": "sameplacetag1",
+            "vType": "STRING",
+            "vStr": "sameplacevalue"
+          },
+          {
+            "key": "sameplacetag2",
+            "vType": "INT64",
+            "vInt64": 123
+          },
+          {
+            "key": "sameplacetag4",
+            "vType": "BOOL",
+            "vBool": true
+          },
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          },
+          {
+            "key": "blob",
+            "vType": "BINARY",
+            "vBinary": "AAAwOQ=="
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_opname_dur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_opname_dur_trace.json
@@ -1,0 +1,53 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAFA==",
+      "spanId": "AAAAAAAAAAM=",
+      "operationName": "query14-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "5000ns",
+      "tags": [],
+      "process": {
+        "serviceName": "query14-service",
+        "tags": []
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "sameplacetag1",
+              "vType": "STRING",
+              "vStr": "sameplacevalue"
+            },
+            {
+              "key": "sameplacetag2",
+              "vType": "INT64",
+              "vInt64": 123
+            },
+            {
+              "key": "sameplacetag4",
+              "vType": "BOOL",
+              "vBool": true
+            },
+            {
+              "key": "sameplacetag3",
+              "vType": "FLOAT64",
+              "vFloat64": 72.5
+            },
+            {
+              "key": "blob",
+              "vType": "BINARY",
+              "vBinary": "AAAwOQ=="
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": []
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_opname_maxdur_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_opname_maxdur_trace.json
@@ -1,0 +1,71 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEw==",
+      "spanId": "AAAAAAAAAAc=",
+      "operationName": "query13-operation",
+      "references": [],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "1000ns",
+      "tags": [
+        {
+          "key": "tag1",
+          "vType": "STRING",
+          "vStr": "value1"
+        }
+      ],
+      "process": {
+        "serviceName": "query13-service",
+        "tags": [
+          {
+            "key": "sameplacetag1",
+            "vType": "STRING",
+            "vStr": "sameplacevalue"
+          },
+          {
+            "key": "sameplacetag2",
+            "vType": "INT64",
+            "vInt64": 123
+          },
+          {
+            "key": "sameplacetag4",
+            "vType": "BOOL",
+            "vBool": true
+          },
+          {
+            "key": "sameplacetag3",
+            "vType": "FLOAT64",
+            "vFloat64": 72.5
+          },
+          {
+            "key": "blob",
+            "vType": "BINARY",
+            "vBinary": "AAAwOQ=="
+          }
+        ]
+      },
+      "logs": [
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "tag3",
+              "vType": "STRING",
+              "vStr": "value3"
+            }
+          ]
+        },
+        {
+          "timestamp": "2017-01-26T16:46:31.639875Z",
+          "fields": [
+            {
+              "key": "something",
+              "vType": "STRING",
+              "vStr": "blah"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_opname_trace.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_opname_trace.json
@@ -1,0 +1,60 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAAEg==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "query12-operation",
+      "references": [
+        {
+          "refType": "CHILD_OF",
+          "traceId": "AAAAAAAAAAAAAAAAAAAA/w==",
+          "spanId": "AAAAAAAAAP8="
+        },
+        {
+          "refType": "CHILD_OF",
+          "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
+          "spanId": "AAAAAAAAAAI="
+        },
+        {
+          "refType": "FOLLOWS_FROM",
+          "traceId": "AAAAAAAAAAAAAAAAAAAAAQ==",
+          "spanId": "AAAAAAAAAAI="
+        }
+      ],
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue"
+        },
+        {
+          "key": "sameplacetag2",
+          "vType": "INT64",
+          "vInt64": 123
+        },
+        {
+          "key": "sameplacetag4",
+          "vType": "BOOL",
+          "vBool": true
+        },
+        {
+          "key": "sameplacetag3",
+          "vType": "FLOAT64",
+          "vFloat64": 72.5
+        },
+        {
+          "key": "blob",
+          "vType": "BINARY",
+          "vBinary": "AAAwOQ=="
+        }
+      ],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "2000ns",
+      "process": {
+        "serviceName": "query12-service",
+        "tags": []
+      },
+      "logs": []
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_wildcard_regex_1.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_wildcard_regex_1.json
@@ -1,0 +1,25 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAAKEg==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "",
+      "references": [
+      ],
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue1"
+        }
+      ],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "2000ns",
+      "process": {
+        "serviceName": "query24-service",
+        "tags": []
+      },
+      "logs": []
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_wildcard_regex_2.json
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/fixtures/traces/tags_wildcard_regex_2.json
@@ -1,0 +1,25 @@
+{
+  "spans": [
+    {
+      "traceId": "AAAAAAAAAAAAAAAAAAASEg==",
+      "spanId": "AAAAAAAAAAQ=",
+      "operationName": "",
+      "references": [
+      ],
+      "tags": [
+        {
+          "key": "sameplacetag1",
+          "vType": "STRING",
+          "vStr": "sameplacevalue2"
+        }
+      ],
+      "startTime": "2017-01-26T16:46:31.639875Z",
+      "duration": "2000ns",
+      "process": {
+        "serviceName": "query24-service",
+        "tags": []
+      },
+      "logs": []
+    }
+  ]
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/jaeger_store_integration.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/jaeger_store_integration.go
@@ -1,0 +1,399 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is copied from upstream jaeger[1] to run storage integration
+// tests as part of promscale e2e.
+// [1] https://github.com/jaegertracing/jaeger/blob/4fc291568d8ac59a1c67cc47ee1d91ab20dd06c4/plugin/storage/integration/integration_test.go
+
+// TODO: Remove this file after adding promscale integration storage changes
+// into upstream jaeger.
+
+package jaeger_integration_tests
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/model"
+	"github.com/jaegertracing/jaeger/storage/dependencystore"
+	"github.com/jaegertracing/jaeger/storage/spanstore"
+)
+
+const (
+	iterations = 100
+)
+
+// StorageIntegration holds components for storage integration test
+type StorageIntegration struct {
+	SpanWriter       spanstore.Writer
+	SpanReader       spanstore.Reader
+	DependencyWriter dependencystore.Writer
+	DependencyReader dependencystore.Reader
+	Fixtures         []*QueryFixtures
+	// TODO: remove this flag after all storage plugins returns spanKind with operationNames
+	NotSupportSpanKindWithOperation bool
+	FixturesPath                    string
+
+	// CleanUp() should ensure that the storage backend is clean before another test.
+	// called either before or after each test, and should be idempotent
+	CleanUp func() error
+
+	// Refresh() should ensure that the storage backend is up to date before being queried.
+	// called between set-up and queries in each test
+	Refresh func() error
+}
+
+// === SpanStore Integration Tests ===
+
+// QueryFixtures and TraceFixtures are under ./fixtures/queries.json and ./fixtures/traces/*.json respectively.
+// Each query fixture includes:
+// - Caption: describes the query we are testing
+// - Query: the query we are testing
+// - ExpectedFixture: the trace fixture that we want back from these queries.
+// Queries are not necessarily numbered, but since each query requires a service name,
+// the service name is formatted "query##-service".
+type QueryFixtures struct {
+	Caption          string
+	Query            *spanstore.TraceQueryParameters
+	ExpectedFixtures []string
+}
+
+func (s *StorageIntegration) cleanUp(t *testing.T) {
+	require.NotNil(t, s.CleanUp, "CleanUp function must be provided")
+	require.NoError(t, s.CleanUp())
+}
+
+func (s *StorageIntegration) refresh(t *testing.T) {
+	require.NotNil(t, s.Refresh, "Refresh function must be provided")
+	require.NoError(t, s.Refresh())
+}
+
+func (s *StorageIntegration) waitForCondition(t *testing.T, predicate func(t *testing.T) bool) bool {
+	for i := 0; i < iterations; i++ {
+		t.Logf("Waiting for storage backend to update documents, iteration %d out of %d", i+1, iterations)
+		if predicate(t) {
+			return true
+		}
+		time.Sleep(100 * time.Millisecond) // Will wait up to 10 seconds at worst.
+	}
+	return predicate(t)
+}
+
+func (s *StorageIntegration) testGetServices(t *testing.T) {
+	defer s.cleanUp(t)
+
+	expected := []string{"example-service-1", "example-service-2", "example-service-3"}
+	s.loadParseAndWriteExampleTrace(t)
+	s.refresh(t)
+
+	var actual []string
+	found := s.waitForCondition(t, func(t *testing.T) bool {
+		actual, err := s.SpanReader.GetServices(context.Background())
+		require.NoError(t, err)
+		return assert.ObjectsAreEqualValues(expected, actual)
+	})
+
+	if !assert.True(t, found) {
+		t.Log("\t Expected:", expected)
+		t.Log("\t Actual  :", actual)
+	}
+}
+
+func (s *StorageIntegration) testGetLargeSpan(t *testing.T) {
+	if os.Getenv("RUN_UNSUPPORTED_JAEGER_TEST") == "" {
+		t.Skip("not yet supported")
+	}
+	defer s.cleanUp(t)
+
+	t.Log("Testing Large Trace over 10K ...")
+	expected := s.loadParseAndWriteLargeTrace(t)
+	expectedTraceID := expected.Spans[0].TraceID
+	s.refresh(t)
+
+	var actual *model.Trace
+	found := s.waitForCondition(t, func(t *testing.T) bool {
+		var err error
+		actual, err = s.SpanReader.GetTrace(context.Background(), expectedTraceID)
+		return err == nil && len(actual.Spans) == len(expected.Spans)
+	})
+	if !assert.True(t, found) {
+		CompareTraces(t, expected, actual)
+	}
+}
+
+func (s *StorageIntegration) testGetOperations(t *testing.T) {
+	defer s.cleanUp(t)
+
+	var expected []spanstore.Operation
+	if s.NotSupportSpanKindWithOperation {
+		expected = []spanstore.Operation{
+			{Name: "example-operation-1"},
+			{Name: "example-operation-3"},
+			{Name: "example-operation-4"},
+		}
+	} else {
+		expected = []spanstore.Operation{
+			{Name: "example-operation-1"},
+			{Name: "example-operation-3", SpanKind: "server"},
+			{Name: "example-operation-4", SpanKind: "client"},
+		}
+	}
+	s.loadParseAndWriteExampleTrace(t)
+	s.refresh(t)
+
+	var actual []spanstore.Operation
+	found := s.waitForCondition(t, func(t *testing.T) bool {
+		var err error
+		actual, err = s.SpanReader.GetOperations(context.Background(),
+			spanstore.OperationQueryParameters{ServiceName: "example-service-1"})
+		require.NoError(t, err)
+		return assert.ObjectsAreEqualValues(expected, actual)
+	})
+
+	if !assert.True(t, found) {
+		t.Log("\t Expected:", expected)
+		t.Log("\t Actual  :", actual)
+	}
+}
+
+func (s *StorageIntegration) testGetTrace(t *testing.T) {
+	defer s.cleanUp(t)
+
+	expected := s.loadParseAndWriteExampleTrace(t)
+	expectedTraceID := expected.Spans[0].TraceID
+	s.refresh(t)
+
+	var actual *model.Trace
+	found := s.waitForCondition(t, func(t *testing.T) bool {
+		var err error
+		actual, err = s.SpanReader.GetTrace(context.Background(), expectedTraceID)
+		if err != nil {
+			t.Log(err)
+		}
+		return err == nil && len(actual.Spans) == len(expected.Spans)
+	})
+	if !assert.True(t, found) {
+		CompareTraces(t, expected, actual)
+	}
+
+	t.Run("NotFound error", func(t *testing.T) {
+		fakeTraceID := model.TraceID{High: 0, Low: 0}
+		trace, err := s.SpanReader.GetTrace(context.Background(), fakeTraceID)
+		assert.Equal(t, spanstore.ErrTraceNotFound, err)
+		assert.Nil(t, trace)
+	})
+}
+
+//go:embed fixtures
+var fixtures embed.FS
+
+func (s *StorageIntegration) testFindTraces(t *testing.T) {
+	if os.Getenv("RUN_UNSUPPORTED_JAEGER_TEST") == "" {
+		t.Skip("not yet supported")
+	}
+	defer s.cleanUp(t)
+
+	// Note: all cases include ServiceName + StartTime range
+	s.Fixtures = append(s.Fixtures, LoadAndParseQueryTestCases(t, "fixtures/queries.json")...)
+
+	// Each query test case only specifies matching traces, but does not provide counterexamples.
+	// To improve coverage we get all possible traces and store all of them before running queries.
+	allTraceFixtures := make(map[string]*model.Trace)
+	expectedTracesPerTestCase := make([][]*model.Trace, 0, len(s.Fixtures))
+	for _, queryTestCase := range s.Fixtures {
+		var expected []*model.Trace
+		for _, traceFixture := range queryTestCase.ExpectedFixtures {
+			trace, ok := allTraceFixtures[traceFixture]
+			if !ok {
+				trace = s.getTraceFixture(t, traceFixture)
+				err := s.writeTrace(t, trace)
+				require.NoError(t, err, "Unexpected error when writing trace %s to storage", traceFixture)
+				allTraceFixtures[traceFixture] = trace
+			}
+			expected = append(expected, trace)
+		}
+		expectedTracesPerTestCase = append(expectedTracesPerTestCase, expected)
+	}
+	s.refresh(t)
+	for i, queryTestCase := range s.Fixtures {
+		t.Run(queryTestCase.Caption, func(t *testing.T) {
+			expected := expectedTracesPerTestCase[i]
+			actual := s.findTracesByQuery(t, queryTestCase.Query, expected)
+			CompareSliceOfTraces(t, expected, actual)
+		})
+	}
+}
+
+func (s *StorageIntegration) findTracesByQuery(t *testing.T, query *spanstore.TraceQueryParameters, expected []*model.Trace) []*model.Trace {
+	var traces []*model.Trace
+	found := s.waitForCondition(t, func(t *testing.T) bool {
+		var err error
+		traces, err = s.SpanReader.FindTraces(context.Background(), query)
+		require.NoError(t, err)
+		if len(expected) != len(traces) {
+			t.Logf("FindTraces: expected: %d, actual: %d", len(expected), len(traces))
+			return false
+		}
+		return true
+	})
+	require.True(t, found)
+	tracesMatch(t, traces, expected)
+	return traces
+}
+
+func (s *StorageIntegration) writeTrace(t *testing.T, trace *model.Trace) error {
+	for _, span := range trace.Spans {
+		if err := s.SpanWriter.WriteSpan(context.Background(), span); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *StorageIntegration) loadParseAndWriteExampleTrace(t *testing.T) *model.Trace {
+	trace := s.getTraceFixture(t, "example_trace")
+	err := s.writeTrace(t, trace)
+	require.NoError(t, err, "Not expecting error when writing example_trace to storage")
+	return trace
+}
+
+func (s *StorageIntegration) loadParseAndWriteLargeTrace(t *testing.T) *model.Trace {
+	trace := s.getTraceFixture(t, "example_trace")
+	span := trace.Spans[0]
+	spns := make([]*model.Span, 1, 10008)
+	trace.Spans = spns
+	trace.Spans[0] = span
+	for i := 1; i < 10008; i++ {
+		s := new(model.Span)
+		*s = *span
+		s.SpanID = model.SpanID(i)
+		s.StartTime = s.StartTime.Add(time.Second * time.Duration(i+1))
+		trace.Spans = append(trace.Spans, s)
+	}
+	err := s.writeTrace(t, trace)
+	require.NoError(t, err, "Not expecting error when writing example_trace to storage")
+	return trace
+}
+
+func (s *StorageIntegration) getTraceFixture(t *testing.T, fixture string) *model.Trace {
+	fileName := fmt.Sprintf("fixtures/traces/%s.json", fixture)
+	return getTraceFixtureExact(t, fileName)
+}
+
+func getTraceFixtureExact(t *testing.T, fileName string) *model.Trace {
+	var trace model.Trace
+	loadAndParseJSONPB(t, fileName, &trace)
+	return &trace
+}
+
+func loadAndParseJSONPB(t *testing.T, path string, object proto.Message) {
+	// #nosec
+	inStr, err := fixtures.ReadFile(path)
+	require.NoError(t, err, "Not expecting error when loading fixture %s", path)
+	err = jsonpb.Unmarshal(bytes.NewReader(correctTime(inStr)), object)
+	require.NoError(t, err, "Not expecting error when unmarshaling fixture %s", path)
+}
+
+// LoadAndParseQueryTestCases loads and parses query test cases
+func LoadAndParseQueryTestCases(t *testing.T, queriesFile string) []*QueryFixtures {
+	var queries []*QueryFixtures
+	loadAndParseJSON(t, queriesFile, &queries)
+	return queries
+}
+
+func loadAndParseJSON(t *testing.T, path string, object interface{}) {
+	// #nosec
+	inStr, err := fixtures.ReadFile(path)
+	require.NoError(t, err, "Not expecting error when loading fixture %s", path)
+	err = json.Unmarshal(correctTime(inStr), object)
+	require.NoError(t, err, "Not expecting error when unmarshaling fixture %s", path)
+}
+
+// required, because we want to only query on recent traces, so we replace all the dates with recent dates.
+func correctTime(json []byte) []byte {
+	jsonString := string(json)
+	now := time.Now().UTC()
+	yesterday := now.AddDate(0, 0, -1).Format("2006-01-02")
+	twoDaysAgo := now.AddDate(0, 0, -2).Format("2006-01-02")
+	retString := strings.Replace(jsonString, "2017-01-26", yesterday, -1)
+	retString = strings.Replace(retString, "2017-01-25", twoDaysAgo, -1)
+	return []byte(retString)
+}
+
+func tracesMatch(t *testing.T, actual []*model.Trace, expected []*model.Trace) bool {
+	if !assert.Equal(t, len(expected), len(actual), "Expecting certain number of traces") {
+		return false
+	}
+	return assert.Equal(t, spanCount(expected), spanCount(actual), "Expecting certain number of spans")
+}
+
+func spanCount(traces []*model.Trace) int {
+	var count int
+	for _, trace := range traces {
+		count += len(trace.Spans)
+	}
+	return count
+}
+
+// === DependencyStore Integration Tests ===
+
+func (s *StorageIntegration) testGetDependencies(t *testing.T) {
+	if s.DependencyReader == nil || s.DependencyWriter == nil {
+		t.Skipf("Skipping GetDependencies test because dependency reader or writer is nil")
+		return
+	}
+
+	defer s.cleanUp(t)
+
+	expected := []model.DependencyLink{
+		{
+			Parent:    "hello",
+			Child:     "world",
+			CallCount: uint64(1),
+		},
+		{
+			Parent:    "world",
+			Child:     "hello",
+			CallCount: uint64(3),
+		},
+	}
+	require.NoError(t, s.DependencyWriter.WriteDependencies(time.Now(), expected))
+	s.refresh(t)
+	actual, err := s.DependencyReader.GetDependencies(context.Background(), time.Now(), 5*time.Minute)
+	assert.NoError(t, err)
+	assert.EqualValues(t, expected, actual)
+}
+
+// IntegrationTestAll runs all integration tests
+func (s *StorageIntegration) IntegrationTestAll(t *testing.T) {
+	t.Run("GetServices", s.testGetServices)
+	t.Run("GetOperations", s.testGetOperations)
+	t.Run("GetTrace", s.testGetTrace)
+	t.Run("GetLargeSpans", s.testGetLargeSpan)
+	t.Run("FindTraces", s.testFindTraces)
+	t.Run("GetDependencies", s.testGetDependencies)
+}

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/trace_compare.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_tests/trace_compare.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2019 The Jaeger Authors.
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is copied from upstream jaeger[1] to run storage integration
+// tests as part of promscale e2e.
+// [1] https://github.com/jaegertracing/jaeger/blob/4fc291568d8ac59a1c67cc47ee1d91ab20dd06c4/plugin/storage/integration/trace_compare_test.go
+
+// TODO: Remove this file after adding promscale integration storage changes
+// into upstream jaeger.
+
+package jaeger_integration_tests
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jaegertracing/jaeger/model"
+)
+
+// CompareSliceOfTraces compares two trace slices
+func CompareSliceOfTraces(t *testing.T, expected []*model.Trace, actual []*model.Trace) {
+	require.Equal(t, len(expected), len(actual), "Unequal number of expected vs. actual traces")
+	model.SortTraces(expected)
+	model.SortTraces(actual)
+	for i := range expected {
+		checkSize(t, expected[i], actual[i])
+	}
+	if diff := pretty.Diff(expected, actual); len(diff) > 0 {
+		for _, d := range diff {
+			t.Logf("Expected and actual differ: %s\n", d)
+		}
+		out, err := json.Marshal(actual)
+		out2, err2 := json.Marshal(expected)
+		assert.NoError(t, err)
+		assert.NoError(t, err2)
+		t.Logf("Actual traces: %s", string(out))
+		t.Logf("Expected traces: %s", string(out2))
+		t.Fail()
+	}
+}
+
+// CompareTraces compares two traces
+func CompareTraces(t *testing.T, expected *model.Trace, actual *model.Trace) {
+	if expected.Spans == nil {
+		require.Nil(t, actual.Spans)
+		return
+	}
+	require.NotNil(t, actual)
+	require.NotNil(t, actual.Spans)
+	model.SortTrace(expected)
+	model.SortTrace(actual)
+	checkSize(t, expected, actual)
+
+	if diff := pretty.Diff(expected, actual); len(diff) > 0 {
+		for _, d := range diff {
+			t.Logf("Expected and actual differ: %v\n", d)
+		}
+		out, err := json.Marshal(actual)
+		assert.NoError(t, err)
+		t.Logf("Actual trace: %s", string(out))
+		t.Fail()
+	}
+}
+
+func checkSize(t *testing.T, expected *model.Trace, actual *model.Trace) {
+	require.Equal(t, len(expected.Spans), len(actual.Spans))
+	for i := range expected.Spans {
+		expectedSpan := expected.Spans[i]
+		actualSpan := actual.Spans[i]
+		require.True(t, len(expectedSpan.Tags) == len(actualSpan.Tags))
+		require.True(t, len(expectedSpan.Logs) == len(actualSpan.Logs))
+		if expectedSpan.Process != nil && actualSpan.Process != nil {
+			require.True(t, len(expectedSpan.Process.Tags) == len(actualSpan.Process.Tags))
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR imports jaeger storage integration tests from https://github.com/jaegertracing/jaeger/blob/main/plugin/storage/integration and adopts those for promscale environment.

May be we can remove the imported tests once we enable promscale integration tests in upstream jaeger.

This PR also fixes `TestJaegerStorageIntegration/*/GetOperations` test which was failing due to a typo.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [X] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
