### PR TITLE
Track metrics per workload in vacuum engine

### DIFF
--- a/pkg/vacuum/vacuum.go
+++ b/pkg/vacuum/vacuum.go
@@ -69,7 +69,7 @@ var (
 	vacuumErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace: util.PromNamespace,
 		Subsystem: "vacuum",
-		Name:      "vacuum_errors_total",
+		Name:      "errors_total",
 		Help:      "Total number of errors encountered by the Promscale vacuum engine while vacuuming tables.",
 	},
 		[]string{"workload"},

--- a/pkg/vacuum/vacuum.go
+++ b/pkg/vacuum/vacuum.go
@@ -63,7 +63,7 @@ var (
 	numberVacuumConnections = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: util.PromNamespace,
 		Subsystem: "vacuum",
-		Name:      "number_vacuum_connections",
+		Name:      "num_connections",
 		Help:      "Number of database connections currently in use by the vacuum engine. One taken up by the advisory lock, the rest by vacuum commands.",
 	})
 	vacuumErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{

--- a/pkg/vacuum/vacuum_test.go
+++ b/pkg/vacuum/vacuum_test.go
@@ -42,7 +42,7 @@ func Test_runWorkers(t *testing.T) {
 			var mu sync.Mutex
 			// when we "work" on a chunk, append its name to actual
 			actual := make([]string, 0)
-			runWorkers(context.Background(), tt.numWorkers, tt.chunks, func(ctx context.Context, id int, todo <-chan *chunk) {
+			runWorkers(context.Background(), "test", tt.numWorkers, tt.chunks, func(ctx context.Context, workload string, id int, todo <-chan *chunk) {
 				for c := range todo {
 					func(ctx context.Context, id int, c *chunk) {
 						mu.Lock()


### PR DESCRIPTION
## Description

Adjusts vacuum engine metrics to add a `workload` label to keep separate metrics per workload.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
