### PR TITLE
Remove TestMetricView

### DIFF
--- a/pkg/tests/end_to_end_tests/functions_test.go
+++ b/pkg/tests/end_to_end_tests/functions_test.go
@@ -20,33 +20,6 @@ import (
 	"github.com/timescale/promscale/pkg/prompb"
 )
 
-func TestMetricView(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
-	withDB(t, *testDatabase, func(dbOwner *pgxpool.Pool, t testing.TB) {
-		db := testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_reader")
-		defer db.Close()
-		dbWriter := testhelpers.PgxPoolWithRole(t, *testDatabase, "prom_writer")
-		defer dbWriter.Close()
-
-		_, err := dbWriter.Exec(context.Background(), "SELECT * FROM _prom_catalog.get_or_create_metric_table_name(metric_name => $1)", "test_metric_name")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		var res string
-		err = dbWriter.QueryRow(context.Background(), "SELECT metric_name FROM _prom_catalog.metric_view()").Scan(&res)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if res != "test_metric_name" {
-			t.Fatal("Fail")
-		}
-	})
-}
-
 func TestSQLJsonLabelArray(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")


### PR DESCRIPTION


## Description

This test is no longer needed on the connector side. It is covered on the extension side, and it is blocking pending changes in the extension.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
