### PR TITLE
Include Jaeger ingest metrics in promscale dashboard

### DIFF
--- a/docs/mixin/.lint
+++ b/docs/mixin/.lint
@@ -4,4 +4,12 @@ exclusions:
   panel-datasource-rule:
   panel-title-description-rule:
   panel-units-rule:
-
+  target-counter-agg-rule:
+    reason: "disabled for promscale_sql_database_worker_maintenance_job_locks_total, promscale_sql_database_worker_maintenance_job_long_running_total. This metric should be not have total due to naming conventions as its a gauge, not a counter"
+    entries:
+      - dashboard: Promscale
+        panel: Long running maintenance queries by job type
+      - dashboard: Promscale
+        panel: Long running maintenance queries by wait event
+      - dashboard: Promscale
+        panel: Locks held by maintenance jobs by lock mode

--- a/docs/mixin/dashboards/promscale.json
+++ b/docs/mixin/dashboards/promscale.json
@@ -471,7 +471,7 @@
               "refId": "A"
             }
           ],
-          "title": "Requests (HTTP)",
+          "title": "Requests to Ingestor",
           "type": "timeseries"
         },
         {
@@ -761,9 +761,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(grpc_server_handled_total{grpc_service=~\"opentelemetry.proto.collector.trace.v1.TraceService\",grpc_method=~\"Export\"}[$__rate_interval]) > 0",
+              "expr": "rate(grpc_server_msg_received_total{grpc_method=~\"(WriteSpan|WriteSpanStream|Export)\"}[$__rate_interval])",
               "interval": "",
-              "legendFormat": "{{ grpc_type }}",
+              "legendFormat": "{{ grpc_service }}",
               "refId": "A"
             }
           ],
@@ -1774,7 +1774,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "exemplar": true,
-          "expr": "1 - promscale_sql_database_health_check_errors_total / promscale_sql_database_health_check_total",
+          "expr": "1 - rate(promscale_sql_database_health_check_errors_total[$__rate_interval]) / rate(promscale_sql_database_health_check_total[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{ instance }}",
           "refId": "A"


### PR DESCRIPTION
The `Requests (gRPC)` panel in the promscale dashboard was only showing handled requests by the OTEL collector. To include the metrics from the native Jaeger ingest endpoints are adding up 2 more metrics.

We are switching to the metric`grpc_server_msg_received_total` because of the way streaming works. Streaming allows to send/receive multiple messages on a single connection, so we need to count the amount of messages received and not the connection that were handled.