### PR TITLE
Dictionary encoding for series cache key

### DIFF
--- a/pkg/pgmodel/ingestor/ingestor.go
+++ b/pkg/pgmodel/ingestor/ingestor.go
@@ -208,10 +208,11 @@ func (ingestor *DBIngestor) ingestTimeseries(ctx context.Context, timeseries []p
 		}
 		// Normalize and canonicalize ts.Labels.
 		// After this point ts.Labels should never be used again.
-		series, metricName, err = ingestor.sCache.GetSeriesFromProtos(ts.Labels)
+		series, err = ingestor.sCache.GetSeriesFromProtos(ts.Labels)
 		if err != nil {
 			return 0, err
 		}
+		metricName = series.MetricName()
 		if metricName == "" {
 			return 0, errors.ErrNoMetricName
 		}

--- a/pkg/pgmodel/ingestor/metric_batcher_test.go
+++ b/pkg/pgmodel/ingestor/metric_batcher_test.go
@@ -201,7 +201,7 @@ func TestOrderExemplarLabelValues(t *testing.T) {
 	}
 	exemplarSeriesLabels := []prompb.Label{{Name: "__name__", Value: "exemplar_test_metric"}, {Name: "component", Value: "test_infra"}}
 
-	series := model.NewSeries("hash_key", exemplarSeriesLabels)
+	series := model.NewSeries(exemplarSeriesLabels)
 	insertables := make([]model.Insertable, 3) // Since 3 exemplars.
 
 	for i, exemplar := range rawExemplars {

--- a/pkg/pgmodel/model/series.go
+++ b/pkg/pgmodel/model/series.go
@@ -41,14 +41,12 @@ type Series struct {
 	epoch    SeriesEpoch
 
 	metricName string
-	str        string
 }
 
-func NewSeries(key string, labelPairs []prompb.Label) *Series {
+func NewSeries(labelPairs []prompb.Label) *Series {
 	series := &Series{
 		names:    make([]string, len(labelPairs)),
 		values:   make([]string, len(labelPairs)),
-		str:      key,
 		seriesID: invalidSeriesID,
 		epoch:    InvalidSeriesEpoch,
 	}
@@ -77,17 +75,11 @@ func (l *Series) MetricName() string {
 // This representation is guaranteed to uniquely represent the underlying label
 // set, though need not human-readable, or indeed, valid utf-8
 func (l *Series) String() string {
-	return l.str
-}
-
-// Compare returns a comparison int between two Labels
-func (l *Series) Compare(b *Series) int {
-	return strings.Compare(l.str, b.str)
-}
-
-// Equal returns true if two Labels are equal
-func (l *Series) Equal(b *Series) bool {
-	return l.str == b.str
+	s := strings.Builder{}
+	for i := range l.names {
+		s.WriteString(fmt.Sprintf("%s=%s,", l.names[i], l.values[i]))
+	}
+	return s.String()
 }
 
 func (l *Series) isSeriesIDSetNoLock() bool {
@@ -105,7 +97,7 @@ func (l *Series) IsSeriesIDSet() bool {
 func (l *Series) FinalSizeBytes() uint64 {
 	//size is the base size of the struct + the str and metricName strings
 	//names and values are not counted since they will be nilled out
-	return uint64(unsafe.Sizeof(*l)) + uint64(len(l.str)+len(l.metricName)) // #nosec
+	return uint64(unsafe.Sizeof(*l)) + uint64(len(l.metricName)) // #nosec
 }
 
 func (l *Series) GetSeriesID() (SeriesID, SeriesEpoch, error) {

--- a/pkg/rules/adapters/ingest.go
+++ b/pkg/rules/adapters/ingest.go
@@ -60,11 +60,11 @@ func (app *appenderAdapter) Append(_ storage.SeriesRef, l labels.Labels, t int64
 	if err != nil {
 		return 0, fmt.Errorf("get ingestor: %w", err)
 	}
-	series, metricName, err := dbIngestor.SeriesCache().GetSeriesFromProtos(util.LabelToPrompbLabels(l))
+	series, err := dbIngestor.SeriesCache().GetSeriesFromProtos(util.LabelToPrompbLabels(l))
 	if err != nil {
 		return 0, fmt.Errorf("get series from protos: %w", err)
 	}
-
+	metricName := series.MetricName()
 	samples := model.NewPromSamples(series, []prompb.Sample{{Timestamp: t, Value: v}})
 	if _, found := app.data[metricName]; !found {
 		app.data[metricName] = make([]model.Insertable, 0)


### PR DESCRIPTION
This makes key much smaller and have positive impact on memory usage. Benchmark is showing 2X reduction in memory usage.

Before:
<img width="1360" alt="Screenshot 2022-12-21 at 12 13 37" src="https://user-images.githubusercontent.com/3705942/208965704-1e165c5f-4173-4efe-8d89-d3b6732c71e4.png">

<img width="1398" alt="Screenshot 2022-12-21 at 12 08 03" src="https://user-images.githubusercontent.com/3705942/208965758-68bbeaff-710e-44bd-a0c2-5d30832c9b59.png">


After:
<img width="1418" alt="Screenshot 2022-12-21 at 13 18 34" src="https://user-images.githubusercontent.com/3705942/208965545-fc5c1597-073c-4f77-b148-55af1d573495.png">

<img width="1473" alt="Screenshot 2022-12-21 at 13 17 33" src="https://user-images.githubusercontent.com/3705942/208965654-12522456-14f3-484a-8431-88acce5072ea.png">





