### PR TITLE
Adjust Storage alerts

### DIFF
--- a/docs/mixin/alerts/alerts.yaml
+++ b/docs/mixin/alerts/alerts.yaml
@@ -194,23 +194,22 @@ groups:
       runbook_url: https://github.com/timescale/promscale/blob/master/docs/runbooks/PromscaleCacheHighNumberOfEvictions.md
 - name: promscale-database-connection
   rules:
-  - alert: PromscaleDBHighErrorRate
+  - alert: PromscaleStorageHighErrorRate
     expr: |
       (
-        sum by (job, instance, namespace) (
-          # Error counter exists for query, query_row & exec, and not for send_batch.
-          rate(promscale_database_request_errors_total{method=~"query.*|exec"}[5m])
+        sum by (job, instance, namespace, method) (
+          rate(promscale_database_request_errors_total[5m])
         )
       /
-        sum by (job, instance, namespace) (
-          rate(promscale_database_requests_total{method=~"query.*|exec"}[5m])
+        sum by (job, instance, namespace, method) (
+          rate(promscale_database_requests_total[5m])
         )
       ) > 0.05
     labels:
       severity: warning
     annotations:
       summary: Promscale experiences a high error rate when connecting to the database.
-      description: "Promscale connection with the database has an error of {{ $value | humanizePercentage }}."
+      description: "Promscale connection with the database has an error rate of {{ $value | humanizePercentage }}."
       runbook_url: https://github.com/timescale/promscale/blob/master/docs/runbooks/PromscaleDBHighErrorRate.md
   - alert: PromscaleStorageHighLatency
     expr: |

--- a/docs/mixin/alerts/alerts.yaml
+++ b/docs/mixin/alerts/alerts.yaml
@@ -216,20 +216,20 @@ groups:
     expr: |
       (
         histogram_quantile(0.9,
-          sum by (job, instance, namespace, le) (
-            rate(promscale_database_requests_duration_seconds_bucket[5m])
+          sum by (job, instance, namespace, method, le) (
+            rate(promscale_database_requests_duration_seconds_bucket{method!="exec"}[5m])
           )
         ) > 5
       and
-        sum by (job, instance, namespace) (
-          rate(promscale_database_requests_duration_seconds_count[5m])
+        sum by (job, instance, namespace, method) (
+          rate(promscale_database_requests_duration_seconds_count{method!="exec"}[5m])
         ) > 0
       )
     labels:
       severity: warning
     annotations:
       summary: Slow database response.
-      description: "Slowest 10% of database requests are taking more than {{ $value | humanizeDuration }} seconds to respond."
+      description: "Slowest 10% of database requests with method {{ $labels.method }} are taking more than {{ $value | humanizeDuration }} seconds to respond."
       runbook_url: https://github.com/timescale/promscale/blob/master/docs/runbooks/PromscaleStorageHighLatency.md
 - name: promscale-database
   rules:


### PR DESCRIPTION
Based on our experience `PromscaleStorageHighErrorRate` alert shouldn't include `exec` method as this is an outlier and only causes false-positive alerting. Additionally it would be beneficial to group Storage alerts by `method` so it is clearer who is the offender.

While fixing the above I noticed discrepancy in naming of our Storage/DB alerts, so I changed name of one alert from `PromscaleDBHighErrorRate` to `PromscaleStorageHighErrorRate` to align with other alerts and I also simplified this alert a bit. 
