### PR TITLE
Unblock CI by using latest instead of main for prom/prometheus in e2e

### DIFF
--- a/pkg/internal/testhelpers/prometheus_container.go
+++ b/pkg/internal/testhelpers/prometheus_container.go
@@ -14,7 +14,15 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-const prometheusImage = "prom/prometheus:main"
+// FIXME: we had to change from main to latest because the main tag was
+// broken and blocked our CI. Whenever a container is started it fails
+// with the following error:
+//
+// Error setting up container Error response from daemon: failed to create shim
+// task: OCI runtime create failed: runc create failed: unable to start
+// container process: exec: "/bin/prometheus": permission denied: unknown:
+// failed to start container
+const prometheusImage = "prom/prometheus:latest"
 
 // StartPromContainer starts a Prometheus container for use in testing
 func StartPromContainer(storagePath string, ctx context.Context) (testcontainers.Container, string, nat.Port, error) {


### PR DESCRIPTION
## Description

### Change from prom/prometheust main to latest in e2e 
 
 There's a problem with the main tag. When a container is started it
fails with the following error:

Error setting up container Error response from daemon: failed to create shim
task: OCI runtime create failed: runc create failed: unable to start
container process: exec: "/bin/prometheus": permission denied: unknown:
failed to start container.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
