### PR TITLE
Change log level in vacuum engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ We use the following categories for changes:
 
 ## Unreleased
 
+### Added
+
+### Changed
+- Reduced the verbosity of the logs emitted by the vacuum engine [#1715]
+
+### Fixed
+
+
 ## [0.16.0] - 2022-10-20
 
 ### Added

--- a/pkg/vacuum/vacuum.go
+++ b/pkg/vacuum/vacuum.go
@@ -135,7 +135,7 @@ func (e *Engine) Run(ctx context.Context) {
 		return
 	}
 	if !acquired {
-		log.Info("msg", "vacuum engine did not acquire advisory lock")
+		log.Debug("msg", "vacuum engine did not acquire advisory lock")
 		return
 	}
 	// release the advisory lock when we're done
@@ -213,7 +213,7 @@ func runWorkers(ctx context.Context, parallelism int, chunks []string, worker fu
 // worker pulls chunks from a channel and vacuums them
 func (e *Engine) worker(ctx context.Context, id int, todo <-chan string) {
 	for chunk := range todo {
-		log.Info("msg", "vacuuming a chunk", "worker", id, "chunk", chunk)
+		log.Debug("msg", "vacuuming a chunk", "worker", id, "chunk", chunk)
 		sql := fmt.Sprintf(sqlVacuumFmt, chunk)
 		_, err := e.pool.Exec(ctx, sql)
 		if err != nil {


### PR DESCRIPTION
## Description

The log messages emitted by the vacuum engine were too verbose. This change makes some logs debug which were info.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
