### PR TITLE
Use common array pool when unmarshalling protobufs

### DIFF
--- a/pkg/api/parser/json/json_test.go
+++ b/pkg/api/parser/json/json_test.go
@@ -186,7 +186,7 @@ func TestParseRequest(t *testing.T) {
 				t.Fatalf("unexpected error occured, none expected: %s", err)
 			}
 
-			if !reflect.DeepEqual(*response, c.response) {
+			if !reflect.DeepEqual(response.String(), c.response.String()) {
 				t.Fatalf("unexpected result:\ngot\n%+v\nwanted\n%+v\n", *response, c.response)
 			}
 		})

--- a/pkg/pgmodel/ingestor/write_request_pool.go
+++ b/pkg/pgmodel/ingestor/write_request_pool.go
@@ -12,7 +12,7 @@ import (
 
 var wrPool = sync.Pool{
 	New: func() interface{} {
-		return new(prompb.WriteRequest)
+		return prompb.NewWriteRequest()
 	},
 }
 
@@ -26,18 +26,6 @@ func FinishWriteRequest(wr *prompb.WriteRequest) {
 	if wr == nil {
 		return
 	}
-	for i := range wr.Timeseries {
-		ts := &wr.Timeseries[i]
-		for j := range ts.Labels {
-			ts.Labels[j] = prompb.Label{}
-		}
-		ts.Labels = ts.Labels[:0]
-		ts.Samples = ts.Samples[:0]
-		ts.Exemplars = ts.Exemplars[:0]
-		ts.XXX_unrecognized = nil
-	}
-	wr.Timeseries = wr.Timeseries[:0]
-	wr.Metadata = wr.Metadata[:0]
-	wr.XXX_unrecognized = nil
+	wr.Reset()
 	wrPool.Put(wr)
 }

--- a/pkg/prompb/custom.ts.go
+++ b/pkg/prompb/custom.ts.go
@@ -6,7 +6,22 @@ package prompb
 
 func (m *Labels) Reset() { *m = Labels{Labels: m.Labels[:0]} }
 func (m *WriteRequest) Reset() {
-	*m = WriteRequest{Timeseries: m.Timeseries[:0], Metadata: m.Metadata[:0]}
+	for i := range m.Timeseries {
+		ts := &m.Timeseries[i]
+		for j := range ts.Labels {
+			ts.Labels[j] = Label{}
+		}
+		ts.Labels = ts.Labels[:0]
+		ts.Samples = ts.Samples[:0]
+		ts.Exemplars = ts.Exemplars[:0]
+		ts.XXX_unrecognized = nil
+	}
+	m.Timeseries = m.Timeseries[:0]
+	m.Metadata = m.Metadata[:0]
+	m.XXX_unrecognized = nil
+	m.XXX_arrayPool.labelsPool = m.XXX_arrayPool.labelsPool[:0]
+	m.XXX_arrayPool.samplesPool = m.XXX_arrayPool.samplesPool[:0]
+	m.XXX_arrayPool.exemplarsPool = m.XXX_arrayPool.exemplarsPool[:0]
 }
 func (m *TimeSeries) Reset() {
 	*m = TimeSeries{Labels: m.Labels[:0], Exemplars: m.Exemplars[:0], Samples: m.Samples[:0]}

--- a/pkg/tests/testsupport/metric_loader.go
+++ b/pkg/tests/testsupport/metric_loader.go
@@ -1,3 +1,7 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
 package testsupport
 
 import (

--- a/pkg/tests/testsupport/utils.go
+++ b/pkg/tests/testsupport/utils.go
@@ -1,0 +1,39 @@
+// This file and its contents are licensed under the Apache License 2.0.
+// Please see the included NOTICE for copyright information and
+// LICENSE for a copy of the license.
+
+package testsupport
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/golang/snappy"
+	"github.com/timescale/promscale/pkg/prompb"
+)
+
+func GetHTTPWriteRequest(url string, protoRequest *prompb.WriteRequest) (*http.Request, error) {
+	data, err := proto.Marshal(protoRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	body := string(snappy.Encode(nil, data))
+
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(
+		"POST",
+		url,
+		strings.NewReader(body),
+	)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Content-Encoding", "snappy")
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	req.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+	return req, nil
+}


### PR DESCRIPTION
We reuse one bigger array and avoid allocating smaller arrays for each Timeseries.
This results in less memory allocations.

Before:
`BenchmarkProtoUnmarshall-10           144       8194256 ns/op    22833242 B/op     150342 allocs/op`

After:
`BenchmarkProtoUnmarshall-10          145       8174649 ns/op    32628033 B/op     100650 allocs/op`

So the allocations are down by around 1/3, however memory usage is up for 1/3 due to larger arrays being allocated.


