### PR TITLE
Wrap extension upgrades in a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use the following categories for changes:
 - Do not collect telemetry if `timescaledb.telemetry_level=off` [#1612]
 - Fix broken cache eviction in clockcache [#1603]
 - Possible goroutine leak due to unbuffered channel in select block [#1604]
+- Wrap extension upgrades in an explicit transaction [#1665]
 
 ## [0.14.0] - 2022-08-30
 


### PR DESCRIPTION
## Description

In some cases, an extension upgrade is a multi-step process. This change wraps some of those steps in an explicit transaction. Specifically, we don't want a failure to result in the extension being left at version 0.0.0

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
