### PR TITLE
Add metrics to track inflight requests

### DIFF
--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -96,6 +96,9 @@ func (ingestor *DBIngestor) IngestTraces(ctx context.Context, traces ptrace.Trac
 	}
 	_, span := tracer.Default().Start(ctx, "ingest-traces")
 	defer span.End()
+	inflight := metrics.IngestorInflightRequests.WithLabelValues("trace")
+	defer inflight.Dec()
+	inflight.Inc()
 	return ingestor.tWriter.InsertTraces(ctx, traces)
 }
 
@@ -109,6 +112,9 @@ func (ingestor *DBIngestor) IngestMetrics(ctx context.Context, r *prompb.WriteRe
 	}
 	ctx, span := tracer.Default().Start(ctx, "db-ingest")
 	defer span.End()
+	inflight := metrics.IngestorInflightRequests.WithLabelValues("metric")
+	defer inflight.Dec()
+	inflight.Inc()
 	metrics.IngestorActiveWriteRequests.With(prometheus.Labels{"type": "metric", "kind": "sample_or_metadata"}).Inc()
 	defer metrics.IngestorActiveWriteRequests.With(prometheus.Labels{"type": "metric", "kind": "sample_or_metadata"}).Dec()
 	var (

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -157,6 +157,14 @@ var (
 			Help:      "Total requests bytes ingested for traces or metrics",
 		}, []string{"type"},
 	)
+	IngestorInflightRequests = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: util.PromNamespace,
+			Subsystem: "ingest",
+			Name:      "inflight_requests",
+			Help:      "Requests which are yet to be answered",
+		}, []string{"type"},
+	)
 	IngestorRequests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: util.PromNamespace,
@@ -225,6 +233,7 @@ func init() {
 		IngestorBatchFlushTotal,
 		IngestorPendingBatches,
 		IngestorRequestsQueued,
+		IngestorInflightRequests,
 	)
 }
 


### PR DESCRIPTION
This commit adds a new metrics `promscale_ingest_inflight_requests` to trace number of inflight requests in both metrics and trace ingestion path.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
