### PR TITLE
Fix typo (?) in MaintenanceJobRunningTooLong runbook

### DIFF
--- a/docs/runbooks/PromscaleMaintenanceJobRunningTooLong.md
+++ b/docs/runbooks/PromscaleMaintenanceJobRunningTooLong.md
@@ -23,7 +23,7 @@ SELECT
 FROM  prom_info.metric;
 ```
 
-If `avg_not_yet_compressed_interval > 2` then See [Lots of uncompressed chunks](#lots-of-uncompressed-chunks) for mitigation
+If `avg_not_yet_compressed_chunks > 2` then See [Lots of uncompressed chunks](#lots-of-uncompressed-chunks) for mitigation
 
 If `avg_not_yet_compressed_interval is high AND avg_not_yet_compressed_chunks is small (<2)` then it indicates very big chunks.
 This can lead to maintenance jobs stuck on compressing this large chunk or waiting for the current chunk to stop getting new data.


### PR DESCRIPTION
## Description

When going through this runbook, i found what I assume is a mixup of `_interval` and `_chunks`, since the former would be, of course, an interval, and the latter seems to fit better with the context.

My apologies if I'm wrong, and I really appreciate these well-written runbooks!

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
