### PR TITLE
Run multiple tracegen workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We use the following categories for changes:
 ### Added
 
 ### Changed
+- tracegen.py now runs 4 worker processes generating traces concurrently. [#1702]
 
 ### Fixed
 - Fix queries returning no references/links when querying traces that were


### PR DESCRIPTION
## Description

tracegen.py now runs 4 worker processes generating traces concurrently. Also, fixes an issue with inserts into _ps_trace.span which were missing the duration_ms column.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
