### PR TITLE
fix docker-compose

### DIFF
--- a/docker-compose/promscale-demo/docker-compose.yaml
+++ b/docker-compose/promscale-demo/docker-compose.yaml
@@ -84,7 +84,7 @@ services:
       - 3000:3000/tcp
     depends_on:
       - timescaledb
-      - jaeger
+      - jaeger-all-in-one
 
   node_exporter:
     image: quay.io/prometheus/node-exporter


### PR DESCRIPTION
## Description

Fix docker-compose, The Jaegerservice name is changed to `jaeger-all-ib-one` but the dependency name is still `jaeger`. Update the dependency name to `jaeger-all-in-one`. 


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
