### PR TITLE
Fix series cache growth

### DIFF
--- a/pkg/clockcache/cache_bench_test.go
+++ b/pkg/clockcache/cache_bench_test.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 )
 
 // microbenchmark. measure the length of the Insert critical section
@@ -73,8 +74,9 @@ func BenchmarkEviction(b *testing.B) {
 }
 
 func (c *Cache) markAll() {
+	now := int32(time.Now().Unix())
 	for i := range c.storage {
-		c.storage[i].used = 2
+		c.storage[i].usedWithTs = packUsedAndTimestamp(true, now)
 	}
 }
 

--- a/pkg/pgmodel/cache/series_cache_test.go
+++ b/pkg/pgmodel/cache/series_cache_test.go
@@ -6,11 +6,13 @@ package cache
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
-	"github.com/timescale/promscale/pkg/prompb"
 	"math"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/timescale/promscale/pkg/prompb"
 
 	promLabels "github.com/prometheus/prometheus/model/labels"
 )
@@ -51,4 +53,44 @@ func TestGenerateKey(t *testing.T) {
 
 	require.Equal(t, "test", metricName)
 	require.Equal(t, []byte("\x08\x00__name__\x04\x00test\x04\x00hell\x06\x00oworld\x05\x00hello\x05\x00world"), keyBuffer.Bytes())
+}
+
+func TestGrowSeriesCache(t *testing.T) {
+	testCases := []struct {
+		name         string
+		sleep        time.Duration
+		cacheGrowCnt int
+	}{
+		{
+			name:         "Grow criteria satisfied - we shoulnd't be evicting elements",
+			sleep:        time.Millisecond,
+			cacheGrowCnt: 1,
+		},
+		{
+			name:         "Growth criteria not satisfied - we can keep evicting old elements",
+			sleep:        time.Second * 2,
+			cacheGrowCnt: 0,
+		},
+	}
+
+	t.Setenv("IS_TEST", "true")
+	evictionMaxAge = time.Second // tweaking it to not wait too long
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := NewSeriesCache(Config{SeriesCacheInitialSize: 100, SeriesCacheMemoryMaxBytes: DefaultConfig.SeriesCacheMemoryMaxBytes}, nil)
+			cacheGrowCounter := 0
+			for i := 0; i < 200; i++ {
+				cache.cache.Insert(i, i, 1)
+				if i%100 == 0 {
+					time.Sleep(tc.sleep)
+				}
+				if cache.shouldGrow() {
+					cache.grow()
+					cacheGrowCounter++
+				}
+			}
+			require.Equal(t, tc.cacheGrowCnt, cacheGrowCounter, "series cache unexpectedly grow")
+		})
+	}
+
 }


### PR DESCRIPTION
Approach is using timestamps to have better understanding on what elements are getting evicted. 
If we see an eviction of recently used/inserted element (defined with `evictionMaxAge`) we will attempt to grow the cache. 
`evictionMaxAge` defines max age where we are doing evictions and not growing the cache.
We don't use additional memory to track timestamps but re-use existing field by bit packing data into `uint32`.

Closes https://github.com/timescale/promscale/issues/1389
