### PR TITLE
Add histogram to track number samples/metadata/span sent per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We use the following categories for changes:
   configuration. Supersedes `startup.dataset.config` which accepts a string
   instead of a mapping [#1737]
 - Add alert to notify about duplicate sample/metric ingestion. [#1688]
+- Add histogram to track number samples/metadata/span sent per request [#1767]
 
 ### Changed
 - Reduced the verbosity of the logs emitted by the vacuum engine [#1715]

--- a/docs/mixin/dashboards/promscale.json
+++ b/docs/mixin/dashboards/promscale.json
@@ -440,7 +440,7 @@
           },
           "gridPos": {
             "h": 9,
-            "w": 8,
+            "w": 12,
             "x": 0,
             "y": 10
           },
@@ -474,6 +474,86 @@
           ],
           "title": "Requests",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 10
+          },
+          "id": 71,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "none"
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(promscale_ingest_items_received_bucket{kind=\"sample\", namespace=~\"$namespace\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Samples per request",
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -535,9 +615,9 @@
           },
           "gridPos": {
             "h": 9,
-            "w": 8,
-            "x": 8,
-            "y": 10
+            "w": 12,
+            "x": 0,
+            "y": 19
           },
           "id": 10,
           "interval": "2m",
@@ -632,9 +712,9 @@
           },
           "gridPos": {
             "h": 9,
-            "w": 8,
-            "x": 16,
-            "y": 10
+            "w": 12,
+            "x": 12,
+            "y": 19
           },
           "id": 8,
           "interval": "2m",
@@ -768,9 +848,9 @@
           },
           "gridPos": {
             "h": 9,
-            "w": 8,
+            "w": 12,
             "x": 0,
-            "y": 11
+            "y": 29
           },
           "id": 9,
           "interval": "2m",
@@ -803,6 +883,86 @@
           ],
           "title": "Requests",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "scaleDistribution": {
+                  "type": "linear"
+                }
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 29
+          },
+          "id": 73,
+          "options": {
+            "calculate": false,
+            "cellGap": 1,
+            "color": {
+              "exponent": 0.5,
+              "fill": "dark-orange",
+              "mode": "scheme",
+              "reverse": false,
+              "scale": "exponential",
+              "scheme": "Oranges",
+              "steps": 64
+            },
+            "exemplars": {
+              "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+              "le": 1e-9
+            },
+            "legend": {
+              "show": true
+            },
+            "rowsFrame": {
+              "layout": "auto"
+            },
+            "tooltip": {
+              "show": true,
+              "yHistogram": false
+            },
+            "yAxis": {
+              "axisPlacement": "left",
+              "reverse": false,
+              "unit": "none"
+            }
+          },
+          "pluginVersion": "9.2.3",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(rate(promscale_ingest_items_received_bucket{kind=\"span\", namespace=~\"$namespace\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "hide": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "D"
+            }
+          ],
+          "title": "Spans per request",
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -865,9 +1025,9 @@
           },
           "gridPos": {
             "h": 9,
-            "w": 8,
-            "x": 8,
-            "y": 11
+            "w": 12,
+            "x": 0,
+            "y": 38
           },
           "id": 7,
           "interval": "2m",
@@ -961,9 +1121,9 @@
           },
           "gridPos": {
             "h": 9,
-            "w": 8,
-            "x": 16,
-            "y": 11
+            "w": 12,
+            "x": 12,
+            "y": 38
           },
           "id": 11,
           "interval": "2m",

--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -26,8 +26,8 @@ type Metrics struct {
 func updateIngestMetrics(code string, duration, receivedSamples, receivedMetadata float64) {
 	pgMetrics.IngestorRequests.With(prometheus.Labels{"type": "metric", "code": code}).Inc()
 	pgMetrics.IngestorDuration.With(prometheus.Labels{"type": "metric", "code": code}).Observe(duration)
-	pgMetrics.IngestorItemsReceived.With(prometheus.Labels{"type": "metric", "kind": "sample"}).Add(receivedSamples)
-	pgMetrics.IngestorItemsReceived.With(prometheus.Labels{"type": "metric", "kind": "metadata"}).Add(receivedMetadata)
+	pgMetrics.IngestorItemsReceived.With(prometheus.Labels{"type": "metric", "kind": "sample"}).Observe(receivedSamples)
+	pgMetrics.IngestorItemsReceived.With(prometheus.Labels{"type": "metric", "kind": "metadata"}).Observe(receivedMetadata)
 }
 
 func updateQueryMetrics(handler, code string, duration float64) {

--- a/pkg/pgmodel/ingestor/trace/writer.go
+++ b/pkg/pgmodel/ingestor/trace/writer.go
@@ -139,7 +139,7 @@ func (t *traceWriterImpl) InsertTraces(ctx context.Context, traces ptrace.Traces
 	startIngest := time.Now() // Time taken for complete ingestion => Processing + DB insert.
 	code := "500"
 	metrics.IngestorActiveWriteRequests.With(traceSpanLabel).Inc()
-	metrics.IngestorItemsReceived.With(traceSpanLabel).Add(float64(traces.SpanCount()))
+	metrics.IngestorItemsReceived.With(traceSpanLabel).Observe(float64(traces.SpanCount()))
 	defer func() {
 		metrics.IngestorDuration.With(prometheus.Labels{"type": "trace", "code": code}).Observe(time.Since(startIngest).Seconds())
 		metrics.IngestorActiveWriteRequests.With(traceSpanLabel).Dec()

--- a/pkg/pgmodel/metrics/ingest.go
+++ b/pkg/pgmodel/metrics/ingest.go
@@ -141,13 +141,15 @@ var (
 			Help:      "Total number of items (sample/metadata/span) ingested",
 		}, []string{"type", "kind", "subsystem"},
 	)
-	IngestorItemsReceived = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
+	IngestorItemsReceived = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Namespace: util.PromNamespace,
 			Subsystem: "ingest",
-			Name:      "items_received_total",
-			Help:      "Total items (samples/exemplars/spans) received.",
-		}, []string{"type", "kind"},
+			Name:      "items_received",
+			Help:      "Number of (samples/exemplars/spans) received",
+			Buckets:   []float64{10, 50, 100, 200, 500, 1000, 2000, 4000, 6000, 8000, 10000, 20000, 30000},
+		},
+		[]string{"type", "kind"},
 	)
 	IngestorBytes = prometheus.NewCounterVec(
 		prometheus.CounterOpts{


### PR DESCRIPTION
This commit also removes the metric promscale_ingest_items_received_total which is not used anywhere and the same information can be now obtained using the newly introduced `promscale_ingest_items_received_*` histogram metric.

Signed-off-by: Arunprasad Rajkumar <ar.arunprasad@gmail.com>

This is how it looks on Promscale dashboard

![image](https://user-images.githubusercontent.com/3874763/208041336-21016e4a-608e-42c1-b163-b7d7baeb18d0.png)

## TODO
- [ ] Decide on bucket size - Current bucket size is inclusive of both metrics and traces.
- [x] Dashboard(Histogram vs Heat-map)
- ~~[ ] Alerting? - I'm not sure how feasible it would be when considering low ingestion use cases.~~

## Description

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. Linking an issue can be done by mentioning a key word (`closes #111`, `fixes #222`, `resolve #333`) or manually on github.com, even after the pull request is created. 

Note: If your PR involves benchmarks, you can run the `Benchmarks` workflow by adding `action:benchmarks` label. The PR must be opened from Promscale branch so that Github actions can leave a comment comparing results against `master`.
-->

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
