### PR TITLE
Run Jaeger storage integration tests in separate GH actions job

### DIFF
--- a/.github/workflows/go-e2e.yml
+++ b/.github/workflows/go-e2e.yml
@@ -119,6 +119,53 @@ jobs:
         SHORTNAME: ${{ matrix.test-setups.shortname }}
       run: go test -race -timeout=30m ./pkg/tests/end_to_end_tests/ -use-multinode=$MULTI -timescale-docker-image=$DOCKER_IMAGE
 
+  test-jaeger-storage-integration:
+    name: jaeger-storage-integration
+    needs: pick_docker_image
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-setups:
+        - {name: "Singlenode (14)", shortname: "singlenode-14", multi: false, pg: 14}
+        - {name: "Singlenode (13)", shortname: "singlenode-13", multi: false, pg: 13}
+        - {name: "Singlenode (12)", shortname: "singlenode-12", multi: false, pg: 12}
+        # TODO (james): Skipping multinode because tests are broken for now
+        # - {name: "Multinode",                shortname: "multinode",      multi: true,  pg: 14}
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        repository: timescale/promscale
+        ref: ${{ inputs.ref }}
+
+    - name: Set up Go ${{ env.golang-version }}
+      uses: actions/setup-go@v3.2.1
+      with:
+        go-version: ${{ env.golang-version }}
+      id: go
+
+    - name: Use Go module caching
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Test ${{ matrix.test-setups.name }}
+      env:
+        DOCKER_IMAGE: ${{  needs.pick_docker_image.outputs[ format('docker_image_{0}', matrix.test-setups.pg) ] }}
+        MULTI: ${{ matrix.test-setups.multi }}
+        SHORTNAME: ${{ matrix.test-setups.shortname }}
+      run: go test -v -race -timeout=30m ./pkg/tests/end_to_end_tests/ -use-multinode=$MULTI -timescale-docker-image=$DOCKER_IMAGE -tags=jaeger_storage_test -run="^TestJaegerStorageIntegration/"
+
   upgrade_test:
     name: upgrade_tests
     needs: pick_docker_image
@@ -151,7 +198,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Test ${{ matrix.test-setups.name }}
+    - name: Test Upgrade from PG12
       env:
         DOCKER_IMAGE:  ${{  needs.pick_docker_image.outputs.docker_image_12 }}
       run: go test -race -v -timeout=30m ./pkg/tests/upgrade_tests/ -timescale-docker-image=$DOCKER_IMAGE
@@ -162,11 +209,12 @@ jobs:
     if: always()
     needs:
       - test-end-to-end
+      - test-jaeger-storage-integration
     runs-on: ubuntu-latest
     steps:
       - name: Mark the job as a success
-        if: needs.test-end-to-end.result == 'success'
+        if: needs.test-end-to-end.result == 'success' && needs.test-jaeger-storage-integration.result == 'success'
         run: exit 0
       - name: Mark the job as a failure
-        if: needs.test-end-to-end.result != 'success'
+        if: needs.test-end-to-end.result != 'success' || needs.test-jaeger-storage-integration.result != 'success'
         run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,16 @@ LOCAL_DOCKER_BASE := local/dev_promscale_extension
 GHCR_DOCKER_BASE := ghcr.io/timescale/dev_promscale_extension
 MDOX_BIN=mdox
 MDOX_VALIDATE_CONFIG=
+CURRENT_BRANCH?=$(shell git branch --show-current | sed 's#/#-#')
+EXTENSION_VERSION=$(shell cat EXTENSION_VERSION | tr -d '[:space:]')
+
 
 .PHONY: build
 build: generate
 	go build -ldflags "-X 'github.com/timescale/promscale/pkg/version.Branch=${GIT_BRANCH}' -X 'github.com/timescale/promscale/pkg/version.CommitHash=${GIT_COMMIT}'" -o dist/promscale ./cmd/promscale
 
 .PHONY: test
-test: unit e2e upgrade-test
+test: unit e2e jaeger-storage-test upgrade-test
 
 .PHONY: unit
 unit: generate prom-migrator
@@ -25,8 +28,6 @@ pkg/tests/testdata/traces-dataset.sz:
 	wget https://github.com/timescale/promscale-test-data/raw/main/traces-dataset.sz -O ./pkg/tests/testdata/traces-dataset.sz
 
 .PHONY: e2e
-e2e: CURRENT_BRANCH?=$(shell git branch --show-current | sed 's#/#-#')
-e2e: EXTENSION_VERSION=$(shell cat EXTENSION_VERSION | tr -d '[:space:]')
 e2e: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg14 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg14 $(GHCR_DOCKER_BASE):$(EXTENSION_VERSION)-ts2-pg14)
 e2e: pkg/tests/testdata/traces-dataset.sz generate
 	go test -v ./pkg/tests/end_to_end_tests/ -timescale-docker-image=$(DOCKER_IMAGE)
@@ -34,9 +35,12 @@ e2e: pkg/tests/testdata/traces-dataset.sz generate
 	# TODO: Skipping multinode because tests are broken for now
 	# go test -v ./pkg/tests/end_to_end_tests/ -use-multinode -timescale-docker-image=$(DOCKER_IMAGE)
 
+.PHONY: jaeger-storage-test
+jaeger-storage-test: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg14 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg14 $(GHCR_DOCKER_BASE):$(EXTENSION_VERSION)-ts2-pg14)
+jaeger-storage-test:
+	go test -v ./pkg/tests/end_to_end_tests/ -timescale-docker-image=$(DOCKER_IMAGE) -tags=jaeger_storage_test -run="^TestJaegerStorageIntegration/"
+
 .PHONY: upgrade-test
-upgrade-test: CURRENT_BRANCH?=$(shell git branch --show-current | sed 's#/#-#')
-upgrade-test: EXTENSION_VERSION=$(shell cat EXTENSION_VERSION | tr -d '[:space:]')
 upgrade-test: DOCKER_IMAGE?=$(shell ./scripts/fallback-docker.sh $(LOCAL_DOCKER_BASE):head-ts2-pg13 $(GHCR_DOCKER_BASE):$(CURRENT_BRANCH)-ts2-pg13 $(GHCR_DOCKER_BASE):$(EXTENSION_VERSION)-ts2-pg13)
 upgrade-test:
 	go test -v ./pkg/tests/upgrade_tests/ -timescale-docker-image=$(DOCKER_IMAGE)

--- a/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
+++ b/pkg/tests/end_to_end_tests/jaeger_store_integration_test.go
@@ -1,3 +1,5 @@
+//go:build jaeger_storage_test
+
 package end_to_end_tests
 
 import (


### PR DESCRIPTION
Prior to this PR Jaeger storage tests used to run as part of promscale e2e job.

Now it has been modified to run Jaeger tests in a dedicated job for a better visibility and easy auditing.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
