### PR TITLE
Fix: `0 samples/sec` in throughput by logging metric metadata throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ We use the following categories for changes:
   reader and writer [#1020].
 - Run timescaledb-tune with the promscale profile [#1615]
 - Propagate the context from received HTTP read requests downstream to database
-  requests [#1205]. 
+  requests [#1205]
+
+### Changed
+- Log throughput in the same line for samples, spans and metric metadata [#1643]
 
 ### Fixed
 - Fix broken cache eviction in clockcache [#1603]

--- a/pkg/util/throughput/throughput.go
+++ b/pkg/util/throughput/throughput.go
@@ -70,16 +70,24 @@ func (tc *throughputCalc) run() {
 			continue
 		}
 
-		if samplesRate+metadataRate != 0 {
-			// Metric data ingested.
+		throughput := []interface{}{"msg", "ingestor throughput"}
+		if samplesRate != 0 {
 			maxSentTs := timestamp.Time(atomic.LoadInt64(&tc.metricsMaxSentTs))
-			log.Info("msg", "ingestor throughput", "samples/sec", int(samplesRate), "metrics-max-sent-ts", maxSentTs)
+			throughput = append(throughput, []interface{}{"samples/sec", int(samplesRate), "metrics-max-sent-ts", maxSentTs}...)
 		}
 
 		if spansRate != 0 {
-			// Spans ingested.
 			spansLastWriteOn := timestamp.Time(atomic.LoadInt64(&tc.spansLastWriteOn))
-			log.Info("msg", "ingestor throughput", "spans/sec", int(spansRate), "spans-last-write-on", spansLastWriteOn)
+			throughput = append(throughput, []interface{}{"spans/sec", int(spansRate), "spans-last-write-on", spansLastWriteOn}...)
+		}
+
+		if metadataRate != 0 {
+			throughput = append(throughput, []interface{}{"metric-metadata/sec", int(metadataRate)}...)
+		}
+
+		if len(throughput) > 2 {
+			// Log only if we had any activity.
+			log.Info(throughput...)
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #1642 

Signed-off-by: Harkishen-Singh <harkishensingh@hotmail.com>

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

This commit fixes `0 samples/sec` logging in throughput. The reason behind this behaviour was metric-metadata not being printed, rather it was just updating the `metrics-max-ts-send`, which was causing the log.

This `metrics-max-ts-send` was updated even when we were writing metadata.

Now, the log for metric, metric-metadata and spans will be in single line, compared to the earlier separate lines.

```shell
level=info ts=2022-09-14T07:36:34.072Z caller=throughput.go:90 msg="ingestor throughput" samples/sec=80000 metrics-max-sent-ts="2022-09-14 07:36:13.178 +0000 UTC" metric-metadata/sec=249
level=info ts=2022-09-14T07:40:17.419Z caller=throughput.go:90 msg="ingestor throughput" samples/sec=64223 metrics-max-sent-ts="2022-09-14 07:39:41.002 +0000 UTC" spans/sec=200 spans-last-write-on="2022-09-14 07:40:16.459 +0000 UTC"
```

**Update**
Now we log like this.

```shell

level=info ts=2022-09-15T06:13:43.010Z caller=throughput.go:90 msg="ingestor throughput" spans/sec=200 spans-last-write-on=2022-09-15T06:13:42.14Z
level=info ts=2022-09-15T06:13:44.011Z caller=throughput.go:90 msg="ingestor throughput" samples/sec=1000 metrics-max-sent-ts=2022-09-15T06:13:42.583Z spans/sec=200 spans-last-write-on=2022-09-15T06:13:43.124Z
```

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
