### PR TITLE
Implement series cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use the following categories for changes:
   configuration. Supersedes `startup.dataset.config` which accepts a string
   instead of a mapping [#1737]
 - Add alert to notify about duplicate sample/metric ingestion. [#1688]
+- Implemented proper invalidation of the series cache [#1752]
 
 ### Changed
 - Reduced the verbosity of the logs emitted by the vacuum engine [#1715]

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3.0'
 
 services:
   db:
-    image: timescale/timescaledb-ha:pg14-latest
+    # TODO (james): replace this when our changes are published in the docker image
+    image: ghcr.io/timescale/dev_promscale_extension:jg-logical-to-time-epoch-2-ts2-pg14
     ports:
       - 5432:5432/tcp
     environment:
@@ -42,6 +43,7 @@ services:
       PROMSCALE_TELEMETRY_TRACE_OTEL_ENDPOINT: "otel-collector:4317"
       PROMSCALE_TELEMETRY_TRACE_SAMPLING_RATIO: "0.1"
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
+      PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS: true
 
   otel-collector:
     platform: linux/amd64

--- a/docker-compose/high-availability/docker-compose.yaml
+++ b/docker-compose/high-availability/docker-compose.yaml
@@ -2,7 +2,8 @@ version: '3.0'
 
 services:
   db:
-    image: timescale/timescaledb-ha:pg14-latest
+    # TODO (james): replace this when our changes are published in the docker image
+    image: ghcr.io/timescale/dev_promscale_extension:jg-logical-to-time-epoch-2-ts2-pg14
     ports:
       - 5432:5432/tcp
     environment:
@@ -44,6 +45,7 @@ services:
       PROMSCALE_METRICS_HIGH_AVAILABILITY: true
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
+      PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS: true
 
   promscale-connector2:
     image: timescale/promscale:latest
@@ -61,6 +63,7 @@ services:
       PROMSCALE_METRICS_HIGH_AVAILABILITY: true
       PROMSCALE_DB_URI: postgres://postgres:password@db:5432/postgres?sslmode=allow
       PROMSCALE_METRICS_RULES_CONFIG_FILE: /prometheus.yml
+      PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS: true
 
   node_exporter:
     image: quay.io/prometheus/node-exporter

--- a/pkg/clockcache/cache.go
+++ b/pkg/clockcache/cache.go
@@ -329,6 +329,13 @@ func (self *Cache) ExpandTo(newMax int) {
 }
 
 func (self *Cache) Reset() {
+	self.ResetAndCallWhileLocksHeld(func() {})
+}
+
+// ResetAndCallWhileLocksHeld resets the cache and calls fn while holding the
+// insert and elements locks. This allows a consumer of the cache to coordinate
+// its state with the state of the cache.
+func (self *Cache) ResetAndCallWhileLocksHeld(fn func()) {
 	self.insertLock.Lock()
 	defer self.insertLock.Unlock()
 	oldSize := cap(self.storage)
@@ -338,6 +345,10 @@ func (self *Cache) Reset() {
 
 	self.elementsLock.Lock()
 	defer self.elementsLock.Unlock()
+
+	// We're holding all locks here, so call fn
+	fn()
+
 	self.elements = newElements
 	self.storage = newStorage
 	self.next = 0
@@ -414,4 +425,48 @@ func packUsedAndTimestamp(used bool, ts int32) uint32 {
 		usedBit = 1
 	}
 	return uint32(usedBit<<31) | uint32(ts)
+}
+
+// RemoveMatchingItems removes items whose value passes the check applied by
+// the passed `matcher` function. It returns the number of entries which were
+// removed from the cache.
+// Note: Due to the locks that this function takes, it is best used when very
+// few items stored in the cache are to be removed.
+func (self *Cache) RemoveMatchingItems(matcher func(value interface{}) bool) int {
+	// Note: we take an RLock to find matching items, then release it and take
+	// a full Lock to remove them. This has two assumptions:
+	// 1. len(matchingItems) << len(storage): taking a big lock should be fine.
+	// 2. Missing the addition of an item to the cache is not problematic.
+	//    Locking like this doesn't provide a consistent view of the cache
+	//    contents. Either an entry is removed or added under our feet. An
+	//    entry being removed is not a problem, we will just skip it. An entry
+	//    being added is fine for the one consumer of this method (cache
+	//    invalidation): if an item is added to the cache, then it was just
+	//    created/resurrected in the DB, so it wouldn't have been a candidate
+	//    for removal.
+
+	self.elementsLock.RLock()
+	matchingItems := make([]interface{}, 0)
+	for k, v := range self.elements {
+		if matcher(v.value) {
+			matchingItems = append(matchingItems, k)
+		}
+	}
+	self.elementsLock.RUnlock()
+	self.elementsLock.Lock()
+	for _, v := range matchingItems {
+		self.remove(v)
+	}
+	self.elementsLock.Unlock()
+	return len(matchingItems)
+}
+
+func (self *Cache) remove(key interface{}) {
+	value, present := self.elements[key]
+	if !present {
+		// do nothing
+		return
+	}
+	delete(self.elements, key)
+	*value = element{}
 }

--- a/pkg/pgmodel/cache/series_cache.go
+++ b/pkg/pgmodel/cache/series_cache.go
@@ -30,28 +30,46 @@ var evictionMaxAge = time.Minute * 2      // grow cache if we are evicting eleme
 
 // SeriesCache is a cache of model.Series entries.
 type SeriesCache interface {
-	Reset()
+	Reset(epoch model.SeriesEpoch)
 	GetSeriesFromProtos(labelPairs []prompb.Label) (series *model.Series, metricName string, err error)
 	Len() int
 	Cap() int
 	Evictions() uint64
+	EvictSeriesById(seriesIds []model.SeriesID, epoch model.SeriesEpoch) int
+	CacheEpoch() model.SeriesEpoch
+	SetCacheEpoch(epoch model.SeriesEpoch)
 }
 
 type SeriesCacheImpl struct {
 	cache        *clockcache.Cache
 	maxSizeBytes uint64
+	cacheEpoch   model.SeriesEpoch
+	epochLock    sync.RWMutex
 }
 
 func NewSeriesCache(config Config, sigClose <-chan struct{}) *SeriesCacheImpl {
 	cache := &SeriesCacheImpl{
-		clockcache.WithMetrics("series", "metric", config.SeriesCacheInitialSize),
-		config.SeriesCacheMemoryMaxBytes,
+		cache:        clockcache.WithMetrics("series", "metric", config.SeriesCacheInitialSize),
+		maxSizeBytes: config.SeriesCacheMemoryMaxBytes,
+		cacheEpoch:   model.SeriesEpoch(0),
 	}
 
 	if sigClose != nil {
 		go cache.runSizeCheck(sigClose)
 	}
 	return cache
+}
+
+func (t *SeriesCacheImpl) CacheEpoch() model.SeriesEpoch {
+	t.epochLock.RLock()
+	defer t.epochLock.RUnlock()
+	return t.cacheEpoch
+}
+
+func (t *SeriesCacheImpl) SetCacheEpoch(epoch model.SeriesEpoch) {
+	t.epochLock.Lock()
+	defer t.epochLock.Unlock()
+	t.cacheEpoch = epoch
 }
 
 func (t *SeriesCacheImpl) runSizeCheck(sigClose <-chan struct{}) {
@@ -115,8 +133,12 @@ func (t *SeriesCacheImpl) Evictions() uint64 {
 }
 
 // Reset should be concurrency-safe
-func (t *SeriesCacheImpl) Reset() {
-	t.cache.Reset()
+func (t *SeriesCacheImpl) Reset(epoch model.SeriesEpoch) {
+	t.cache.ResetAndCallWhileLocksHeld(func() {
+		// When we reset the cache, we need to reset the cache epoch as well,
+		// otherwise it may be out of date as soon as data is loaded into it.
+		t.SetCacheEpoch(epoch)
+	})
 }
 
 // Get the canonical version of a series if one exists.
@@ -133,7 +155,7 @@ func (t *SeriesCacheImpl) loadSeries(str string) (l *model.Series) {
 // representation, returning the canonical version (which can be different in
 // the even of multiple goroutines setting labels concurrently).
 func (t *SeriesCacheImpl) setSeries(str string, lset *model.Series) *model.Series {
-	//str not counted twice in size since the key and lset.str will point to same thing.
+	// str not counted twice in size since the key and lset.str will point to same thing.
 	val, _ := t.cache.Insert(str, lset, lset.FinalSizeBytes())
 	return val.(*model.Series)
 }
@@ -277,4 +299,29 @@ func (t *SeriesCacheImpl) GetSeriesFromProtos(labelPairs []prompb.Label) (*model
 	}
 
 	return series, metricName, nil
+}
+
+func (t *SeriesCacheImpl) EvictSeriesById(seriesIds []model.SeriesID, epoch model.SeriesEpoch) int {
+	if len(seriesIds) == 0 {
+		return 0
+	}
+	seriesIdMap := make(map[model.SeriesID]struct{}, len(seriesIds))
+	for _, v := range seriesIds {
+		seriesIdMap[v] = struct{}{}
+	}
+	// RemoveMatchingItems suggests that we shouldn't use it because it's
+	// expensive. In normal operation (with ~30 day retention), we don't expect
+	// our cache to contain a lot of the series that we want to remove. This
+	// matches well with RemoveMatchingItems locking mechanism. See the impl.
+	count := t.cache.RemoveMatchingItems(func(v interface{}) bool {
+		value := v.(*model.Series)
+		id, err := value.GetSeriesID()
+		if err != nil {
+			return false
+		}
+		_, present := seriesIdMap[id]
+		return present
+	})
+	t.SetCacheEpoch(epoch)
+	return count
 }

--- a/pkg/pgmodel/ingestor/buffer.go
+++ b/pkg/pgmodel/ingestor/buffer.go
@@ -79,4 +79,5 @@ func (p *pendingBuffer) release() {
 func (p *pendingBuffer) addReq(req *insertDataRequest) {
 	p.needsResponse = append(p.needsResponse, insertDataTask{finished: req.finished, errChan: req.errChan})
 	p.batch.AppendSlice(req.data)
+	p.batch.UpdateSeriesCacheEpoch(req.seriesCacheEpoch)
 }

--- a/pkg/pgmodel/ingestor/handler_test.go
+++ b/pkg/pgmodel/ingestor/handler_test.go
@@ -5,12 +5,11 @@
 package ingestor
 
 import (
-	"testing"
-
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/stretchr/testify/require"
 	"github.com/timescale/promscale/pkg/pgmodel/cache"
 	"github.com/timescale/promscale/pkg/pgmodel/model"
+	"testing"
 )
 
 func getSeries(t *testing.T, scache *cache.SeriesCacheImpl, labels labels.Labels) *model.Series {
@@ -74,7 +73,7 @@ func TestLabelArrayCreator(t *testing.T) {
 
 	/* test one series already set */
 	setSeries := getSeries(t, scache, labels.Labels{metricNameLabel, valTwo})
-	setSeries.SetSeriesID(5, 4)
+	setSeries.SetSeriesID(5)
 	seriesSet = []*model.Series{
 		getSeries(t, scache, labels.Labels{metricNameLabel, valOne}),
 		setSeries,

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -194,6 +194,14 @@ func (ingestor *DBIngestor) ingestTimeseries(ctx context.Context, timeseries []p
 		insertables = make(map[string][]model.Insertable)
 	)
 
+	// Determine the value of the series cache epoch _before_ getting any items
+	// from the cache. In order to properly abort the insert transaction if the
+	// cache is out of date (epoch abort), we want to determine the minimum
+	// cache epoch for all samples in an ingest batch. We know that everything
+	// currently in the cache has this epoch, and everything that we load from
+	// the database later will have _at least_ that epoch.
+	epoch := ingestor.sCache.CacheEpoch()
+
 	for i := range timeseries {
 		var (
 			err        error
@@ -238,7 +246,7 @@ func (ingestor *DBIngestor) ingestTimeseries(ctx context.Context, timeseries []p
 	}
 	releaseMem()
 
-	numInsertablesIngested, errSamples := ingestor.dispatcher.InsertTs(ctx, model.Data{Rows: insertables, ReceivedTime: time.Now()})
+	numInsertablesIngested, errSamples := ingestor.dispatcher.InsertTs(ctx, model.Data{Rows: insertables, ReceivedTime: time.Now(), SeriesCacheEpoch: epoch})
 	if errSamples == nil && numInsertablesIngested != totalRowsExpected {
 		return numInsertablesIngested, fmt.Errorf("failed to insert all the data! Expected: %d, Got: %d", totalRowsExpected, numInsertablesIngested)
 	}

--- a/pkg/pgmodel/ingestor/metric_batcher.go
+++ b/pkg/pgmodel/ingestor/metric_batcher.go
@@ -7,7 +7,6 @@ package ingestor
 import (
 	"context"
 	"fmt"
-
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 

--- a/pkg/pgmodel/ingestor/metric_batcher_test.go
+++ b/pkg/pgmodel/ingestor/metric_batcher_test.go
@@ -136,7 +136,7 @@ func TestInitializeMetricBatcher(t *testing.T) {
 func TestSendBatches(t *testing.T) {
 	makeSeries := func(seriesID int) *model.Series {
 		l := &model.Series{}
-		l.SetSeriesID(pgmodel.SeriesID(seriesID), 1)
+		l.SetSeriesID(pgmodel.SeriesID(seriesID))
 		return l
 	}
 	var workFinished sync.WaitGroup
@@ -154,7 +154,7 @@ func TestSendBatches(t *testing.T) {
 
 	// we make sure that we receive batch data
 	for i := 0; i < 3; i++ {
-		id, _, err := batch.data.batch.Data()[i].Series().GetSeriesID()
+		id, err := batch.data.batch.Data()[i].Series().GetSeriesID()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/pgmodel/model/series.go
+++ b/pkg/pgmodel/model/series.go
@@ -19,8 +19,7 @@ import (
 type SeriesID int64
 
 const (
-	invalidSeriesID    = -1
-	InvalidSeriesEpoch = -1
+	invalidSeriesID = -1
 )
 
 func (s SeriesID) String() string {
@@ -30,6 +29,14 @@ func (s SeriesID) String() string {
 // SeriesEpoch represents the series epoch
 type SeriesEpoch int64
 
+func (s SeriesEpoch) After(o SeriesEpoch) bool {
+	return s > o
+}
+
+func (s SeriesEpoch) AfterEq(o SeriesEpoch) bool {
+	return s >= o
+}
+
 // Series stores a Prometheus labels.Labels in its canonical string representation
 type Series struct {
 	//protects names, values, seriesID, epoch
@@ -38,7 +45,6 @@ type Series struct {
 	names    []string
 	values   []string
 	seriesID SeriesID
-	epoch    SeriesEpoch
 
 	metricName string
 	str        string
@@ -50,7 +56,6 @@ func NewSeries(key string, labelPairs []prompb.Label) *Series {
 		values:   make([]string, len(labelPairs)),
 		str:      key,
 		seriesID: invalidSeriesID,
-		epoch:    InvalidSeriesEpoch,
 	}
 	for i, l := range labelPairs {
 		series.names[i] = l.Name
@@ -108,26 +113,25 @@ func (l *Series) FinalSizeBytes() uint64 {
 	return uint64(unsafe.Sizeof(*l)) + uint64(len(l.str)+len(l.metricName)) // #nosec
 }
 
-func (l *Series) GetSeriesID() (SeriesID, SeriesEpoch, error) {
+func (l *Series) GetSeriesID() (SeriesID, error) {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
 
 	switch l.seriesID {
 	case invalidSeriesID:
-		return 0, 0, fmt.Errorf("Series id not set")
+		return 0, fmt.Errorf("Series id not set")
 	case 0:
-		return 0, 0, fmt.Errorf("Series id invalid")
+		return 0, fmt.Errorf("Series id invalid")
 	default:
-		return l.seriesID, l.epoch, nil
+		return l.seriesID, nil
 	}
 }
 
-// note this has to be idempotent
-func (l *Series) SetSeriesID(sid SeriesID, eid SeriesEpoch) {
+// Note: This has to be idempotent
+func (l *Series) SetSeriesID(sid SeriesID) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 	l.seriesID = sid
-	l.epoch = eid
 	l.names = nil
 	l.values = nil
 }

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -413,6 +413,10 @@ func (m *MockRows) Scan(dest ...interface{}) error {
 			if d, ok := dest[i].(*time.Time); ok {
 				*d = s
 			}
+		case time.Duration:
+			if d, ok := dest[i].(*time.Duration); ok {
+				*d = s
+			}
 		case float64:
 			if _, ok := dest[i].(float64); !ok {
 				return fmt.Errorf("wrong value type float64")

--- a/pkg/tests/end_to_end_tests/drop_test.go
+++ b/pkg/tests/end_to_end_tests/drop_test.go
@@ -659,7 +659,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 			t.Error("expected ingest to fail due to old epoch")
 		}
 
-		scache.Reset()
+		scache.Reset(pgmodel.SeriesEpoch(time.Now().Unix()))
 
 		ingestor.Close()
 		ingestor2, err := ingstr.NewPgxIngestorForTests(pgxconn.NewPgxConn(db), nil)

--- a/scripts/end_to_end_tests.sh
+++ b/scripts/end_to_end_tests.sh
@@ -88,6 +88,7 @@ PROMSCALE_DB_PASSWORD=postgres \
 PROMSCALE_DB_NAME=postgres \
 PROMSCALE_DB_SSL_MODE=disable \
 PROMSCALE_WEB_TELEMETRY_PATH=/metrics \
+PROMSCALE_STARTUP_UPGRADE_PRERELEASE_EXTENSIONS=true \
 ./promscale -startup.only
 
 docker exec e2e-tsdb psql -U postgres -d postgres \


### PR DESCRIPTION
This change implements invalidation of the series cache, and mechanisms to prevent the ingestion of data based on stale cache information.

In principle, the cache invalidation mechanism works as follows:

In the database, we track two values: `current_epoch`, and `delete_epoch`. These are unix timestamps (which, for reasons of backwards-compatibility, are stored in a BIGINT field), updated every time that rows in the series table are deleted. `current_epoch` is set from `now()`, and `delete_epoch` is set from `now() - epoch_duration`. `epoch_duration` is a configurable parameter. 

When a series row is to be deleted, instead of immediately deleting it, we set the `delete_epoch` column of the series row to the `current_epoch` timestamp (the time at which we decided that it will be deleted). After `epoch_duration` time elapses, the row is removed.

When the connector starts, it reads `current_epoch` from the database and stores this value with the series cache as `cache_current_epoch`. The connector periodically fetches the ids of series rows where `delete_epoch` is not null, together with `current_epoch`. It removes these entries from the cache, and updates `cache_current_epoch` to the value of `current_epoch` which was fetched from the database.

As the connector receives samples to be inserted, it tracks the smallest value of `cache_current_epoch` that it saw for that batch. When it comes to inserting the samples in a batch into the database, it asserts (in the database) that the cache which was read from was not stale. This is expressed as: `cache_current_epoch > delete_epoch`. If this is not the case, the insert is aborted.

This is a companion change to [1] which implements the database-side logic required for cache invalidation.

[1]: https://github.com/timescale/promscale_extension/pull/529

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
