### PR TITLE
Fix event tag correctness

### DIFF
--- a/pkg/tests/end_to_end_tests/trace_query_integration_test.go
+++ b/pkg/tests/end_to_end_tests/trace_query_integration_test.go
@@ -332,7 +332,9 @@ func getTraces(t testing.TB, c httpClient, service string, start, end int64, use
 	r, err := do(queryUrl)
 	require.NoError(t, err)
 
-	traces := convertToTraces(r.Data.([]interface{}))
+	data, ok := r.Data.([]interface{})
+	require.True(t, ok, "Data is not an []interface")
+	traces := convertToTraces(data)
 	sort.SliceStable(traces, func(i, j int) bool {
 		return traces[i].TraceID < traces[j].TraceID
 	})


### PR DESCRIPTION
When searching for tags in jaeger, a tag can come from any event attached to a span. Different tags can come from different events on the same span. Previously, this was broken since the events were joined to spans and tags searched one-at-a-time.

Fixed this by searching with EXISTS.



## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
