### PR TITLE
.github: clean up code ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,8 @@ go.mod @timescale/o11y-applications
 go.sum @timescale/o11y-applications
 
 # CI system and repository configuration
-.github/ @timescale/o11y-applications @timescale/o11y-services
+.github/ @timescale/o11y-applications
+.github/workflows/mixin.yml @timescale/o11y-services
 
 # Go packages
 /pkg/api @antekresic @Harkishen-Singh
@@ -20,6 +21,3 @@ go.sum @timescale/o11y-applications
 /pkg/tests/upgrade_tests/ @timescale/o11y-data-platform
 
 /docs/mixin @timescale/o11y-services
-
-# helm and kubernetes related parts
-/deploy @timescale/o11y-services @cevian

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,12 +22,6 @@
     },
     {
       "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
-      "matchStrings": ["helm-version:\\s(?<currentValue>.*?)\\n"],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "helm/helm"
-    },
-    {
-      "fileMatch": ["^\\.github\\/workflows\\/[^/]+\\.ya?ml$"],
       "matchStrings": ["goreleaser-version:\\s(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "goreleaser/goreleaser"
@@ -40,11 +34,6 @@
     }
   ],
   "packageRules": [
-    {
-      "addLabels": ["helm"],
-      "groupName": "helm charts",
-      "matchManagers": ["helmv3", "helm-values"]
-    },
     {
       "addLabels": ["go"],
       "groupName": "golang dependencies",

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,8 +1,0 @@
-# See https://github.com/helm/chart-testing#configuration
-remote: origin
-target-branch: master
-chart-dirs:
-  - deploy
-chart-repos: []
-helm-extra-args: --timeout 600s
-check-version-increment: false


### PR DESCRIPTION
## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

This is just a repository cleanup PR.

- Moved CI and repository configuration ownership solely to Applications team (as it de-facto was for the last months)
- Specified ownership of github action workflow related to monitoring mixin (mixin is owned by the services team)
- Removed Services ownership of `deploy/` directory as helm chart was moved
- Cleaned configurations related to helm

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
