### PR TITLE
Tell renovate about golang versions in Dockerfiles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,12 @@
       "matchStrings": ["golang-version:\\s(?<currentValue>.*?)\\n"],
       "datasourceTemplate": "golang-version",
       "depNameTemplate": "golang"
+    },
+    {
+      "fileMatch": ["Dockerfile"],
+      "matchStrings": ["FROM golang:(?<currentValue>.*?)-alpine"],
+      "datasourceTemplate": "golang-version",
+      "depNameTemplate": "golang"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Description

Renovate knows about golang versions, but it doesn't know to bump the version in a Dockerfile.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] ~~CHANGELOG entry for user-facing changes~~
- [ ] ~~Updated the relevant documentation~~
