### PR TITLE
Replace deprecated github actions '::set-output' command

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -56,7 +56,7 @@ jobs:
           echo "${OUTPUT}"
           OUTPUT="${OUTPUT//$'\n'/'%0A'}"
           OUTPUT="${OUTPUT//$'\r'/'%0D'}"
-          echo "::set-output name=result::$OUTPUT"
+          echo "result=$OUTPUT" >> ${GITHUB_OUTPUT}
 
       - name: Publish results as comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/go-e2e.yml
+++ b/.github/workflows/go-e2e.yml
@@ -65,9 +65,9 @@ jobs:
           docker_image_13=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg13 ${image_base}:${stable_branch_tag}-pg13)
           docker_image_14=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag}-pg14 ${image_base}:${stable_branch_tag}-pg14)
         fi;
-        echo "::set-output name=docker_image_12::${docker_image_12}"
-        echo "::set-output name=docker_image_13::${docker_image_13}"
-        echo "::set-output name=docker_image_14::${docker_image_14}"
+        echo "docker_image_12=${docker_image_12}" >> ${GITHUB_OUTPUT}
+        echo "docker_image_13=${docker_image_13}" >> ${GITHUB_OUTPUT}
+        echo "docker_image_14=${docker_image_14}" >> ${GITHUB_OUTPUT}
 
   test-end-to-end:
     name: e2e

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -42,7 +42,7 @@ jobs:
         stable_branch_tag=$(echo ${extension_version}-ts2-pg${{matrix.pg}})
         image_base="ghcr.io/timescale/dev_promscale_extension"
         docker_image=$(./scripts/fallback-docker.sh ${image_base}:${possible_branch_tag} ${image_base}:${stable_branch_tag})
-        echo "::set-output name=docker_image::${docker_image}"
+        echo "docker_image=${docker_image}" >> ${GITHUB_OUTPUT}
 
     - name: TimescaleDB 2.x with Promscale extension (pg${{matrix.pg}})
       run: ./scripts/end_to_end_tests.sh ${{steps.metadata.outputs.docker_image}}


### PR DESCRIPTION

## Description

The `::set-output` pattern is deprecated [1], and has been replaced with piping the results to a specific file.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
