### PR TITLE
Removing 16 bytes alignment for cache elements

### DIFF
--- a/pkg/clockcache/cache_bench_test.go
+++ b/pkg/clockcache/cache_bench_test.go
@@ -3,7 +3,6 @@ package clockcache
 import (
 	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 	"time"
 )
@@ -239,72 +238,6 @@ func BenchmarkInsertConcurrent(b *testing.B) {
 	}
 }
 
-// BenchmarkCacheFalseSharing is a benchmark to measure the effect of the false
-// sharing of CPU cache lines. In the clockcache.element struct, we introduce
-// padding to ensure that only one clockcache.element fits in a CPU cache line,
-// avoiding false sharing.
-//
-// The principle behind this benchmark is simple: construct a cache with two
-// entries, and start two goroutines which each clobber one of the cache values
-// over and over again. If there is false sharing, it should be measurable by
-// toggling the padding on and off, and measuring the difference in output of
-// this benchmark.
-//
-// At the time of writing, this code was tested on an M1 MacBook Pro, where the
-// advantage obtained by introducing padding is approximately 16%:
-//
-//	go test -bench=BenchmarkCacheFalseSharing -cpu=2 -count=10 > no-padding.txt
-//	go test -bench=BenchmarkCacheFalseSharing -cpu=2 -count=10 > padding.txt
-//	benchstat no-padding.txt padding.txt
-//	  name                 old time/op    new time/op    delta
-//	  CacheFalseSharing-2     230ns ± 6%     193ns ±19%  -16.09%  (p=0.001 n=10+9)
-//
-// Note: This benchmark _must_ be run with the `-cpu=2` argument, to ensure
-// that each goroutine ends up on a different CPU, possibly causing contention
-// for the same cache line.
-func BenchmarkCacheFalseSharing(b *testing.B) {
-	cache := WithMax(2)
-	b.ReportAllocs()
-
-	// define waitgroup so that we can coordinate the start of the stressors
-	startWg := &sync.WaitGroup{}
-	startWg.Add(2)
-
-	// define waitgroup, so we can wait until concurrent stressors are finished
-	endWg := &sync.WaitGroup{}
-	endWg.Add(2)
-
-	key1 := 0
-	key2 := 1
-	times := b.N
-
-	// stressor is a function to be run in a goroutine which continually writes
-	// and reads to/from a specific key in the cache
-	stressor := func(key, count int) {
-		var val interface{}
-
-		// Coordinate the start of the two stressors
-		startWg.Done()
-		startWg.Wait()
-
-		// Reset the timer immediately before doing the real work
-		b.ResetTimer()
-		for i := 0; i < count; i++ {
-			cache.Insert(key, i, 16)
-			val, _ = cache.Get(key)
-		}
-
-		bval = val
-		endWg.Done()
-	}
-
-	// run two contending goroutines
-	go stressor(key1, times)
-	go stressor(key2, times)
-
-	// wait for tasks to complete
-	endWg.Wait()
-}
 func BenchmarkMemoryEmptyCache(b *testing.B) {
 	b.ReportAllocs()
 	WithMax(uint64(b.N))

--- a/pkg/clockcache/cache_test.go
+++ b/pkg/clockcache/cache_test.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
@@ -318,16 +317,6 @@ func TestReset(t *testing.T) {
 	}
 	if cache.Cap() != 3 {
 		t.Error("Incorrrect len")
-	}
-}
-
-func TestElementCacheAligned(t *testing.T) {
-	elementSize := unsafe.Sizeof(element{})
-	if elementSize%64 != 0 {
-		t.Errorf("unaligned element size: %d", elementSize)
-	}
-	if elementSize != 64 {
-		t.Errorf("unexpected element size: %d", elementSize)
 	}
 }
 


### PR DESCRIPTION
Recent benchmarks are showing that cache element alignment doesn't make significant compute difference. I've run benchmarks on Intel x86 CPUs and compute difference was either non or around 5%. Since cache usually holds millions of elements the cost seems to be higher than the gain.

Benchmark numbers and discussion: https://github.com/timescale/promscale/pull/1705#discussion_r1003237384

Closes https://github.com/timescale/promscale/issues/1717
