### PR TITLE
Fix incorrect histogram quantile in promscale dashboard

### DIFF
--- a/docs/mixin/dashboards/promscale.json
+++ b/docs/mixin/dashboards/promscale.json
@@ -665,7 +665,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "histogram_quantile(0.90, rate(promscale_ingest_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.95, rate(promscale_ingest_duration_seconds_bucket{namespace=~\"$namespace\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "p95 {{ type }}",
@@ -953,7 +953,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "histogram_quantile(0.5, rate(grpc_server_handling_seconds_bucket{grpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\",grpc_method=~\"Export\",namespace=~\"$namespace\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.9, rate(grpc_server_handling_seconds_bucket{grpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\",grpc_method=~\"Export\",namespace=~\"$namespace\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "p90 {{ type }}",
@@ -965,7 +965,7 @@
                 "uid": "${datasource}"
               },
               "exemplar": true,
-              "expr": "histogram_quantile(0.5, rate(grpc_server_handling_seconds_bucket{grpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\",grpc_method=~\"Export\",namespace=~\"$namespace\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.95, rate(grpc_server_handling_seconds_bucket{grpc_service=\"opentelemetry.proto.collector.trace.v1.TraceService\",grpc_method=~\"Export\",namespace=~\"$namespace\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "p95 {{ type }}",


### PR DESCRIPTION
Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

## Description

This PR fixes typo in dashboards causes incorrect graph rendering of P95, P90 in few panels.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [X] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
