### PR TITLE
Grow inverted labels cache if needed

### DIFF
--- a/pkg/pgclient/client.go
+++ b/pkg/pgclient/client.go
@@ -202,6 +202,8 @@ func NewClientWithPool(r prometheus.Registerer, cfg *Config, numCopiers int, wri
 	metricsCache := cache.NewMetricCache(cfg.CacheConfig)
 	labelsCache := cache.NewLabelsCache(cfg.CacheConfig)
 	seriesCache := cache.NewSeriesCache(cfg.CacheConfig, sigClose)
+	invertedLabelsCache := cache.NewInvertedLabelsCache(cfg.CacheConfig, sigClose)
+
 	c := ingestor.Cfg{
 		NumCopiers:              numCopiers,
 		IgnoreCompressedChunks:  cfg.IgnoreCompressedChunks,
@@ -230,7 +232,7 @@ func NewClientWithPool(r prometheus.Registerer, cfg *Config, numCopiers int, wri
 	if !readOnly {
 		var err error
 		writerConn = pgxconn.NewPgxConn(writerPool)
-		dbIngestor, err = ingestor.NewPgxIngestor(writerConn, metricsCache, seriesCache, exemplarKeyPosCache, &c)
+		dbIngestor, err = ingestor.NewPgxIngestor(writerConn, metricsCache, seriesCache, exemplarKeyPosCache, invertedLabelsCache, &c)
 		if err != nil {
 			log.Error("msg", "err starting the ingestor", "err", err)
 			return nil, err

--- a/pkg/pgmodel/cache/flags.go
+++ b/pkg/pgmodel/cache/flags.go
@@ -20,6 +20,12 @@ var (
 			Name:      "series_cache_max_bytes",
 			Help:      "The target for the maximum amount of memory the series_cache can use in bytes.",
 		})
+	InvertedLabelsCacheMaxBytesMetric = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: util.PromNamespace,
+			Name:      "inverted_labels_cache_max_bytes",
+			Help:      "The target for the maximum amount of memory the inverted labels cache can use in bytes.",
+		})
 )
 
 type Config struct {
@@ -27,25 +33,29 @@ type Config struct {
 	seriesCacheMemoryMaxFlag  limits.PercentageAbsoluteBytesFlag
 	SeriesCacheMemoryMaxBytes uint64
 
-	MetricsCacheSize        uint64
-	LabelsCacheSize         uint64
-	ExemplarKeyPosCacheSize uint64
-	InvertedLabelsCacheSize uint64
+	MetricsCacheSize                uint64
+	LabelsCacheSize                 uint64
+	ExemplarKeyPosCacheSize         uint64
+	InvertedLabelsCacheSize         uint64
+	InvertedLabelsCacheMaxBytesFlag limits.PercentageAbsoluteBytesFlag
+	InvertedLabelsCacheMaxBytes     uint64
 }
 
 var DefaultConfig = Config{
 	SeriesCacheInitialSize:    DefaultSeriesCacheSize,
 	SeriesCacheMemoryMaxBytes: 1000000,
 
-	MetricsCacheSize:        DefaultMetricCacheSize,
-	LabelsCacheSize:         DefaultLabelsCacheSize,
-	ExemplarKeyPosCacheSize: DefaultExemplarKeyPosCacheSize,
-	InvertedLabelsCacheSize: DefaultInvertedLabelsCacheSize,
+	MetricsCacheSize:            DefaultMetricCacheSize,
+	LabelsCacheSize:             DefaultLabelsCacheSize,
+	ExemplarKeyPosCacheSize:     DefaultExemplarKeyPosCacheSize,
+	InvertedLabelsCacheSize:     DefaultInvertedLabelsCacheSize,
+	InvertedLabelsCacheMaxBytes: 1000000,
 }
 
 func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	/* set defaults */
 	cfg.seriesCacheMemoryMaxFlag.SetPercent(50)
+	cfg.InvertedLabelsCacheMaxBytesFlag.SetPercent(10)
 
 	fs.Uint64Var(&cfg.MetricsCacheSize, "metrics.cache.metrics.size", DefaultMetricCacheSize, "Maximum number of metric names to cache.")
 	fs.Uint64Var(&cfg.SeriesCacheInitialSize, "metrics.cache.series.initial-size", DefaultSeriesCacheSize, "Maximum number of series to cache.")
@@ -53,8 +63,9 @@ func ParseFlags(fs *flag.FlagSet, cfg *Config) *Config {
 	fs.Uint64Var(&cfg.ExemplarKeyPosCacheSize, "metrics.cache.exemplar.size", DefaultExemplarKeyPosCacheSize, "Maximum number of exemplar metrics key-position to cache. "+
 		"It has one-to-one mapping with number of metrics that have exemplar, as key positions are saved per metric basis.")
 	fs.Var(&cfg.seriesCacheMemoryMaxFlag, "metrics.cache.series.max-bytes", "Initial number of elements in the series cache. "+
-		"Specified in bytes or as a percentage of the memory-target (e.g. 50%).")
+		"Specified in bytes or as a percentage of the cache.memory-target (e.g. 50%).")
 	fs.Uint64Var(&cfg.InvertedLabelsCacheSize, "metrics.cache.inverted-labels.size", DefaultInvertedLabelsCacheSize, "Maximum number of label-ids to cache. This helps increase ingest performance.")
+	fs.Var(&cfg.InvertedLabelsCacheMaxBytesFlag, "metrics.cache.inverted-labels.max-bytes", "Initial size of elements in the invreted labels cache. Specified in bytes or as a percentage of the cache.memory-target (e.g. 50%).")
 	return cfg
 }
 
@@ -66,14 +77,32 @@ func Validate(cfg *Config, lcfg limits.Config) error {
 	case limits.Absolute:
 		cfg.SeriesCacheMemoryMaxBytes = value
 	default:
-		return fmt.Errorf("series-cache-max-bytes flag has unknown kind")
+		return fmt.Errorf("metrics.cache.series.max-bytes flag has unknown kind")
+	}
+	if cfg.SeriesCacheMemoryMaxBytes > lcfg.TargetMemoryBytes {
+		return fmt.Errorf("The metrics.cache.series.max-bytes must be smaller than the cache.memory-target")
 	}
 	SeriesCacheMaxBytesMetric.Set(float64(cfg.SeriesCacheMemoryMaxBytes))
 
-	if cfg.SeriesCacheMemoryMaxBytes > lcfg.TargetMemoryBytes {
-		return fmt.Errorf("The series-cache-max-bytes must be smaller than the memory-target")
+	kind, value = cfg.InvertedLabelsCacheMaxBytesFlag.Get()
+	switch kind {
+	case limits.Percentage:
+		cfg.InvertedLabelsCacheMaxBytes = uint64(float64(lcfg.TargetMemoryBytes) * (float64(value) / 100.0))
+	case limits.Absolute:
+		cfg.InvertedLabelsCacheMaxBytes = value
+	default:
+		return fmt.Errorf("metrics.cache.inverted-labels.max-bytes flag has unknown kind")
 	}
 
+	if cfg.InvertedLabelsCacheMaxBytes > lcfg.TargetMemoryBytes {
+		return fmt.Errorf("The metrics.cache.inverted-labels.max-bytes must be smaller than the cache.memory-target")
+	}
+
+	if cfg.SeriesCacheMemoryMaxBytes+cfg.InvertedLabelsCacheMaxBytes > lcfg.TargetMemoryBytes {
+		return fmt.Errorf("Sum of metrics.cache.series.max-bytes and metrics.cache.inverted-labels.max-bytes must be smaller than the cache.memory-target")
+	}
+
+	InvertedLabelsCacheMaxBytesMetric.Set(float64(cfg.InvertedLabelsCacheMaxBytes))
 	return nil
 }
 

--- a/pkg/pgmodel/cache/series_cache.go
+++ b/pkg/pgmodel/cache/series_cache.go
@@ -11,7 +11,6 @@ import (
 	"math"
 	"sort"
 	"sync"
-	"time"
 	"unsafe"
 
 	"github.com/prometheus/prometheus/model/labels"
@@ -24,10 +23,6 @@ import (
 // this seems like a good default size for /active/ series. This results in Promscale using around 360MB on start.
 const DefaultSeriesCacheSize = 1000000
 
-const growCheckDuration = time.Second * 5 // check whether to grow the series cache this often
-const growFactor = float64(2.0)           // multiply cache size by this factor when growing the cache
-var evictionMaxAge = time.Minute * 5      // grow cache if we are evicting elements younger than `now - evictionMaxAge`
-
 // SeriesCache is a cache of model.Series entries.
 type SeriesCache interface {
 	Reset()
@@ -38,91 +33,20 @@ type SeriesCache interface {
 }
 
 type SeriesCacheImpl struct {
-	cache        *clockcache.Cache
-	maxSizeBytes uint64
+	*ResizableCache
 }
 
 func NewSeriesCache(config Config, sigClose <-chan struct{}) *SeriesCacheImpl {
-	cache := &SeriesCacheImpl{
+	return &SeriesCacheImpl{NewResizableCache(
 		clockcache.WithMetrics("series", "metric", config.SeriesCacheInitialSize),
 		config.SeriesCacheMemoryMaxBytes,
-	}
-
-	if sigClose != nil {
-		go cache.runSizeCheck(sigClose)
-	}
-	return cache
-}
-
-func (t *SeriesCacheImpl) runSizeCheck(sigClose <-chan struct{}) {
-	ticker := time.NewTicker(growCheckDuration)
-	for {
-		select {
-		case <-ticker.C:
-			if t.shouldGrow() {
-				t.grow()
-			}
-		case <-sigClose:
-			return
-		}
-	}
-}
-
-// shouldGrow allows cache growth if we are evicting elements that were recently used or inserted
-// evictionMaxAge defines the interval
-func (t *SeriesCacheImpl) shouldGrow() bool {
-	return t.cache.MaxEvictionTs()+int32(evictionMaxAge.Seconds()) > int32(time.Now().Unix())
-}
-
-func (t *SeriesCacheImpl) grow() {
-	sizeBytes := t.cache.SizeBytes()
-	oldSize := t.cache.Cap()
-	if float64(sizeBytes)*1.2 >= float64(t.maxSizeBytes) {
-		log.Warn("msg", "Series cache is too small and cannot be grown",
-			"current_size_bytes", float64(sizeBytes), "max_size_bytes", float64(t.maxSizeBytes),
-			"current_size_elements", oldSize, "check_interval", growCheckDuration,
-			"eviction_max_age", evictionMaxAge)
-		return
-	}
-
-	multiplier := growFactor
-	if float64(sizeBytes)*multiplier >= float64(t.maxSizeBytes) {
-		multiplier = float64(t.maxSizeBytes) / float64(sizeBytes)
-	}
-	if multiplier < 1.0 {
-		return
-	}
-
-	newNumElements := int(float64(oldSize) * multiplier)
-	log.Info("msg", "Growing the series cache",
-		"new_size_elements", newNumElements, "current_size_elements", oldSize,
-		"new_size_bytes", float64(sizeBytes)*multiplier, "max_size_bytes", float64(t.maxSizeBytes),
-		"multiplier", multiplier,
-		"eviction_max_age", evictionMaxAge)
-	t.cache.ExpandTo(newNumElements)
-}
-
-func (t *SeriesCacheImpl) Len() int {
-	return t.cache.Len()
-}
-
-func (t *SeriesCacheImpl) Cap() int {
-	return t.cache.Cap()
-}
-
-func (t *SeriesCacheImpl) Evictions() uint64 {
-	return t.cache.Evictions()
-}
-
-// Reset should be concurrency-safe
-func (t *SeriesCacheImpl) Reset() {
-	t.cache.Reset()
+		sigClose)}
 }
 
 // Get the canonical version of a series if one exists.
 // input: the string representation of a Labels as defined by generateKey()
 func (t *SeriesCacheImpl) loadSeries(str string) (l *model.Series) {
-	val, ok := t.cache.Get(str)
+	val, ok := t.Get(str)
 	if !ok {
 		return nil
 	}
@@ -134,7 +58,7 @@ func (t *SeriesCacheImpl) loadSeries(str string) (l *model.Series) {
 // the even of multiple goroutines setting labels concurrently).
 func (t *SeriesCacheImpl) setSeries(str string, lset *model.Series) *model.Series {
 	//str not counted twice in size since the key and lset.str will point to same thing.
-	val, inCache := t.cache.Insert(str, lset, lset.FinalSizeBytes())
+	val, inCache := t.Insert(str, lset, lset.FinalSizeBytes())
 	if !inCache {
 		// It seems that cache was full and eviction failed to remove
 		// element due to starvation caused by a lot of concurrent gets

--- a/pkg/pgmodel/cache/series_cache_test.go
+++ b/pkg/pgmodel/cache/series_cache_test.go
@@ -80,7 +80,7 @@ func TestGrowSeriesCache(t *testing.T) {
 			cache := NewSeriesCache(Config{SeriesCacheInitialSize: 100, SeriesCacheMemoryMaxBytes: DefaultConfig.SeriesCacheMemoryMaxBytes}, nil)
 			cacheGrowCounter := 0
 			for i := 0; i < 200; i++ {
-				cache.cache.Insert(i, i, 1)
+				cache.Insert(i, i, 1)
 				if i%100 == 0 {
 					time.Sleep(tc.sleep)
 				}

--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -45,8 +45,8 @@ type DBIngestor struct {
 
 // NewPgxIngestor returns a new Ingestor that uses connection pool and a metrics cache
 // for caching metric table names.
-func NewPgxIngestor(conn pgxconn.PgxConn, cache cache.MetricCache, sCache cache.SeriesCache, eCache cache.PositionCache, cfg *Cfg) (*DBIngestor, error) {
-	dispatcher, err := newPgxDispatcher(conn, cache, sCache, eCache, cfg)
+func NewPgxIngestor(conn pgxconn.PgxConn, cache cache.MetricCache, sCache cache.SeriesCache, eCache cache.PositionCache, lCache *cache.InvertedLabelsCache, cfg *Cfg) (*DBIngestor, error) {
+	dispatcher, err := newPgxDispatcher(conn, cache, sCache, eCache, lCache, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,8 @@ func NewPgxIngestorForTests(conn pgxconn.PgxConn, cfg *Cfg) (*DBIngestor, error)
 	c := cache.NewMetricCache(cacheConfig)
 	s := cache.NewSeriesCache(cacheConfig, nil)
 	e := cache.NewExemplarLabelsPosCache(cacheConfig)
-	return NewPgxIngestor(conn, c, s, e, cfg)
+	l := cache.NewInvertedLabelsCache(cacheConfig, nil)
+	return NewPgxIngestor(conn, c, s, e, l, cfg)
 }
 
 const (

--- a/pkg/pgmodel/ingestor/ingestor_sql_test.go
+++ b/pkg/pgmodel/ingestor/ingestor_sql_test.go
@@ -276,7 +276,7 @@ func TestPGXInserterInsertSeries(t *testing.T) {
 			mock := model.NewSqlRecorder(c.sqlQueries, t)
 			scache := cache.NewSeriesCache(cache.DefaultConfig, nil)
 			scache.Reset()
-			lCache, _ := cache.NewInvertedLabelsCache(10)
+			lCache := cache.NewInvertedLabelsCache(cache.DefaultConfig, nil)
 			sw := NewSeriesWriter(mock, 0, lCache)
 
 			lsi := make([]model.Insertable, 0)
@@ -434,7 +434,7 @@ func TestPGXInserterCacheReset(t *testing.T) {
 
 	mock := model.NewSqlRecorder(sqlQueries, t)
 	scache := cache.NewSeriesCache(cache.DefaultConfig, nil)
-	lcache, _ := cache.NewInvertedLabelsCache(10)
+	lcache := cache.NewInvertedLabelsCache(cache.DefaultConfig, nil)
 	sw := NewSeriesWriter(mock, 0, lcache)
 	inserter := pgxDispatcher{
 		conn:                mock,
@@ -916,6 +916,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			mock := model.NewSqlRecorder(c.sqlQueries, t)
 			scache := cache.NewSeriesCache(cache.DefaultConfig, nil)
+			lcache := cache.NewInvertedLabelsCache(cache.DefaultConfig, nil)
 
 			mockMetrics := &model.MockMetricCache{
 				MetricCache:  make(map[string]model.MetricInfo),
@@ -932,7 +933,7 @@ func TestPGXInserterInsertData(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error setting up mock cache: %s", err.Error())
 			}
-			inserter, err := newPgxDispatcher(mock, mockMetrics, scache, nil, &Cfg{DisableEpochSync: true, InvertedLabelsCacheSize: 10, NumCopiers: 2})
+			inserter, err := newPgxDispatcher(mock, mockMetrics, scache, nil, lcache, &Cfg{DisableEpochSync: true, InvertedLabelsCacheSize: 10, NumCopiers: 2})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/tests/end_to_end_tests/drop_test.go
+++ b/pkg/tests/end_to_end_tests/drop_test.go
@@ -409,6 +409,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 	}
 	withDB(t, *testDatabase, func(db *pgxpool.Pool, t testing.TB) {
 		scache := cache.NewSeriesCache(cache.DefaultConfig, nil)
+		lcache := cache.NewInvertedLabelsCache(cache.DefaultConfig, nil)
 		//this is the range_end of a chunk boundary (exclusive)
 		chunkEnds := time.Date(2009, time.November, 11, 0, 0, 0, 0, time.UTC)
 
@@ -459,7 +460,7 @@ func TestSQLDropMetricChunk(t *testing.T) {
 		}
 
 		c := cache.NewMetricCache(cache.DefaultConfig)
-		ingestor, err := ingstr.NewPgxIngestor(pgxconn.NewPgxConn(db), c, scache, nil, &ingstr.Cfg{
+		ingestor, err := ingstr.NewPgxIngestor(pgxconn.NewPgxConn(db), c, scache, nil, lcache, &ingstr.Cfg{
 			DisableEpochSync:        true,
 			InvertedLabelsCacheSize: cache.DefaultConfig.InvertedLabelsCacheSize,
 			NumCopiers:              2,

--- a/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
+++ b/pkg/tests/end_to_end_tests/ha_single_promscale_test.go
@@ -123,8 +123,9 @@ func prepareWriterWithHa(db *pgxpool.Pool, t testing.TB) (*util.ManualTicker, ht
 	dataParser := parser.NewParser()
 	dataParser.AddPreprocessor(ha.NewFilter(haService))
 	mCache := &cache.MetricNameCache{Metrics: clockcache.WithMax(cache.DefaultMetricCacheSize)}
+	lCache := cache.NewInvertedLabelsCache(cache.DefaultConfig, sigClose)
 
-	ing, err := ingestor.NewPgxIngestor(pgxconn.NewPgxConn(db), mCache, sCache, nil, &ingestor.Cfg{
+	ing, err := ingestor.NewPgxIngestor(pgxconn.NewPgxConn(db), mCache, sCache, nil, lCache, &ingestor.Cfg{
 		InvertedLabelsCacheSize: cache.DefaultConfig.InvertedLabelsCacheSize, NumCopiers: 2,
 	})
 	if err != nil {


### PR DESCRIPTION
Grow cache mechanism was already implemented. This PR mostly refactors the code to make it more generic so we can re-use