### PR TITLE
Implement series cache invalidation

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3.0'
 
 services:
   db:
-    image: timescale/timescaledb-ha:pg14-latest
+    # TODO (james): replace this when Promscale extension 0.7.0 published
+    image: ghcr.io/timescale/dev_promscale_extension:jg-time-based-epoch-ts2-pg14
     ports:
       - 5432:5432/tcp
     environment:
@@ -42,6 +43,7 @@ services:
       PROMSCALE_TELEMETRY_TRACE_OTEL_ENDPOINT: "otel-collector:4317"
       PROMSCALE_TELEMETRY_TRACE_SAMPLING_RATIO: "0.1"
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
+      PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS: true
 
   otel-collector:
     platform: linux/amd64

--- a/docker-compose/high-availability/docker-compose.yaml
+++ b/docker-compose/high-availability/docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3.0'
 
 services:
   db:
-    image: timescale/timescaledb-ha:pg14-latest
+    # TODO (james): replace this when Promscale extension 0.7.0 published
+    image: ghcr.io/timescale/dev_promscale_extension:jg-time-based-epoch-ts2-pg14
     ports:
       - 5432:5432/tcp
     environment:
@@ -44,6 +45,7 @@ services:
       PROMSCALE_METRICS_HIGH_AVAILABILITY: true
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
+      PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS: true
 
   promscale-connector2:
     image: timescale/promscale:latest
@@ -61,6 +63,7 @@ services:
       PROMSCALE_METRICS_HIGH_AVAILABILITY: true
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
+      PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS: true
 
   node_exporter:
     image: quay.io/prometheus/node-exporter

--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -79,4 +79,5 @@ func (p *pendingBuffer) release() {
 func (p *pendingBuffer) addReq(req *insertDataRequest) {
 	p.needsResponse = append(p.needsResponse, insertDataTask{finished: req.finished, errChan: req.errChan})
 	p.batch.AppendSlice(req.data)
+	p.batch.UpdateSeriesCacheEpoch(req.seriesCacheEpoch)
 }

--- a/pkg/pgmodel/ingestor/handler_test.go
+++ b/pkg/pgmodel/ingestor/handler_test.go
@@ -5,12 +5,11 @@
 package ingestor
 
 import (
-	"testing"
-
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
+	"testing"
 )
 
 func getSeries(t *testing.T, scache *cache.SeriesCacheImpl, labels labels.Labels) *model.Series {
@@ -74,7 +73,7 @@ func TestLabelArrayCreator(t *testing.T) {
 
 	/* test one series already set */
 	setSeries := getSeries(t, scache, labels.Labels{metricNameLabel, valTwo})
-	setSeries.SetSeriesID(5, 4)
+	setSeries.SetSeriesID(5)
 	seriesSet = []*model.Series{
 		getSeries(t, scache, labels.Labels{metricNameLabel, valOne}),
 		setSeries,

--- a/pkg/pgmodel/ingestor/metric_batcher.go
+++ b/pkg/pgmodel/ingestor/metric_batcher.go
@@ -7,7 +7,6 @@ package ingestor
 import (
 	"context"
 	"fmt"
-
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 

--- a/pkg/pgmodel/ingestor/metric_batcher_test.go
+++ b/pkg/pgmodel/ingestor/metric_batcher_test.go
@@ -136,7 +136,7 @@ func TestInitializeMetricBatcher(t *testing.T) {
 func TestSendBatches(t *testing.T) {
 	makeSeries := func(seriesID int) *model.Series {
 		l := &model.Series{}
-		l.SetSeriesID(pgmodel.SeriesID(seriesID), 1)
+		l.SetSeriesID(pgmodel.SeriesID(seriesID))
 		return l
 	}
 	var workFinished sync.WaitGroup
@@ -154,7 +154,7 @@ func TestSendBatches(t *testing.T) {
 
 	// we make sure that we receive batch data
 	for i := 0; i < 3; i++ {
-		id, _, err := batch.data.batch.Data()[i].Series().GetSeriesID()
+		id, err := batch.data.batch.Data()[i].Series().GetSeriesID()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/pgmodel/model/series.go
+++ b/pkg/pgmodel/model/series.go
@@ -19,8 +19,7 @@ import (
 type SeriesID int64
 
 const (
-	invalidSeriesID    = -1
-	InvalidSeriesEpoch = -1
+	invalidSeriesID = -1
 )
 
 func (s SeriesID) String() string {
@@ -30,6 +29,14 @@ func (s SeriesID) String() string {
 // SeriesEpoch represents the series epoch
 type SeriesEpoch int64
 
+func (s SeriesEpoch) After(o SeriesEpoch) bool {
+	return s > o
+}
+
+func (s SeriesEpoch) AfterEq(o SeriesEpoch) bool {
+	return s > o
+}
+
 // Series stores a Prometheus labels.Labels in its canonical string representation
 type Series struct {
 	//protects names, values, seriesID, epoch
@@ -38,7 +45,6 @@ type Series struct {
 	names    []string
 	values   []string
 	seriesID SeriesID
-	epoch    SeriesEpoch
 
 	metricName string
 	str        string
@@ -50,7 +56,6 @@ func NewSeries(key string, labelPairs []prompb.Label) *Series {
 		values:   make([]string, len(labelPairs)),
 		str:      key,
 		seriesID: invalidSeriesID,
-		epoch:    InvalidSeriesEpoch,
 	}
 	for i, l := range labelPairs {
 		series.names[i] = l.Name
@@ -108,26 +113,25 @@ func (l *Series) FinalSizeBytes() uint64 {
 	return uint64(unsafe.Sizeof(*l)) + uint64(len(l.str)+len(l.metricName)) // #nosec
 }
 
-func (l *Series) GetSeriesID() (SeriesID, SeriesEpoch, error) {
+func (l *Series) GetSeriesID() (SeriesID, error) {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
 
 	switch l.seriesID {
 	case invalidSeriesID:
-		return 0, 0, fmt.Errorf("Series id not set")
+		return 0, fmt.Errorf("Series id not set")
 	case 0:
-		return 0, 0, fmt.Errorf("Series id invalid")
+		return 0, fmt.Errorf("Series id invalid")
 	default:
-		return l.seriesID, l.epoch, nil
+		return l.seriesID, nil
 	}
 }
 
-//note this has to be idempotent
-func (l *Series) SetSeriesID(sid SeriesID, eid SeriesEpoch) {
+// Note: This has to be idempotent
+func (l *Series) SetSeriesID(sid SeriesID) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	l.seriesID = sid
-	l.epoch = eid
 	l.names = nil
 	l.values = nil
 }

--- a/pkg/tests/end_to_end_tests/drop_test.go
+++ b/pkg/tests/end_to_end_tests/drop_test.go
@@ -659,7 +659,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 			t.Error("expected ingest to fail due to old epoch")
 		}
 
-		scache.Reset()
+		scache.Reset(pgmodel.SeriesEpoch(time.Now().Unix()))
 
 		ingestor.Close()
 		ingestor2, err := ingstr.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), nil)

--- a/scripts/end_to_end_tests.sh
+++ b/scripts/end_to_end_tests.sh
@@ -88,6 +88,7 @@ PROMSCALE_DB_PASSWORD=postgres \
 PROMSCALE_DB_NAME=postgres \
 PROMSCALE_DB_SSL_MODE=disable \
 PROMSCALE_WEB_TELEMETRY_PATH=/metrics \
+PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS=true \
 ./promscale -startup.only
 
 docker exec e2e-tsdb psql -U postgres -d postgres \


### PR DESCRIPTION
This change implements invalidation of the series cache, and mechanisms to prevent the ingestion of data based on stale cache information.

In principle, the cache invalidation mechanism works as follows:

In the database, we track two values: `current_epoch`, and `delete_epoch`. These are unix timestamps (which, for reasons of backwards-compatibility, are stored in a BIGINT field), updated every time that rows in the series table are deleted. `current_epoch` is set from `now()`, and `delete_epoch` is set from `now() - epoch_duration`. `epoch_duration` is a configurable parameter. 

When a series row is to be deleted, instead of immediately deleting it, we set the `delete_epoch` column of the series row to the `current_epoch` timestamp (the time at which we decided that it will be deleted). After `epoch_duration` time elapses, the row is removed.

When the connector starts, it reads `current_epoch` from the database and stores this value with the series cache as `cache_current_epoch`. The connector periodically fetches the ids of series rows where `delete_epoch` is not null, together with `current_epoch`. It removes these entries from the cache, and updates `cache_current_epoch` to the value of `current_epoch` which was fetched from the database.

As the connector receives samples to be inserted, it tracks the smallest value of `cache_current_epoch` that it saw for that batch. When it comes to inserting the samples in a batch into the database, it asserts (in the database) that the cache which was read from was not stale. This is expressed as: `cache_current_epoch > delete_epoch`. If this is not the case, the insert is aborted.

This is a companion change to [1] which implements the database-side logic required for cache invalidation.

[1]: https://github.com/timescale/promscale_extension/pull/529

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
