### PR TITLE
Do not log gRPC NotFound and Canceled status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We use the following categories for changes:
 ### Changed
 - Log throughput in the same line for samples, spans and metric metadata [#1643]
 - The `chunks_created` metrics was removed. [#1634]
+- Stop logging as an error grpc NotFound and Canceled status codes [#1645]
 
 ### Fixed
 - Do not collect telemetry if `timescaledb.telemetry_level=off` [#1612]


### PR DESCRIPTION
## Description

- NotFound is returned, for example, when querying a Trace and the trace is not found.
- Canceled when the context is canceled.

Before we were checking the errors for context.Canceled but gRPC doesn't wrap the errors, it just creates an Status object that contains the error message. 

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
