### PR TITLE
Format advisory lock ID as decimal number

### DIFF
--- a/pkg/pgmodel/common/schema/schema.go
+++ b/pkg/pgmodel/common/schema/schema.go
@@ -11,7 +11,7 @@ const (
 	// Public is where all timescaledb-functions are loaded
 	Public = "public"
 
-	LockID = 0x4D829C732AAFCEDE // Chosen randomly.
+	LockID = 5585198506344173278 // Chosen randomly.
 
 	PromDataSeries = "prom_data_series"
 	PsTrace        = "_ps_trace"


### PR DESCRIPTION
## Description

This magic number is used in the promscale and promscale_extension codebases. In the promscale_extension codebase it's formatted as a decimal number. For the sake of more easily being able to find this number across the different codebases, we should format it the same.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
