### PR TITLE
Use latest jaeger documentation version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ exemplars and Prometheus HA.
 * **Certified Jaeger trace storage:** Promscale is a [certified Jaeger storage backend](https://github.com/jaegertracing/jaeger#multiple-storage-backends).
 Integrate Jaeger with Promscale to store and visualize your traces with a simple configuration change in Jaeger.
 Use Promscale as the storage backend for the metrics required by the
-[Service Performance Management UI](https://www.jaegertracing.io/docs/1.38/spm/). No need for a separate 
+[Service Performance Management UI](https://www.jaegertracing.io/docs/latest/spm/). No need for a separate 
 Prometheus / PromQL compatible storage.
 * **OpenTelemetry trace storage:** support for ingestion of traces through the OpenTelemetry Protocol
 (OTLP).


### PR DESCRIPTION
This will result in a redirect to the latest tagged documentation for Jaeger.

## Description

The link to the SPM documentation is currently outdated. This change ensures the latest tagged version of Jaeger's documentation is pointed to, removing anymore need to maintain this link.

## Merge requirements

Please take into account the following non-code changes that you may need to make with your PR:

- [ ] CHANGELOG entry for user-facing changes
- [x] Updated the relevant documentation
