### PR TITLE
Custom COPY with only one DB roundtrip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ We use the following categories for changes:
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## Unreleased
+
+### Changed
+
+- COPY commands are executed in a single DB roundtrip instead of two [#1814]
+
 ## [0.17.0] - 2023-09-01
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-hclog v1.3.1
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
+	github.com/jackc/pgio v1.0.0
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/jaegertracing/jaeger v1.38.2-0.20221006002917-5bf8a28fe06d
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -667,6 +667,8 @@ github.com/ionos-cloud/sdk-go/v6 v6.1.3 h1:vb6yqdpiqaytvreM0bsn2pXw+1YDvEk2RKSmB
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
+github.com/jackc/pgio v1.0.0 h1:g12B9UwVnzGhueNavwioyEEpAmqMe1E/BN9ES+8ovkE=
+github.com/jackc/pgio v1.0.0/go.mod h1:oP+2QK2wFfUWgr+gxjoBH9KGBb31Eio69xUb0w5bYf8=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b h1:C8S2+VttkHFdOOCXJe+YGfa4vHYwlt4Zx+IVXQ97jYg=

--- a/pkg/pgmodel/common/schema/schema.go
+++ b/pkg/pgmodel/common/schema/schema.go
@@ -4,6 +4,10 @@
 
 package schema
 
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
 const (
 	PromData         = "prom_data"
 	PromDataExemplar = "prom_data_exemplar"
@@ -19,5 +23,23 @@ const (
 
 var (
 	PromDataColumns     = []string{"time", "value", "series_id"}
+	PromDataColumnsOIDs = []uint32{
+		pgtype.TimestamptzOID,
+		pgtype.Float8OID,
+		pgtype.Int8OID,
+	}
 	PromExemplarColumns = []string{"time", "series_id", "exemplar_label_values", "value"}
 )
+
+func PromExemplarColumnsOIDs(typeMap *pgtype.Map) ([]uint32, bool) {
+	labelValueArrayType, ok := typeMap.TypeForName("_prom_api.label_value_array")
+	if !ok {
+		return []uint32{}, ok
+	}
+	return []uint32{
+		pgtype.TimestamptzOID,
+		pgtype.Int8OID,
+		labelValueArrayType.OID,
+		pgtype.Float8OID,
+	}, ok
+}

--- a/pkg/pgmodel/model/sql_test_utils.go
+++ b/pkg/pgmodel/model/sql_test_utils.go
@@ -109,8 +109,16 @@ func (r *SqlRecorder) QueryRow(ctx context.Context, sql string, args ...interfac
 	return &MockRows{results: rows, err: err}
 }
 
-func (r *SqlRecorder) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
-	panic("should never be called")
+func (r *SqlRecorder) CopyFrom(
+	ctx context.Context,
+	tx pgx.Tx,
+	tableName pgx.Identifier,
+	columnNames []string,
+	rowSrc pgx.CopyFromSource,
+	oids []uint32,
+) (int64, error) {
+	// Use the MockTx recorder logic
+	return tx.CopyFrom(ctx, tableName, columnNames, rowSrc)
 }
 
 func (r *SqlRecorder) CopyFromRows(rows [][]interface{}) pgx.CopyFromSource {

--- a/pkg/pgxconn/copy_from.go
+++ b/pkg/pgxconn/copy_from.go
@@ -1,0 +1,234 @@
+// This file was copied from the PGX repository and modified. PGX is
+// licensed under MIT.
+//
+// https://github.com/jackc/pgx/blob/master/copy_from.go
+//
+// The MIT License
+//
+// Copyright (c) 2011 Dominic Tarr
+//
+// Permission is hereby granted, free of charge,
+// to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to
+// deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify,
+// merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom
+// the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+// ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package pgxconn
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+
+	"github.com/jackc/pgio"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+var bufPool = sync.Pool{
+	New: func() any {
+		s := make([]byte, 0, 4096)
+		return &s
+	},
+}
+
+type copyFrom struct {
+	conn          *pgx.Conn
+	tableName     pgx.Identifier
+	columnNames   []string
+	rowSrc        pgx.CopyFromSource
+	readerErrChan chan error
+	oids          []uint32
+	wbuf          []byte
+}
+
+func doCopyFrom(
+	ctx context.Context,
+	conn *pgx.Conn,
+	tableName pgx.Identifier,
+	columnNames []string,
+	rowSrc pgx.CopyFromSource,
+	oids []uint32,
+) (int64, error) {
+	buf := bufPool.Get().(*[]byte)
+	ct := &copyFrom{
+		conn:          conn,
+		tableName:     tableName,
+		columnNames:   columnNames,
+		rowSrc:        rowSrc,
+		readerErrChan: make(chan error),
+		oids:          oids,
+		wbuf:          *buf,
+	}
+	defer bufPool.Put(buf)
+	return ct.run(ctx)
+}
+
+func (ct *copyFrom) run(ctx context.Context) (int64, error) {
+	quotedTableName := ct.tableName.Sanitize()
+	cbuf := &bytes.Buffer{}
+	for i, cn := range ct.columnNames {
+		if i != 0 {
+			cbuf.WriteString(", ")
+		}
+		cbuf.WriteString(quoteIdentifier(cn))
+	}
+	quotedColumnNames := cbuf.String()
+
+	r, w := io.Pipe()
+	doneChan := make(chan struct{})
+
+	go func() {
+		defer close(doneChan)
+
+		// Purposely NOT using defer w.Close(). See https://github.com/golang/go/issues/24283.
+		buf := ct.wbuf
+
+		buf = append(buf, "PGCOPY\n\377\r\n\000"...)
+		buf = pgio.AppendInt32(buf, 0)
+		buf = pgio.AppendInt32(buf, 0)
+
+		moreRows := true
+		for moreRows {
+			var err error
+			moreRows, buf, err = ct.buildCopyBuf(buf, ct.oids)
+			if err != nil {
+				w.CloseWithError(err)
+				return
+			}
+
+			if ct.rowSrc.Err() != nil {
+				w.CloseWithError(ct.rowSrc.Err())
+				return
+			}
+
+			if len(buf) > 0 {
+				_, err = w.Write(buf)
+				if err != nil {
+					_ = w.Close()
+					return
+				}
+			}
+
+			buf = buf[:0]
+		}
+
+		_ = w.Close()
+	}()
+
+	commandTag, err := ct.conn.PgConn().CopyFrom(ctx, r, fmt.Sprintf("copy %s ( %s ) from stdin binary;", quotedTableName, quotedColumnNames))
+
+	_ = r.Close()
+	<-doneChan
+
+	return commandTag.RowsAffected(), err
+}
+
+func (ct *copyFrom) buildCopyBuf(buf []byte, oids []uint32) (bool, []byte, error) {
+
+	if len(ct.columnNames) != len(oids) {
+		return false, nil, fmt.Errorf("expected %d OIDs, got %d OIDs", len(ct.columnNames), len(oids))
+	}
+
+	for ct.rowSrc.Next() {
+		values, err := ct.rowSrc.Values()
+		if err != nil {
+			return false, nil, err
+		}
+
+		if len(values) != len(ct.columnNames) {
+			return false, nil, fmt.Errorf("expected %d values, got %d values", len(ct.columnNames), len(values))
+		}
+
+		buf = pgio.AppendInt16(buf, int16(len(ct.columnNames)))
+		for i, val := range values {
+			buf, err = encodeCopyValue(ct.conn.TypeMap(), buf, oids[i], val)
+			if err != nil {
+				return false, nil, err
+			}
+		}
+
+		if len(buf) > 65536 {
+			return true, buf, nil
+		}
+	}
+
+	return false, buf, nil
+}
+
+func quoteIdentifier(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}
+
+func encodeCopyValue(m *pgtype.Map, buf []byte, oid uint32, arg any) ([]byte, error) {
+	if isNil(arg) {
+		return pgio.AppendInt32(buf, -1), nil
+	}
+
+	sp := len(buf)
+	buf = pgio.AppendInt32(buf, -1)
+	argBuf, err := m.Encode(oid, pgx.BinaryFormatCode, arg, buf)
+	if err != nil {
+		if argBuf2, err2 := tryScanStringCopyValueThenEncode(m, buf, oid, arg); err2 == nil {
+			argBuf = argBuf2
+		} else {
+			return nil, err
+		}
+	}
+
+	if argBuf != nil {
+		buf = argBuf
+		pgio.SetInt32(buf[sp:], int32(len(buf[sp:])-4))
+	}
+	return buf, nil
+}
+
+func tryScanStringCopyValueThenEncode(m *pgtype.Map, buf []byte, oid uint32, arg any) ([]byte, error) {
+	s, ok := arg.(string)
+	if !ok {
+		return nil, errors.New("not a string")
+	}
+
+	var v any
+	err := m.Scan(oid, pgx.TextFormatCode, []byte(s), &v)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.Encode(oid, pgx.BinaryFormatCode, v, buf)
+}
+
+// Is returns true if value is any type of nil. e.g. nil or []byte(nil).
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+
+	refVal := reflect.ValueOf(value)
+	switch refVal.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.UnsafePointer, reflect.Interface, reflect.Slice:
+		return refVal.IsNil()
+	default:
+		return false
+	}
+}

--- a/pkg/tests/testsupport/mock_pgx_conn.go
+++ b/pkg/tests/testsupport/mock_pgx_conn.go
@@ -49,7 +49,14 @@ func (MockPgxConn) Query(ctx context.Context, sql string, args ...interface{}) (
 func (MockPgxConn) QueryRow(ctx context.Context, sql string, args ...interface{}) pgx.Row {
 	return MockRow{}
 }
-func (MockPgxConn) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
+func (MockPgxConn) CopyFrom(
+	ctx context.Context,
+	tx pgx.Tx,
+	tableName pgx.Identifier,
+	columnNames []string,
+	rowSrc pgx.CopyFromSource,
+	oids []uint32,
+) (int64, error) {
 	return 0, nil
 }
 func (MockPgxConn) CopyFromRows(rows [][]interface{}) pgx.CopyFromSource { return nil }


### PR DESCRIPTION
## Description

### Add custom CopyFrom command that avoids an extra roundtrip 
 
 The CopyFrom command from pgx requires the OIDs of the data types is
going to insert when constructing the binary message that contains
the data.

To retrieve the OIDs a statement is prepared per COPY operation. In our
case the statements are very simmilar:

```
copy {tableName} ( `time`, `value`, `series_id` ) from stdin binary
```

These statements can be cached, the problem is that we will have a cache
entry per table name.

Since we always insert to the same columns and we know the OIDs of the
columns we are going to be inserting to, we can avoid the extra
roundtrip and the cache by manually passing the OIDs.

This custom copy command is basically a copy of the pgx CopyCommand that
accepts the list of OIDs.


## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [ ] Updated the relevant documentation
