### PR TITLE
Fix jaeger env vars in docker-compose.yaml

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -56,11 +56,12 @@ services:
     image: jaegertracing/jaeger-query:1.37.0
     environment:
       SPAN_STORAGE_TYPE: grpc-plugin
+      METRICS_STORAGE_TYPE: prometheus
+      GRPC_STORAGE_SERVER: promscale:9202
+      PROMETHEUS_SERVER_URL: "http://promscale:9201"
     depends_on:
       - promscale
-    command: [
-      "--grpc-storage.server=promscale:9202",
-    ]
+
     ports:
       - "16686:16686"
 


### PR DESCRIPTION
## Description

With the default configuration, Jaeger cannot connect to Promscale.
```
level=info ts=2022-11-20T01:06:24.418Z caller=runner.go:86 msg="Version: 0.16.0, Commit Hash: 72c29aa887517dcebc4b47a3d9fbb3ce3ac78450, Branch: HEAD"
level=error ts=2022-11-20T01:06:25.428Z caller=runner.go:127 msg="aborting startup due to error" err="failed to connect to `host=db user=postgres database=postgres`: dial error (dial tcp 192.168.96.4:5432: connect: connection refused)"
```
This PR aims to fix that by replacing the --grpc-storage.server argument to use environment variables.
