### PR TITLE
Vacuum compressed chunks missing stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ We use the following categories for changes:
   metrics won't be collected as often as they used to. None of the affected 
   metrics is expected to change faster than its new collection interval [#1793]
 - Aggregate metrics at global level to avoid legend pollution in dashboards [#1800]
+- The vacuum engine now looks for compressed chunks missing stats and vacuums these too [#1804]
 
 ### Fixed
 - Fixing the query behind chunks_uncompressed. The new definition should

--- a/docs/vacuum.md
+++ b/docs/vacuum.md
@@ -35,3 +35,11 @@ We get the autovacuum count when we produce the list. Just before
 vacuuming a chunk, we check the autovacuum count again to see if it
 has increased. If it has, the autovacuum engine beat us to the
 chunk, and we skip it.
+
+Additionally, we have seen instances in which compresses chunks are
+missing statistics. Autovacuum ignores tables that are missing
+statistics. Analyzing these tables does not help since we rarely
+modify chunks after they are compressed. Therefore, these chunks are
+ignored until they pass the vacuum_freeze_max_age. This can be bad
+for performance. So, the vacuum engine also looks for these chunks
+and vacuums them. We only use one worker for these.

--- a/pkg/tests/end_to_end_tests/vacuum_test.go
+++ b/pkg/tests/end_to_end_tests/vacuum_test.go
@@ -15,7 +15,7 @@ import (
 const (
 	sqlChunksToFreeze = `
 	SELECT %s 
-	FROM _ps_catalog.chunks_to_freeze
+	FROM _ps_catalog.compressed_chunks_to_freeze
 	WHERE coalesce(last_vacuum, '-infinity'::timestamptz) < now() - interval '15 minutes' 
 	AND pg_catalog.age(relfrozenxid) > current_setting('vacuum_freeze_min_age')::bigint
 	`
@@ -192,7 +192,7 @@ func compressChunks(t *testing.T, ctx context.Context, db *pgxpool.Pool, chunks 
 func view(t *testing.T, ctx context.Context, db *pgxpool.Pool) []compressedChunk {
 	rows, err := db.Query(ctx, fmt.Sprintf(sqlChunksToFreeze, "id"))
 	if err != nil {
-		t.Fatalf("Failed to select from _ps_catalog.chunks_to_freeze: %v", err)
+		t.Fatalf("Failed to select from _ps_catalog.compressed_chunks_to_freeze: %v", err)
 	}
 	defer rows.Close()
 	chunks := make([]compressedChunk, 0)


### PR DESCRIPTION
## Description

We have seen instances in which compresses chunks are missing statistics. Autovacuum ignores tables that are missing statistics. Analyzing these tables does not help since we rarely modify chunks after they are compressed. Therefore, these chunks are ignored until they pass the vacuum_freeze_max_age. This can be bad for performance. So, the vacuum engine makes a second pass looking for these chunks and vacuums them. We only use one worker for these.

See also: https://github.com/timescale/promscale_extension/pull/595

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [x] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
