### PR TITLE
Add statement_timeout helpers

### DIFF
--- a/pkg/pgmodel/querier/querier_sql_test.go
+++ b/pkg/pgmodel/querier/querier_sql_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/prometheus/model/timestamp"
-
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
+	"github.com/prometheus/prometheus/model/timestamp"
 	"github.com/timescale/promscale/pkg/clockcache"
 	"github.com/timescale/promscale/pkg/pgmodel/lreader"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
@@ -40,6 +40,15 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					// The query will be checked with model.isStatementTimeout from
+					// pkg/pgmodel/model/sql_test_utils.go by regex matching so
+					// the value is not important.
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -65,6 +74,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -89,6 +104,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -98,6 +119,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 						"ORDER BY m.metric_name, m.table_schema",
 					Args:    []interface{}{"foo", "bar"},
 					Results: model.RowResults{{"prom_data", "foo", []int64{1}}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -120,6 +147,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			result: []*prompb.TimeSeries{},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -132,9 +165,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "foo"},
 					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -160,6 +205,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 				},
 			},
 			sqlQueries: []model.SqlQuery{
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
 				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
@@ -191,6 +242,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			result: []*prompb.TimeSeries{},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -216,6 +273,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			result: []*prompb.TimeSeries{},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "bar"},
 					Results: model.RowResults{nil},
@@ -240,6 +303,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -252,9 +321,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "foo"},
 					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -270,6 +351,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{1}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:    []interface{}{[]int64{1}},
@@ -295,9 +378,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "bar"},
 					Results: model.RowResults{{int64(1), "prom_data", "bar", "bar"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -314,6 +409,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:    []interface{}{[]int64{2}},
@@ -342,9 +439,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "custom"},
 					Results: model.RowResults{{int64(1), "custom_schema", "custom", "bar"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -361,6 +470,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:    []interface{}{[]int64{2}},
@@ -390,9 +501,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "bar"},
 					Results: model.RowResults{{int64(1), "prom_data", "bar", "bar"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -409,6 +532,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{2}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:    []interface{}{[]int64{2}},
@@ -438,6 +563,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -450,15 +581,35 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "foo"},
 					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "bar"},
 					Results: model.RowResults{{int64(1), "prom_data", "bar", "bar"}},
+					Err:     error(nil),
+				},
+				// The following 3 queries go through the same batch that's why there's
+				// no timeout statement between them.
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -487,6 +638,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{4}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:           "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:          []interface{}{[]int64{3, 4}},
@@ -509,9 +662,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 			result: []*prompb.TimeSeries{},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"", "foo"},
 					Results: model.RowResults{{int64(1), "prom_data", "foo", "foo"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -542,6 +707,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -554,9 +725,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "metric"},
 					Results: model.RowResults{{int64(1), "prom_data", "metric", "metric"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -572,6 +755,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{7}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:    []interface{}{[]int64{7}},
@@ -603,6 +788,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -615,9 +806,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "metric"},
 					Results: model.RowResults{{int64(1), "prom_data", "metric", "metric"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -633,6 +836,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{8, 9}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:           "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:          []interface{}{[]int64{9, 8}},
@@ -664,6 +869,12 @@ func TestPGXQuerierQuery(t *testing.T) {
 			},
 			sqlQueries: []model.SqlQuery{
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql: "SELECT m.table_schema, m.metric_name, array_agg(s.id)\n\t" +
 						"FROM _prom_catalog.series s\n\t" +
 						"INNER JOIN _prom_catalog.metric m\n\t" +
@@ -676,9 +887,21 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Err:     error(nil),
 				},
 				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
+					Err:     error(nil),
+				},
+				{
 					Sql:     "SELECT id, table_schema, table_name, series_table FROM _prom_catalog.get_metric_table_name_if_exists($1, $2)",
 					Args:    []interface{}{"prom_data", "metric"},
 					Results: model.RowResults{{int64(1), "prom_data", "metric", "metric"}},
+					Err:     error(nil),
+				},
+				{
+					Sql:     "set local statement_timeout = 42",
+					Args:    []interface{}{},
+					Results: model.RowResults{{pgconn.CommandTag{}}},
 					Err:     error(nil),
 				},
 				{
@@ -694,6 +917,8 @@ func TestPGXQuerierQuery(t *testing.T) {
 					Results: model.RowResults{{[]int64{10}, []time.Time{time.Unix(0, 0)}, []float64{1}}},
 					Err:     error(nil),
 				},
+				// lreader.fetchMissingLabels executes the following query without a
+				// statement_timeout because the context is not propagated to it
 				{
 					Sql:     "SELECT (prom_api.labels_info($1::int[])).*",
 					Args:    []interface{}{[]int64{10}},
@@ -724,7 +949,9 @@ func TestPGXQuerierQuery(t *testing.T) {
 			}
 			querier := pgxQuerier{&queryTools{conn: mock, metricTableNames: mockMetrics, labelsReader: lreader.NewLabelsReader(mock, clockcache.WithMax(0), tenancy.NewNoopAuthorizer().ReadAuthorizer())}}
 
-			result, err := querier.RemoteReadQuerier(context.Background()).Query(c.query)
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			result, err := querier.RemoteReadQuerier(ctx).Query(c.query)
 
 			if err != nil {
 				switch {

--- a/pkg/pgmodel/querier/query_builder_samples.go
+++ b/pkg/pgmodel/querier/query_builder_samples.go
@@ -101,9 +101,16 @@ const (
 	defaultColumnName = "value"
 )
 
+type singleMetricSamplesQuery struct {
+	sql      string
+	values   []interface{}
+	topNode  parser.Node
+	tsSeries TimestampSeries
+}
+
 // buildSingleMetricSamplesQuery builds a SQL query which fetches the data for
 // one metric.
-func buildSingleMetricSamplesQuery(metadata *evalMetadata) (string, []interface{}, parser.Node, TimestampSeries, error) {
+func buildSingleMetricSamplesQuery(metadata *evalMetadata) (singleMetricSamplesQuery, error) {
 	// The basic structure of the SQL query which this function produces is:
 	//		SELECT
 	//		  series.labels
@@ -137,14 +144,14 @@ func buildSingleMetricSamplesQuery(metadata *evalMetadata) (string, []interface{
 		var err error
 		timeClauseBound, values, err = setParameterNumbers(qf.timeClause, values, qf.timeParams...)
 		if err != nil {
-			return "", nil, nil, nil, err
+			return singleMetricSamplesQuery{}, err
 		}
 		selectors = append(selectors, "result.time_array")
 		selectorClauses = append(selectorClauses, timeClauseBound+" as time_array")
 	}
 	valueClauseBound, values, err := setParameterNumbers(qf.valueClause, values, qf.valueParams...)
 	if err != nil {
-		return "", nil, nil, nil, err
+		return singleMetricSamplesQuery{}, err
 	}
 	selectors = append(selectors, "result.value_array")
 	selectorClauses = append(selectorClauses, valueClauseBound+" as value_array")
@@ -225,7 +232,12 @@ func buildSingleMetricSamplesQuery(metadata *evalMetadata) (string, []interface{
 		pgx.Identifier{filter.column}.Sanitize(),
 	)
 
-	return finalSQL, values, node, qf.tsSeries, nil
+	return singleMetricSamplesQuery{
+		finalSQL,
+		values,
+		node,
+		qf.tsSeries,
+	}, nil
 }
 
 func buildMultipleMetricSamplesQuery(filter timeFilter, series []pgmodel.SeriesID) (string, error) {

--- a/pkg/pgmodel/querier/row.go
+++ b/pkg/pgmodel/querier/row.go
@@ -164,7 +164,7 @@ func (r *sampleRow) GetAdditionalLabels() (ll labels.Labels) {
 
 // appendSampleRows adds new results rows to already existing result rows and
 // returns the as a result.
-func appendSampleRows(out []sampleRow, in pgxconn.PgxRows, tsSeries TimestampSeries, metric, schema, column string) ([]sampleRow, error) {
+func appendSampleRows(out []sampleRow, in pgxconn.PgxRows, tsSeries TimestampSeries, metricNameOverride, schema, column string) ([]sampleRow, error) {
 	if in.Err() != nil {
 		return out, in.Err()
 	}
@@ -188,7 +188,7 @@ func appendSampleRows(out []sampleRow, in pgxconn.PgxRows, tsSeries TimestampSer
 		}
 
 		row.values = values
-		row.metricOverride = metric
+		row.metricOverride = metricNameOverride
 		row.schema = schema
 		row.column = column
 

--- a/pkg/pgxconn/helpers.go
+++ b/pkg/pgxconn/helpers.go
@@ -1,0 +1,248 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package pgxconn
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+)
+
+// msUntilCtxDeadline returns the time in milliseconds remaining
+// before the context deadline is reached.
+//
+// ok=false is returned if the given context doesn't have a deadline set.
+func msUntilCtxDeadline(ctx context.Context) (ms int64, ok bool) {
+	t, ok := ctx.Deadline()
+	if !ok {
+		return 0, false
+	}
+	return time.Until(t).Milliseconds(), true
+}
+
+// QueryWithTimeout wraps the given query in a batch along with
+// statement_timeout set to the given timeout value. The timeout value is taken
+// as milliseconds.
+//
+// The results is returned as if it was read with PgxConn.Query.
+//
+// A value of zero disables the timeout.
+//
+// The returned closeFn closes the batch operation. This must be called before
+// the underlying connection can be used again. It's safe to call multiple
+// times.
+//
+// All the queries in a batch are executed in an implicit transaction by using
+// `set local statement_timeout` the timeout it's only applied to the queries
+// belonging to the transaction and not to the connection session.
+//
+// There's a bug with the use of `set local` and implicit transactions.
+// Even though the statements are executed correctly and apply the desire
+// effects the following warning message is logged:
+//
+// `SET LOCAL can only be used in transaction blocks`
+//
+// https://www.postgresql.org/message-id/flat/16988-58edba102adb5128@postgresql.org
+// https://github.com/npgsql/npgsql/issues/3688
+//
+// For more contect on statement_timeout:
+// https://www.postgresql.org/docs/current/runtime-config-client.html
+//
+// statement_timeout (integer)
+//
+// Abort any statement that takes more than the specified amount of time. If
+// log_min_error_statement is set to ERROR or lower, the statement that timed
+// out will also be logged. If this value is specified without units, it is
+// taken as milliseconds. A value of zero (the default) disables the timeout.
+//
+// The timeout is measured from the time a command arrives at the server until
+// it is completed by the server. If multiple SQL statements appear in a single
+// simple-Query message, the timeout is applied to each statement separately.
+// (PostgreSQL versions before 13 usually treated the timeout as applying to
+// the whole query string.) In extended query protocol, the timeout starts
+// running when any query-related message (Parse, Bind, Execute, Describe)
+// arrives, and it is canceled by completion of an Execute or Sync message.
+//
+// Setting statement_timeout in postgresql.conf is not recommended because it
+// would affect all sessions.
+func QueryWithTimeout(
+	ctx context.Context,
+	conn PgxConn,
+	timeout int64,
+	sql string,
+	args ...interface{},
+) (rows PgxRows, closeFn func() error, err error) {
+	batchResults, err := sendQueryInBatchWithTimeout(ctx, conn, timeout, sql, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// sql query
+	rows, err = batchResults.Query()
+	if err != nil {
+		_ = batchResults.Close()
+		return nil, nil, err
+	}
+
+	closeFn = func() error {
+		rows.Close()
+		return batchResults.Close()
+	}
+
+	return rows, closeFn, nil
+}
+
+// QueryWithTimeoutFromCtx executes the given query in a transaction that sets
+// statement_timeout to the remaining time before the context expires. If the
+// context doesn't have a deadline then the query is executed as is, without
+// being wrapped in a transacation.
+//
+// The results is returned as if it was read with PgxConn.Query.
+//
+// For more information refer to the QueryWithTimeout docs.
+func QueryWithTimeoutFromCtx(
+	ctx context.Context,
+	conn PgxConn,
+	sql string,
+	args ...interface{},
+) (rows PgxRows, closeFn func() error, err error) {
+	timeout, ok := msUntilCtxDeadline(ctx)
+	if !ok {
+		rows, err = conn.Query(ctx, sql, args...)
+		closeFn = func() error {
+			rows.Close()
+			return nil
+		}
+		return rows, closeFn, err
+	}
+
+	return QueryWithTimeout(ctx, conn, timeout, sql, args...)
+}
+
+// QueryRowWithTimeout wraps the given query in a batch along with
+// statement_timeout set to the given timeout value. The timeout value is taken
+// as milliseconds.
+//
+// The results is returned as if it was read with PgxConn.QueryRow.
+//
+// A value of zero disables the timeout.
+//
+// The returned closeFn closes the batch operation. This must be called before
+// the underlying connection can be used again. It's safe to call multiple
+// times.
+//
+// For more context see the QueryRowWithTimeout docs.
+func QueryRowWithTimeout(
+	ctx context.Context,
+	conn PgxConn,
+	timeout int64,
+	sql string,
+	args ...interface{},
+) (row pgx.Row, closeFn func() error, err error) {
+	batchResults, err := sendQueryInBatchWithTimeout(ctx, conn, timeout, sql, args...)
+	if err != nil {
+		return nil, nil, err
+	}
+	row = batchResults.QueryRow()
+	closeFn = func() error { return batchResults.Close() }
+	return row, closeFn, nil
+}
+
+// QueryRowWithTimeoutFromCtx executes the given query in a transaction that sets
+// statement_timeout to the remaining time before the context expires. If the
+// context doesn't have a deadline then the query is executed as is, without
+// being wrapped in a transacation.
+//
+// The results is returned as if it was read with PgxConn.QueryRow.
+//
+// For more information refer to the QueryRowWithTimeout docs.
+func QueryRowWithTimeoutFromCtx(
+	ctx context.Context,
+	conn PgxConn,
+	sql string,
+	args ...interface{},
+) (row pgx.Row, closeFn func() error, err error) {
+	timeout, ok := msUntilCtxDeadline(ctx)
+	if !ok {
+		row = conn.QueryRow(ctx, sql, args...)
+		// pgxRow doesn't have a close function and we are not using a batch
+		// so there's nothing to cleanup.
+		noopCloseFn := func() error {
+			return nil
+		}
+		return row, noopCloseFn, err
+	}
+
+	return QueryRowWithTimeout(ctx, conn, timeout, sql, args...)
+}
+
+func sendQueryInBatchWithTimeout(
+	ctx context.Context,
+	conn PgxConn,
+	timeout int64,
+	sql string,
+	args ...interface{},
+) (pgx.BatchResults, error) {
+	batch := NewBatchWithTimeout(conn, timeout)
+	batch.Queue(sql, args...)
+	return SendBatch(ctx, conn, batch, true)
+}
+
+// NewBatchWithTimeout returns a batch with its first item set to
+// `set local statement_timeout=timeout`.
+func NewBatchWithTimeout(conn PgxConn, timeout int64) PgxBatch {
+	b := conn.NewBatch()
+	b.Queue(fmt.Sprintf("set local statement_timeout = %d", timeout))
+	return b
+}
+
+// NewBatchWithTimeoutFromCtx returns a batch that in its first item sets
+// statement_timeout to the remaining time before the context expires. if
+// the context doesn't have a deadline then an empty batch is returned.
+//
+// The returned sendBatchFn handles sending the batch and reading the result
+// of the statement_timeout if it was set.
+func NewBatchWithTimeoutFromCtx(
+	ctx context.Context,
+	conn PgxConn,
+) (batch PgxBatch, sendBatchFn func() (pgx.BatchResults, error)) {
+
+	batch = conn.NewBatch()
+	timeout, withTimeout := msUntilCtxDeadline(ctx)
+	if withTimeout {
+		batch = NewBatchWithTimeout(conn, timeout)
+	}
+	sendBatchFn = func() (pgx.BatchResults, error) {
+		return SendBatch(ctx, conn, batch, withTimeout)
+	}
+	return batch, sendBatchFn
+}
+
+// SendBatch is a convenience function it uses the given PgxConn to send the
+// batch. If withTimeout=true then it's assume that the first item in the
+// batch is a statement_timeout and its result is read before returning
+// the pgx.BatchResults.
+func SendBatch(
+	ctx context.Context,
+	conn PgxConn,
+	batch PgxBatch,
+	withTimeout bool,
+) (pgx.BatchResults, error) {
+	batchResults, err := conn.SendBatch(ctx, batch)
+	if err != nil {
+		return nil, err
+	}
+	if !withTimeout {
+		return batchResults, nil
+	}
+	_, err = batchResults.Exec()
+	if err != nil {
+		_ = batchResults.Close()
+		return nil, err
+	}
+	return batchResults, nil
+}

--- a/pkg/tests/end_to_end_tests/query_with_timeout_test.go
+++ b/pkg/tests/end_to_end_tests/query_with_timeout_test.go
@@ -1,0 +1,127 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package end_to_end_tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/timescale/promscale/pkg/pgxconn"
+)
+
+func TestQueryRowWithTimeoutErr(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
+		c := pgxconn.NewPgxConn(db)
+		defer c.Close()
+		// Given a query that returns corretly
+		row, closeFn, err := pgxconn.QueryRowWithTimeout(context.Background(), c, 1000, "SELECT 1")
+		require.NoError(t, err)
+		defer func() {
+			_ = closeFn()
+		}()
+		var a int
+		err = row.Scan(&a)
+		require.NoError(t, err)
+		assert.Equal(t, 1, a)
+
+		// When the same query is given a very small timeout (1 ms)
+		row2, closeFn2, err := pgxconn.QueryRowWithTimeout(context.Background(), c, 1, "SELECT pg_sleep(1)")
+		require.NoError(t, err)
+		defer func() {
+			_ = closeFn2()
+		}()
+		err = row2.Scan(&a)
+		// It's cancelled due to a timeout
+		assert.ErrorContains(t, err, "ERROR: canceling statement due to statement timeout (SQLSTATE 57014)")
+	})
+}
+
+func TestQueryWithTimeoutErr(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
+		c := pgxconn.NewPgxConn(db)
+		defer c.Close()
+		// Given a query that returns corretly
+		rows, closeFn, err := pgxconn.QueryWithTimeout(context.Background(), c, 1000, "SELECT 1")
+		require.NoError(t, err)
+		defer func() {
+			_ = closeFn()
+		}()
+		require.NoError(t, rows.Err())
+		require.True(t, rows.Next())
+		var queryR int
+		_ = rows.Scan(&queryR)
+		require.Equal(t, 1, queryR)
+
+		// When the same query is given a very small timeout (1 ms)
+		rows2, closeFn2, err := pgxconn.QueryWithTimeout(context.Background(), c, 1, "SELECT pg_sleep(1)")
+		if err == nil {
+			defer func() {
+				_ = closeFn2()
+			}()
+			require.False(t, rows2.Next())
+			err = rows2.Err()
+		}
+		// It's cancelled due to a timeout
+		assert.ErrorContains(t, err, "ERROR: canceling statement due to statement timeout (SQLSTATE 57014)")
+	})
+}
+
+func TestQueryWithCanceledCtx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
+		defer db.Close()
+		c := pgxconn.NewPgxConn(db)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+		_, _, err := pgxconn.QueryWithTimeoutFromCtx(ctx, c, "SELECT pg_sleep(1)")
+		assert.ErrorContains(t, err, "timeout: context deadline exceeded")
+	})
+}
+
+func TestBatchWithTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
+		defer db.Close()
+		conn := pgxconn.NewPgxConn(db)
+		batch := pgxconn.NewBatchWithTimeout(conn, 1)
+		batch.Queue("SELECT pg_sleep(1)")
+		r, err := pgxconn.SendBatch(context.Background(), conn, batch, true)
+		require.NoError(t, err)
+		defer func() {
+			_ = r.Close()
+		}()
+		_, err = r.Exec()
+		assert.ErrorContains(t, err, "ERROR: canceling statement due to statement timeout (SQLSTATE 57014)")
+	})
+}
+
+func TestBatchWithTimeoutFromCtx(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
+		conn := pgxconn.NewPgxConn(db)
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+		defer cancel()
+		batch, sendBatchFn := pgxconn.NewBatchWithTimeoutFromCtx(ctx, conn)
+		batch.Queue("SELECT pg_sleep(1)")
+		_, err := sendBatchFn()
+		assert.ErrorContains(t, err, "timeout: context deadline exceeded")
+	})
+}


### PR DESCRIPTION
## Description

### Add statement_timeout helpers 
 
The helper functions wrap queries in a implicit transaction that
executes a `set local statement_timeout` as its first item. The `set
local` directive scopes the statement to the transaction and not to the
session/connection.

Additional helpers that set the timeout to the remaining time before a
context is deadline is reached are provided. These are suffixed with
`WithTimeoutFromCtx`, for example `QueryWithTimeoutFromCtx` and
`QueryRowWithTimeoutFromCtx` are meant to replace the usage of `Query`
and `QueryRow` respectively.

When working directly with batches `NewBatchWithTimeoutFromCtx` can be
used to handle the process of:

- Creating a new batch.
- Getting the timeout from the context.
- Queue the statement_timeout query.
- Sending the batch and if the batch has a statement_timeout query then
  reading its result.

There's a bug with the use of `set local` and implicit transactions.
Even though the statements are executed correctly and apply the desire
effects the following warning message is logged:

`SET LOCAL can only be used in transaction blocks`

https://www.postgresql.org/message-id/flat/16988-58edba102adb5128@postgresql.org
https://github.com/npgsql/npgsql/issues/3688

For more contect on statement_timeout:
https://www.postgresql.org/docs/current/runtime-config-client.html


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
