### PR TITLE
Throttle vacuum workers based on chunk age

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ We use the following categories for changes:
 
 ### Changed
 - Reduced the verbosity of the logs emitted by the vacuum engine [#1715]
+- The vacuum engine now throttles the number of workers used based on the oldest txid from
+  the chunks needing freezing [#1761]
 
 ### Fixed
 

--- a/docs/vacuum.md
+++ b/docs/vacuum.md
@@ -3,15 +3,35 @@
 The Promscale connector has a background job called the vacuum engine.
 The goal of the vacuum engine is to help prevent transaction id wraparound
 which can be a problem for high transaction workloads.
-It periodically looks for compressed chunks that likely need to be
-[vacuumed/frozen](https://www.postgresql.org/docs/current/routine-vacuuming.html#VACUUM-FOR-WRAPAROUND).
-These chunks are manually [vacuumed](https://www.postgresql.org/docs/current/sql-vacuum.html)
-with the freeze and analyze options.
 
-Only one instance of the engine needs to run at a time across all Promscale
-connector instances. An advisory lock is held in the database while the engine
-is running. This lock is used to coordinate and prevent concurrent runs.
+Once a chunk is compressed, it is unlikely to be modified.
+Therefore, a compressed chunk should only need to be vacuumed once
+and never again. We want to vacuum a compressed chunk as soon as
+possible in hopes of freezing all the pages for the chunk. We want
+to freeze so that we don't risk burning through transaction ids too
+quickly under heavy ingest.
 
-If the engine finds chunks to vacuum, it can use multiple database connections
-to parallelize the work. Multiple chunks will be vacuumed simultaneously. The
-degree of parallelism can be configured.
+The vacuum engine periodically wakes up. If it can grab an advisory
+lock (only one vacuum engine runs at a time per database regardless
+of the number of connectors), it will look for compressed chunks
+that are not fully frozen.
+
+If chunks needing freezing are found, it uses the maximum
+transaction age of the chunks in the set to determine how many
+workers to use to vacuum the chunks. The closer the maximum
+transaction age is to autovacuum_freeze_max_age the more workers are
+used (up to a maximum number). This is done to throttle how much
+database CPU is consumed by vacuuming.
+
+We ignore chunks that have been vacuumed in the last 15 minutes.
+
+We ignore chunks with a transaction id age less than
+vacuum_freeze_min_age.
+
+We grab a list of chunks and then let workers pull from this list.
+Vacuuming may take a while, so there is a decent chance that the
+postgres autovacuum engine may vacuum a chunk before we get to it.
+We get the autovacuum count when we produce the list. Just before
+vacuuming a chunk, we check the autovacuum count again to see if it
+has increased. If it has, the autovacuum engine beat us to the
+chunk, and we skip it.

--- a/pkg/runner/flags_test.go
+++ b/pkg/runner/flags_test.go
@@ -182,7 +182,7 @@ func TestParseFlags(t *testing.T) {
 			result: func(c Config) Config {
 				c.VacuumCfg.Disable = true
 				c.VacuumCfg.RunFrequency = 10 * time.Minute
-				c.VacuumCfg.Parallelism = 4
+				c.VacuumCfg.MaxParallelism = 4
 				return c
 			},
 		},
@@ -192,7 +192,7 @@ func TestParseFlags(t *testing.T) {
 			shouldError: false,
 			result: func(c Config) Config {
 				c.VacuumCfg.RunFrequency = 30 * time.Minute
-				c.VacuumCfg.Parallelism = 5
+				c.VacuumCfg.MaxParallelism = 5
 				return c
 			},
 		},

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -279,7 +279,11 @@ func Run(cfg *Config) error {
 	)
 
 	if !cfg.VacuumCfg.Disable {
-		ve := vacuum.NewEngine(client.MaintenanceConnection(), cfg.VacuumCfg.RunFrequency, cfg.VacuumCfg.Parallelism)
+		ve, err := vacuum.NewEngine(client.MaintenanceConnection(), cfg.VacuumCfg.RunFrequency, cfg.VacuumCfg.MaxParallelism)
+		if err != nil {
+			log.Error("msg", "Failed to create vacuum engine", "err", err)
+			return err
+		}
 		group.Add(
 			func() error {
 				log.Info("msg", "Starting vacuum engine")

--- a/pkg/vacuum/vacuum.go
+++ b/pkg/vacuum/vacuum.go
@@ -1,9 +1,46 @@
+// Package vacuum implements a background engine that vacuums
+// compressed chunks.
+//
+// The goal of the vacuum engine is to help prevent transaction id
+// wraparound which can be a problem for high transaction workloads.
+//
+// Once a chunk is compressed, it is unlikely to be modified.
+// Therefore, a compressed chunk should only need to be vacuumed once
+// and never again. We want to vacuum a compressed chunk as soon as
+// possible in hopes of freezing all the pages for the chunk. We want
+// to freeze so that we don't risk burning through transaction ids too
+// quickly under heavy ingest.
+//
+// The vacuum engine periodically wakes up. If it can grab an advisory
+// lock (only one vacuum engine runs at a time per database regardless
+// of the number of connectors), it will look for compressed chunks
+// that are not fully frozen.
+//
+// If chunks needing freezing are found, it uses the maximum
+// transaction age of the chunks in the set to determine how many
+// workers to use to vacuum the chunks. The closer the maximum
+// transaction age is to autovacuum_freeze_max_age the more workers are
+// used (up to a maximum number). This is done to throttle how much
+// database CPU is consumed by vacuuming.
+//
+// We ignore chunks that have been vacuumed in the last 15 minutes.
+// We ignore chunks with a transaction id age less than
+// vacuum_freeze_min_age.
+//
+// We grab a list of chunks and then let workers pull from this list.
+// Vacuuming may take a while, so there is a decent chance that the
+// postgres autovacuum engine may vacuum a chunk before we get to it.
+// We get the autovacuum count when we produce the list. Just before
+// vacuuming a chunk, we check the autovacuum count again to see if it
+// has increased. If it has, the autovacuum engine beat us to the
+// chunk, and we skip it.
 package vacuum
 
 import (
 	"context"
 	"flag"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -39,34 +76,62 @@ var (
 		Name:      "number_vacuum_connections",
 		Help:      "Number of database connections currently in use by the vacuum engine. One taken up by the advisory lock, the rest by vacuum commands.",
 	})
+	vacuumDurationSeconds = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: util.PromNamespace,
+		Subsystem: "vacuum",
+		Name:      "vacuum_duration_seconds",
+		Help:      "Time spent vacuuming chunks.",
+	})
 )
 
 func init() {
-	prometheus.MustRegister(tablesVacuumedTotal, vacuumErrorsTotal, tablesNeedingVacuum, numberVacuumConnections)
+	prometheus.MustRegister(tablesVacuumedTotal, vacuumErrorsTotal, tablesNeedingVacuum, numberVacuumConnections, vacuumDurationSeconds)
 }
 
 const (
-	sqlAcquireLock      = "SELECT _prom_catalog.lock_for_vacuum_engine()"
-	sqlListChunks       = "SELECT format('%I.%I', schema_name, table_name) FROM _ps_catalog.chunks_to_freeze WHERE coalesce(last_vacuum, '-infinity'::timestamptz) < now() - interval '15 minutes' LIMIT 1000"
-	sqlVacuumFmt        = "VACUUM (FREEZE, ANALYZE) %s"
-	sqlReleaseLock      = "SELECT _prom_catalog.unlock_for_vacuum_engine()"
-	delay               = 10 * time.Second
-	defaultDisable      = false
+	sqlAboveVersion12    = "SELECT current_setting('server_version_num')::int >= 130000"
+	sqlAcquireLock       = "SELECT _prom_catalog.lock_for_vacuum_engine()"
+	sqlVacuumFmt12       = "VACUUM (FREEZE, ANALYZE) %s"             // for postgres v12
+	sqlVacuumFmt         = "VACUUM (FREEZE, ANALYZE, PARALLEL 1) %s" // for postgres > v12
+	sqlReleaseLock       = "SELECT _prom_catalog.unlock_for_vacuum_engine()"
+	sqlGetVacuumSettings = `
+	SELECT
+		current_setting('vacuum_freeze_min_age')::bigint as vacuum_freeze_min_age,
+		current_setting('autovacuum_freeze_max_age')::bigint as autovacuum_freeze_max_age
+	`
+	sqlListChunks = `
+	SELECT 
+		format('%I.%I', schema_name, table_name) AS schema_table,
+		pg_stat_get_autovacuum_count(format('%I.%I', schema_name, table_name)::regclass::oid) AS autovacuum_count,
+		pg_catalog.age(relfrozenxid) as age
+	FROM _ps_catalog.chunks_to_freeze 
+	WHERE coalesce(last_vacuum, '-infinity'::timestamptz) < now() - interval '15 minutes' 
+	AND pg_catalog.age(relfrozenxid) > current_setting('vacuum_freeze_min_age')::bigint
+	ORDER BY pg_catalog.age(relfrozenxid) DESC --oldest first
+	LIMIT 1000`
+	// finds out how many times the autovacuum engine has vacuumed a chunk
+	sqlGetAutovacuumCount = "SELECT pg_catalog.pg_stat_get_autovacuum_count($1::regclass::oid)"
+	// delay - on each iteration of the engine, we will sleep a bit before querying
+	// a new list of chunks to give the ones last vacuumed time to have their stats updated
+	delay          = 10 * time.Second
+	defaultDisable = false
+	// defaultRunFrequency is how often the engine wakes up and looks for work
 	defaultRunFrequency = 10 * time.Minute
-	defaultParallelism  = 4
-	minParallelism      = 1
+	// defaultParallelism is the maximum number of concurrent workers used to vacuum chunks
+	defaultMaxParallelism = 4
+	minParallelism        = 1
 )
 
 type Config struct {
-	Disable      bool
-	RunFrequency time.Duration
-	Parallelism  int
+	Disable        bool
+	RunFrequency   time.Duration
+	MaxParallelism int
 }
 
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.BoolVar(&cfg.Disable, "vacuum.disable", defaultDisable, "disables the vacuum engine")
 	fs.DurationVar(&cfg.RunFrequency, "vacuum.run-frequency", defaultRunFrequency, "how often should the vacuum engine run")
-	fs.IntVar(&cfg.Parallelism, "vacuum.parallelism", defaultParallelism, "how many goroutines/connections should be used to vacuum")
+	fs.IntVar(&cfg.MaxParallelism, "vacuum.parallelism", defaultMaxParallelism, "the maximum number of goroutines/connections used to vacuum")
 	return cfg
 }
 
@@ -74,8 +139,8 @@ func Validate(cfg *Config) error {
 	if cfg.Disable {
 		return nil
 	}
-	if cfg.Parallelism < minParallelism {
-		return fmt.Errorf("vacuum.parallelism must be at least %d: %d", minParallelism, cfg.Parallelism)
+	if cfg.MaxParallelism < minParallelism {
+		return fmt.Errorf("vacuum.parallelism must be at least %d: %d", minParallelism, cfg.MaxParallelism)
 	}
 	if cfg.RunFrequency <= 0 {
 		return fmt.Errorf("vacuum.run-frequency must be positive: %d", cfg.RunFrequency)
@@ -85,20 +150,42 @@ func Validate(cfg *Config) error {
 
 // Engine periodically vacuums compressed chunks
 type Engine struct {
-	runFreq     time.Duration
-	pool        pgxconn.PgxConn
-	parallelism int
-	mu          sync.Mutex
-	kill        func()
+	runFreq        time.Duration
+	pool           pgxconn.PgxConn
+	maxParallelism int
+	mu             sync.Mutex
+	kill           func()
+	vacuumSQL      string
 }
 
 // NewEngine creates a new Engine
-func NewEngine(pool pgxconn.PgxConn, runFreq time.Duration, parallelism int) *Engine {
-	return &Engine{
-		runFreq:     runFreq,
-		pool:        pool,
-		parallelism: parallelism,
+func NewEngine(pool pgxconn.PgxConn, runFreq time.Duration, maxParallelism int) (*Engine, error) {
+	e := &Engine{
+		runFreq:        runFreq,
+		pool:           pool,
+		maxParallelism: maxParallelism,
 	}
+	if sql, err := e.getVacuumSQL(); err != nil {
+		log.Error("msg", "failed to determine the appropriate vacuum command based on postgres version", "error", err)
+		return nil, err
+	} else {
+		e.vacuumSQL = sql
+	}
+	return e, nil
+}
+
+// getVacuumSQL gets the appropriate VACUUM SQL statement based on the Postgres version.
+// Version 12 does not support the PARALLEL option to the VACUUM command
+func (e *Engine) getVacuumSQL() (string, error) {
+	var aboveVersion12 bool
+	err := e.pool.QueryRow(context.Background(), sqlAboveVersion12).Scan(&aboveVersion12)
+	if err != nil {
+		return "", err
+	}
+	if aboveVersion12 {
+		return sqlVacuumFmt, nil
+	}
+	return sqlVacuumFmt12, nil
 }
 
 // Start starts the Engine
@@ -153,6 +240,12 @@ func every(every time.Duration, task func(ctx context.Context)) (execute, kill f
 	return
 }
 
+type chunk struct {
+	name            string
+	autovacuumCount int64
+	age             int64
+}
+
 // Run attempts vacuum a batch of compressed chunks
 func (e *Engine) Run(ctx context.Context) {
 	con, err := e.pool.Acquire(ctx)
@@ -196,69 +289,172 @@ func (e *Engine) Run(ctx context.Context) {
 			return
 		}
 		log.Info("msg", "compressed chunks need to be vacuumed", "count", len(chunks))
-		p := e.parallelism
-		if len(chunks) < p {
-			// don't spin up more workers than we could possibly use
-			// if parallelism is 6, but we only have 5 chunks to work on, use 5 workers
-			p = len(chunks)
+		numWorkers, err := e.calcNumWorkers(ctx, con, chunks)
+		if err != nil {
+			log.Error("msg", "failed to calc num workers", "error", err)
+			return
 		}
-		runWorkers(ctx, p, chunks, e.worker)
+		runWorkers(ctx, numWorkers, chunks, e.worker)
+		log.Debug("msg", "vacuum workers finished. delaying before next iteration...")
 		// in some cases, have seen it take up to 10 seconds for the stats to be updated post vacuum
 		time.Sleep(delay)
 	}
 }
 
 // listChunks identifies chunks which need to be vacuumed
-func (e *Engine) listChunks(ctx context.Context, con *pgxpool.Conn) ([]string, error) {
+func (e *Engine) listChunks(ctx context.Context, con *pgxpool.Conn) ([]*chunk, error) {
 	rows, err := con.Query(ctx, sqlListChunks)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	tables := make([]string, 0)
+	chunks := make([]*chunk, 0)
 	for rows.Next() {
-		var table string
-		err := rows.Scan(&table)
+		c := chunk{}
+		err := rows.Scan(&c.name, &c.autovacuumCount, &c.age)
 		if err != nil {
 			return nil, err
 		}
-		tables = append(tables, table)
+		chunks = append(chunks, &c)
 	}
-	return tables, nil
+	return chunks, nil
+}
+
+func (e *Engine) getVacuumSettings(ctx context.Context, con *pgxpool.Conn) (vacuumFreezeMinAge, autovacuumFreezeMaxAge int64, err error) {
+	err = con.QueryRow(ctx, sqlGetVacuumSettings).Scan(&vacuumFreezeMinAge, &autovacuumFreezeMaxAge)
+	if err != nil {
+		return 0, 0, err
+	}
+	return
+}
+
+// interpolate figures out how many workers to used based on the oldest transaction id age of the
+// chunks in our batch. The age should be between vacuumFreezeMinAge and autovacuumFreezeMaxAge.
+// The closer the maxChunkAge is to the autovacuumFreezeMaxAge, the more workers we assign. If
+// maxChunkAge is == vacuumFreezeMinAge, then we just use 1 worker.
+//
+//	       vacuumFreezeMinAge
+//	        |              maxChunkAge
+//	        |               |       autovacuumFreezeMaxAge
+//	0-------|---------------X--------|------
+//	        1000            6789     11000
+//
+// In this example, maxChunkAge is 57.89% of the way between vacuumFreezeMinAge and
+// autovacuumFreezeMaxAge. If maxParallelism is 5, then we will use 3 workers.
+func interpolate(vacuumFreezeMinAge, autovacuumFreezeMaxAge, maxChunkAge, maxParallelism float64) int {
+	if maxParallelism == 1 {
+		return 1
+	}
+	if maxChunkAge <= vacuumFreezeMinAge {
+		// this "shouldn't happen" but just in case
+		return 1
+	}
+	if autovacuumFreezeMaxAge <= maxChunkAge {
+		return int(maxParallelism)
+	}
+	if autovacuumFreezeMaxAge <= vacuumFreezeMinAge {
+		// this "shouldn't happen" but just in case
+		return int(maxParallelism)
+	}
+	percent := (maxChunkAge - vacuumFreezeMinAge) / (autovacuumFreezeMaxAge - vacuumFreezeMinAge)
+	workers := math.Trunc(maxParallelism*percent) + 1
+	// bounds check. workers should be between 1 and maxParallelism
+	if workers > maxParallelism {
+		workers = maxParallelism
+	} else if workers < 1 {
+		workers = 1
+	}
+	return int(workers)
+}
+
+// calcNumWorkers calculates the number of workers to use to vacuum chunks. The closer the oldest chunk
+// age gets to autovacuumFreezeMaxAge, the more workers we will use
+func (e *Engine) calcNumWorkers(ctx context.Context, con *pgxpool.Conn, chunks []*chunk) (int, error) {
+	vacuumFreezeMinAge, autovacuumFreezeMaxAge, err := e.getVacuumSettings(ctx, con)
+	if err != nil {
+		log.Error("msg", "failed to get vacuum settings", "error", err)
+		return 0, err
+	}
+	// never ought to have an empty slice, but just in case...
+	if len(chunks) == 0 {
+		return 1, nil
+	}
+	var maxChunkAge = chunks[0].age // query ordered by oldest age first
+	w := interpolate(float64(vacuumFreezeMinAge), float64(autovacuumFreezeMaxAge), float64(maxChunkAge), float64(e.maxParallelism))
+	if len(chunks) < w {
+		// don't spin up more workers than we could possibly use
+		w = len(chunks)
+	}
+	return w, nil
 }
 
 // runWorkers kicks off a number of goroutines to work on the chunks in parallel
 // blocks until the workers complete
-func runWorkers(ctx context.Context, parallelism int, chunks []string, worker func(context.Context, int, <-chan string)) {
-	todo := make(chan string, len(chunks))
+func runWorkers(ctx context.Context, numWorkers int, chunks []*chunk, worker func(context.Context, int, <-chan *chunk)) {
+	todo := make(chan *chunk, len(chunks))
 	var wg sync.WaitGroup
-	wg.Add(parallelism)
-	for id := 0; id < parallelism; id++ {
-		go func(ctx context.Context, id int, todo <-chan string) {
+	wg.Add(numWorkers)
+	for id := 0; id < numWorkers; id++ {
+		go func(ctx context.Context, id int, todo <-chan *chunk) {
 			defer wg.Done()
 			worker(ctx, id, todo)
 		}(ctx, id, todo)
 	}
-	for _, chunk := range chunks {
-		todo <- chunk
+	for _, c := range chunks {
+		todo <- c
 	}
 	close(todo)
 	wg.Wait()
 }
 
+// getAutovacuumCount gets the current number of times autovacuum has vacuumed a table
+func (e *Engine) getAutovacuumCount(ctx context.Context, con *pgxpool.Conn, name string) (autovacuumCount int64, err error) {
+	err = con.QueryRow(ctx, sqlGetAutovacuumCount, name).Scan(&autovacuumCount)
+	if err != nil {
+		return 0, err
+	}
+	return
+}
+
 // worker pulls chunks from a channel and vacuums them
-func (e *Engine) worker(ctx context.Context, id int, todo <-chan string) {
-	for chunk := range todo {
-		log.Debug("msg", "vacuuming a chunk", "worker", id, "chunk", chunk)
-		sql := fmt.Sprintf(sqlVacuumFmt, chunk)
-		numberVacuumConnections.Inc()
-		_, err := e.pool.Exec(ctx, sql)
+func (e *Engine) worker(ctx context.Context, id int, todo <-chan *chunk) {
+	con, err := e.pool.Acquire(ctx)
+	if err != nil {
+		log.Error("msg", "failed to acquire a database connection", "worker", id, "error", err)
+		vacuumErrorsTotal.Inc()
+		return
+	}
+	numberVacuumConnections.Inc()
+	defer func() {
+		con.Release()
 		numberVacuumConnections.Dec()
+	}()
+
+	for c := range todo {
+		// see if the current autovacuum count is higher than the count that we got
+		// when we first listed chunks to vacuum. if it is higher, then the autovacuum
+		// engine got to this chunk before we did. skip it
+		autovacuumCount, err := e.getAutovacuumCount(ctx, con, c.name)
 		if err != nil {
-			log.Error("msg", "failed to vacuum chunk", "chunk", chunk, "worker", id, "error", err)
+			log.Error("msg", "failed to get current autovacuum count", "chunk", c.name, "worker", id, "error", err)
 			vacuumErrorsTotal.Inc()
-			// don't return error here. attempt to vacuum other chunks. keep working
+			continue
+		}
+		if c.autovacuumCount < autovacuumCount {
+			log.Debug("msg", "autovacuum has vacuumed this chunk before we got to it. skipping.", "chunk", c.name, "worker", id)
+			continue
+		}
+		// vacuum the chunk
+		log.Debug("msg", "vacuuming a chunk", "worker", id, "chunk", c.name)
+		sql := fmt.Sprintf(e.vacuumSQL, c.name)
+		before := time.Now()
+		_, err = con.Exec(ctx, sql)
+		elapsed := time.Since(before).Seconds()
+		if err != nil {
+			log.Error("msg", "failed to vacuum chunk", "chunk", c.name, "worker", id, "error", err)
+			vacuumErrorsTotal.Inc()
 		} else {
+			vacuumDurationSeconds.Observe(elapsed)
 			tablesVacuumedTotal.Inc()
 		}
 	}

--- a/pkg/vacuum/vacuum_test.go
+++ b/pkg/vacuum/vacuum_test.go
@@ -12,36 +12,53 @@ import (
 )
 
 func Test_runWorkers(t *testing.T) {
+	// make a number of chunks
+	// each chunk has a name that is one distinct ascii char
+	// starting with A...
+	makeChunks := func(num int) []*chunk {
+		chunks := make([]*chunk, num)
+		for i := 0; i < num; i++ {
+			chunks[i] = &chunk{
+				name: string(rune(65 + i)),
+			}
+		}
+		return chunks
+	}
+
 	tests := []struct {
-		parallelism int
-		work        string
+		name       string
+		numWorkers int
+		chunks     []*chunk
 	}{
-		{1, "abcdef"},
-		{2, "helloworld"},
-		{3, "foobarbaz12"},
-		{4, "1"},
-		{5, "buzz"},
-		{6, "buzzbuzz"},
+		{"1", 1, makeChunks(6)},
+		{"2", 2, makeChunks(8)},
+		{"3", 3, makeChunks(11)},
+		{"4", 4, makeChunks(1)},
+		{"5", 5, makeChunks(4)},
+		{"6", 6, makeChunks(8)},
 	}
 	for _, tt := range tests {
-		t.Run(tt.work, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			var mu sync.Mutex
-			// each individual char is a unit of "work"
-			// the work will consist of adding the char to worked slice
-			chunks := strings.Split(tt.work, "")
-			worked := make([]string, 0)
-			runWorkers(context.Background(), tt.parallelism, chunks, func(ctx context.Context, id int, todo <-chan string) {
-				for chunk := range todo {
-					func(ctx context.Context, id int, chunk string) {
+			// when we "work" on a chunk, append its name to actual
+			actual := make([]string, 0)
+			runWorkers(context.Background(), tt.numWorkers, tt.chunks, func(ctx context.Context, id int, todo <-chan *chunk) {
+				for c := range todo {
+					func(ctx context.Context, id int, c *chunk) {
 						mu.Lock()
 						defer mu.Unlock()
-						worked = append(worked, chunk)
-					}(ctx, id, chunk)
+						actual = append(actual, c.name)
+					}(ctx, id, c)
 				}
 			})
-			sort.Strings(chunks)
-			sort.Strings(worked)
-			require.Equal(t, strings.Join(chunks, ""), strings.Join(worked, ""))
+			// now do the same thing without the workers
+			expected := make([]string, 0)
+			for _, c := range tt.chunks {
+				expected = append(expected, c.name)
+			}
+			sort.Strings(actual)
+			sort.Strings(expected)
+			require.Equal(t, strings.Join(expected, ""), strings.Join(actual, ""))
 		})
 	}
 }
@@ -124,12 +141,357 @@ func TestValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
-				Disable:      tt.fields.disable,
-				RunFrequency: tt.fields.runFrequency,
-				Parallelism:  tt.fields.parallelism,
+				Disable:        tt.fields.disable,
+				RunFrequency:   tt.fields.runFrequency,
+				MaxParallelism: tt.fields.parallelism,
 			}
 			if err := Validate(cfg); (err != nil) != tt.wantErr {
 				t.Errorf("Validate(cfg) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_interpolate(t *testing.T) {
+	// the following sql was used to generate the test cases
+	/*
+		select string_agg(format(
+		$${
+		    name: "%s",
+		    args: args{
+		        vacuumFreezeMinAge:     %s,
+		        autovacuumFreezeMaxAge: %s,
+		        maxChunkAge:            %s,
+		        maxParallelism:         %s,
+		    },
+		    want: %s,
+		}$$
+		, format('maxParallelism %s maxChunkAge %s', x.max_parallelism, x.max_chunk_age)
+		, x.vacuum_freeze_min_age
+		, x.autovacuum_freeze_max_age
+		, x.max_chunk_age
+		, x.max_parallelism
+		, x.want
+		), E',\n' order by x.max_parallelism, x.max_chunk_age)
+		from
+		(
+		values
+		 (5, 1000, 11000, 1000,  1)
+		,(5, 1000, 11000, 2000,  1)
+		,(5, 1000, 11000, 3000,  2)
+		,(5, 1000, 11000, 4000,  2)
+		,(5, 1000, 11000, 5000,  3)
+		,(5, 1000, 11000, 6000,  3)
+		,(5, 1000, 11000, 7000,  4)
+		,(5, 1000, 11000, 8000,  4)
+		,(5, 1000, 11000, 9000,  5)
+		,(5, 1000, 11000, 10000, 5)
+		,(5, 1000, 11000, 11000, 5)
+		,(5, 1000, 11000, 10500, 5)
+		,(5, 1000, 11000, 5333,  3)
+		--------------------------
+		,(3, 1000, 11000, 1000,  1)
+		,(3, 1000, 11000, 2000,  1)
+		,(3, 1000, 11000, 3000,  1)
+		,(3, 1000, 11000, 4000,  1)
+		,(3, 1000, 11000, 5000,  2)
+		,(3, 1000, 11000, 6000,  2)
+		,(3, 1000, 11000, 7000,  2)
+		,(3, 1000, 11000, 8000,  3)
+		,(3, 1000, 11000, 9000,  3)
+		,(3, 1000, 11000, 10000, 3)
+		,(3, 1000, 11000, 11000, 3)
+		,(3, 1000, 11000, 10500, 3)
+		,(3, 1000, 11000, 5333,  2)
+		) x(max_parallelism, vacuum_freeze_min_age, autovacuum_freeze_max_age, max_chunk_age, want)
+		;
+	*/
+	type args struct {
+		vacuumFreezeMinAge     float64
+		autovacuumFreezeMaxAge float64
+		maxChunkAge            float64
+		maxParallelism         float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{
+			name: "maxParallelism 3 maxChunkAge 1000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            1000,
+				maxParallelism:         3,
+			},
+			want: 1,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 2000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            2000,
+				maxParallelism:         3,
+			},
+			want: 1,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 3000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            3000,
+				maxParallelism:         3,
+			},
+			want: 1,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 4000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            4000,
+				maxParallelism:         3,
+			},
+			want: 1,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 5000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            5000,
+				maxParallelism:         3,
+			},
+			want: 2,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 5333",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            5333,
+				maxParallelism:         3,
+			},
+			want: 2,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 6000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            6000,
+				maxParallelism:         3,
+			},
+			want: 2,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 7000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            7000,
+				maxParallelism:         3,
+			},
+			want: 2,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 8000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            8000,
+				maxParallelism:         3,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 9000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            9000,
+				maxParallelism:         3,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 10000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            10000,
+				maxParallelism:         3,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 10500",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            10500,
+				maxParallelism:         3,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 3 maxChunkAge 11000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            11000,
+				maxParallelism:         3,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 1000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            1000,
+				maxParallelism:         5,
+			},
+			want: 1,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 2000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            2000,
+				maxParallelism:         5,
+			},
+			want: 1,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 3000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            3000,
+				maxParallelism:         5,
+			},
+			want: 2,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 4000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            4000,
+				maxParallelism:         5,
+			},
+			want: 2,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 5000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            5000,
+				maxParallelism:         5,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 5333",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            5333,
+				maxParallelism:         5,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 6000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            6000,
+				maxParallelism:         5,
+			},
+			want: 3,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 7000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            7000,
+				maxParallelism:         5,
+			},
+			want: 4,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 8000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            8000,
+				maxParallelism:         5,
+			},
+			want: 4,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 9000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            9000,
+				maxParallelism:         5,
+			},
+			want: 5,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 10000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            10000,
+				maxParallelism:         5,
+			},
+			want: 5,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 10500",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            10500,
+				maxParallelism:         5,
+			},
+			want: 5,
+		},
+		{
+			name: "maxParallelism 5 maxChunkAge 11000",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            11000,
+				maxParallelism:         5,
+			},
+			want: 5,
+		},
+		{
+			name: "capped",
+			args: args{
+				vacuumFreezeMinAge:     1000,
+				autovacuumFreezeMaxAge: 11000,
+				maxChunkAge:            15000,
+				maxParallelism:         10,
+			},
+			want: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := interpolate(tt.args.vacuumFreezeMinAge, tt.args.autovacuumFreezeMaxAge, tt.args.maxChunkAge, tt.args.maxParallelism); got != tt.want {
+				t.Errorf("interpolate() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Description

Throttle vacuum workers based on chunk age. Figure out how many workers to used based on the oldest transaction id age of the chunks in our batch. The age should be between `vacuumFreezeMinAge` and `autovacuumFreezeMaxAge`. The closer the `maxChunkAge` is to the `autovacuumFreezeMaxAge`, the more workers we assign. If `maxChunkAge` is == `vacuumFreezeMinAge`, then we just use 1 worker.

```
	       vacuumFreezeMinAge
	        |              maxChunkAge
	        |               |       autovacuumFreezeMaxAge
	0-------|---------------X--------|------
	        1000            6789     11000
```

In this example, `maxChunkAge` is 57.89% of the way between `vacuumFreezeMinAge` and `autovacuumFreezeMaxAge`. If `maxParallelism` is 5, then we will use 3 workers.

If the autovacuum engine beats us to a chunk, skip that chunk.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
